### PR TITLE
Fetch default dpi from cups

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -769,7 +769,8 @@ var qz = (function() {
          *   @param {number} [data.options.y] Optional with <code>[raw]</code> type <code>[image]</code> format. The Y position of the image.
          *   @param {string|number} [data.options.dotDensity] Optional with <code>[raw]</code> type <code>[image]</code> format.
          *   @param {string} [data.options.xmlTag] Required with <code>[xml]</code> format. Tag name containing base64 formatted data.
-         *   @param {number} [data.options.pageWidth] Optional with <code>[html]</code> type printing. Width of the web page to render.
+         *   @param {number} [data.options.pageWidth] Optional with <code>[html]</code> type printing. Width of the web page to render. Defaults to paper width.
+         *   @param {number} [data.options.pageHeight] Optional with <code>[html]</code> type printing. Height of the web page to render. Defaults to adjusted web page height.
          * @param {boolean} [signature] Pre-signed signature of JSON string containing <code>call</code>, <code>params</code>, and <code>timestamp</code>.
          * @param {number} [signingTimestamp] Required with <code>signature</code>. Timestamp used with pre-signed content.
          *
@@ -943,7 +944,7 @@ var qz = (function() {
         usb: {
             /**
              * List of available USB devices. Includes (hexadecimal) vendor ID, (hexadecimal) product ID, and hub status.
-             * If support, also returns manufacturer and product descriptions.
+             * If supported, also returns manufacturer and product descriptions.
              *
              * @param includeHubs Whether to include USB hubs.
              * @returns {Promise<Array<Object>|Error>} Array of JSON objects containing information on connected USB devices.

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -101,7 +101,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         PageFormat page = job.getPageFormat(null);
 
         PrintOptions.Pixel pxlOpts = options.getPixelOptions();
-        PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page);
+        PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page, false);
 
         scaleImage = pxlOpts.isScaleContent();
         interpolation = pxlOpts.getInterpolation();

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -15,8 +15,6 @@ import qz.printer.PrintOutput;
 import qz.utils.PrintingUtilities;
 
 import javax.print.attribute.PrintRequestAttributeSet;
-import javax.print.attribute.ResolutionSyntax;
-import javax.print.attribute.standard.PrinterResolution;
 import java.awt.print.Book;
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterException;
@@ -80,18 +78,13 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
         PageFormat page = job.getPageFormat(null);
 
         PrintOptions.Pixel pxlOpts = options.getPixelOptions();
-        PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page);
+        PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page, true);
 
         Scaling scale = (pxlOpts.isScaleContent()? Scaling.SCALE_TO_FIT:Scaling.ACTUAL_SIZE);
 
-        double density = pxlOpts.getDensity();
-        if (density == 0 && pxlOpts.isRasterize()) {
-            density = ((PrinterResolution)output.getPrintService().getDefaultAttributeValue(PrinterResolution.class)).getFeedResolution(ResolutionSyntax.DPI);
-        }
-
         Book book = new Book();
         for(PDDocument doc : pdfs) {
-            book.append(new PDFPrintable(doc, scale, false, (float)(density * pxlOpts.getUnits().as1Inch()), false), page, doc.getNumberOfPages());
+            book.append(new PDFPrintable(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false), page, doc.getNumberOfPages());
         }
 
         job.setJobName(pxlOpts.getJobName(Constants.PDF_PRINT));

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -3,9 +3,21 @@ package qz.utils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import qz.printer.action.*;
 
+import javax.print.PrintService;
+import javax.print.attribute.standard.PrinterResolution;
+import java.util.HashMap;
+
 public class PrintingUtilities {
+
+    private static final Logger log = LoggerFactory.getLogger(PrintingUtilities.class);
+
+    private static HashMap<String,String> CUPS_DESC; //name -> description
+    private static HashMap<String,PrinterResolution> CUPS_DPI; //description -> default dpi
+
 
     private PrintingUtilities() {}
 
@@ -38,6 +50,49 @@ public class PrintingUtilities {
             case RAW:
                 return new PrintRaw();
         }
+    }
+
+    /**
+     * Gets the printerId for use with CUPS commands
+     * @param printerName
+     * @return Id of the printer for use with CUPS commands
+     */
+    public static String getPrinterId(String printerName) {
+        if (!SystemUtilities.isMac()) {
+            return printerName;
+        }
+
+        if (CUPS_DESC == null || !CUPS_DESC.containsValue(printerName)) {
+            CUPS_DESC = ShellUtilities.getCupsPrinters();
+        }
+
+        for(String name : CUPS_DESC.keySet()) {
+            if (CUPS_DESC.get(name).equals(printerName)) {
+                return name;
+            }
+        }
+
+        log.warn("Could not locate printerId matching {}", printerName);
+        return printerName;
+    }
+
+    public static PrinterResolution getNativeDensity(PrintService service) {
+        if (service == null) { return null; }
+
+        PrinterResolution pRes = (PrinterResolution)service.getDefaultAttributeValue(PrinterResolution.class);
+
+        if (pRes == null && !SystemUtilities.isWindows()) {
+            String printerId = getPrinterId(service.getName());
+
+            if (CUPS_DPI == null || !CUPS_DPI.containsKey(printerId)) {
+                CUPS_DPI = ShellUtilities.getCupsDensities(CUPS_DESC);
+            }
+
+            return CUPS_DPI.get(printerId);
+        }
+
+        log.debug("Found Resolution: {}", pRes);
+        return pRes;
     }
 
 }

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -435,7 +435,7 @@ public class PrintSocketClient {
     private void processPrintRequest(Session session, String UID, JSONObject params) {
         try {
             PrintOutput output = new PrintOutput(params.optJSONObject("printer"));
-            PrintOptions options = new PrintOptions(params.optJSONObject("options"));
+            PrintOptions options = new PrintOptions(params.optJSONObject("options"), output);
 
             PrintProcessor processor = PrintingUtilities.getPrintProcessor(params.getJSONArray("data"));
             log.debug("Using {} to print", processor.getClass().getName());


### PR DESCRIPTION
**Background:**

Since JVM + Mac suffer a hard crash (https://github.com/qzind/qz-print/issues/155) when the DPI isn't provided.  Like all upstream bugs, this forces us to get creative with a workaround...  

The recommended solution from PDFBOX developers is to provide a density to avoid the hard-crashes, which in turn forces PDFBOX to rasterize the PDF prior to printing.  This works well if we know the printer DPI.... Unfortunately, this DPI comes back as Null on Mac and Linux.

The work-around is to query this value from CUPS. The API we're using in the `lpstat` and `lpoptions` command line utilities.

The advantage of this enhancement is it has other benefits... it allows printer-DPI detection where Java simply didn't provide it before, helping out our Pixel printing logic considerably with the CUPS backends OSs... 

This native work-around uses a shell command to parse attributes from CUPS, namely the default resolution of the printer.

**Exceptions:**

On OS X, this workaround also takes into consideration the delicate renaming problems, as printers identified on Mac default to the CUPS printer `Description:` rather than the `Name:`.  e.g. "List all printers" has a different behavior on Mac versus other platforms as the human readable "Description" is returned by Java whereas Unix/Linux returns the CUPS device name.  This solution works for both scenarios.

**Sample output:**

When this feature is working and a supported printer driver is used, the DPI should show in the console as follows:

Mac:

```properties
[DEBUG] 2016-03-22 22:25:56,442 @ qz.utils.ShellUtilities:?
	Executing: [lpoptions, -p, PDFwriter, -l]
[DEBUG] 2016-03-22 22:25:56,565 @ qz.printer.action.PrintPDF:?
	Parsed density from CUPS: 300 dpi
[INFO] 2016-03-22 22:25:56,583 @ qz.printer.action.PrintPixel:?
	Starting printing (1 copies)
```

Ubuntu:

```properties
[DEBUG] 2016-03-22 22:43:27,433 @ qz.utils.ShellUtilities:?
	Executing: [lpoptions, -p, PDF, -l]
[DEBUG] 2016-03-22 22:43:27,467 @ qz.printer.action.PrintPDF:?
	Parsed density from CUPS: 300 dpi
[INFO] 2016-03-22 22:43:27,523 @ qz.printer.action.PrintPixel:?
	Starting printing (1 copies)
```