### PR TITLE
Allow custom CA certificates without altering Java properties

### DIFF
--- a/ant/apple/apple-keygen.sh.in
+++ b/ant/apple/apple-keygen.sh.in
@@ -125,7 +125,7 @@ eval "$makedercert" > /dev/null 2>&1
 check_exists "$dercertpath"
 
 echo "Writing properties file..."
-echo "wss.alias=${jks.alias}" > "$propspath"
+echo "wss.alias=${jks.alias}" >> "$propspath"
 echo "wss.keystore=$keystorepath" >> "$propspath"
 echo "wss.keypass=$password" >> "$propspath"
 echo "wss.storepass=$password" >> "$propspath"

--- a/ant/linux/linux-keygen.sh.in
+++ b/ant/linux/linux-keygen.sh.in
@@ -74,7 +74,7 @@ eval "$makedercert" > /dev/null 2>&1
 check_exists "$dercertpath"
 
 echo "Writing properties file..."
-echo "wss.alias=${jks.alias}" > "$propspath"
+echo "wss.alias=${jks.alias}" >> "$propspath"
 echo "wss.keystore=$keystorepath" >> "$propspath"
 echo "wss.keypass=$password" >> "$propspath"
 echo "wss.storepass=$password" >> "$propspath"

--- a/ant/windows/windows-keygen.js.in
+++ b/ant/windows/windows-keygen.js.in
@@ -240,7 +240,7 @@ function createJavaKeystore() {
     shell.Run(makeKeyStore, 0, true);
     verifyExists(keyStore, "Check keystore exists");
 
-    var file = fso.OpenTextFile(fixPath("${jks.properties}"), 2, true);
+    var file = fso.OpenTextFile(fixPath("${jks.properties}"), 8, true);
     file.WriteLine("wss.alias=" + "${jks.alias}");
     file.WriteLine("wss.keystore=" + keyStore.replace(/\\/g, "\\\\"));
     file.WriteLine("wss.keypass=" + password);

--- a/ant/windows/windows-packager.nsi.in
+++ b/ant/windows/windows-packager.nsi.in
@@ -47,8 +47,7 @@ Section
 
   ; Cleanup resources from previous versions
   DetailPrint "Cleaning up resources from previous versions..."
-  RMDir /r "$INSTDIR\demo\js\3rdparty"
-  Delete "$INSTDIR\demo\js\qz-websocket.js"
+  RMDir /r "$INSTDIR"
 
   File /r "${dist.dir}\*"
 

--- a/build.xml
+++ b/build.xml
@@ -146,12 +146,16 @@
 
     </target>
 
-    <target name="check-ca">
-        <available file="ca.pem" property="ca-exists" />
+    <target name="check-ca" if="cacert.path">
+        <available file="${cacert.path}/${cacert.filename}" property="ca-exists" />
     </target>
 
     <target name="include-ca" depends="check-ca" if="ca-exists">
-        <copy file="ca.pem" todir="${dist.dir}" />
+        <copy file="${cacert.path}/${cacert.filename}" todir="${dist.dir}" />
+        <propertyfile
+            file="${dist.dir}/${project.filename}.properties">
+            <entry key="ca.certificate" value="${cacert.filename}" />
+        </propertyfile>
     </target>
 
     <!--

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
 <project name="qz" default="distribute" basedir=".">
 
-    <target name="distribute" depends="init,clean,sign-jar,include-assets">
+    <target name="distribute" depends="init,clean,sign-jar,include-assets,include-ca">
         <echo message="Process complete" />
     </target>
 
@@ -144,6 +144,14 @@
             <fileset file="${basedir}/LICENSE.txt"/>
         </copy>
 
+    </target>
+
+    <target name="check-ca">
+        <available file="ca.pem" property="ca-exists" />
+    </target>
+
+    <target name="include-ca" depends="check-ca" if="ca-exists">
+        <copy file="ca.pem" todir="${dist.dir}" />
     </target>
 
     <!--

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.sourceforge.iharder.Base64;
 import qz.common.Constants;
+import qz.deploy.DeployUtilities;
 import qz.utils.ByteUtilities;
 import qz.utils.FileUtilities;
 
@@ -28,6 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Properties;
 
 /**
  * Created by Steven on 1/27/2015. Package: qz.auth Project: qz-print
@@ -79,6 +81,21 @@ public class Certificate {
 
     static {
         try {
+            Properties sslProperties = DeployUtilities.loadSSLProperties();
+            String certFile = sslProperties.getProperty("ca.certificate");
+            if (certFile != null) {
+                File caCert = new File(certFile);
+                if (caCert.exists()) {
+                    try {
+                        trustedRootCert = new Certificate(FileUtilities.readLocalFile(caCert.getPath()));
+                        overrideTrustedRootCert = true;
+                    }
+                    catch(IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
             String overridePath = System.getProperty("trustedRootCert");
             if (overridePath != null) {
                 try {

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -84,7 +84,8 @@ public class Certificate {
             Properties sslProperties = DeployUtilities.loadSSLProperties();
             String certFile = sslProperties.getProperty("ca.certificate");
             if (certFile != null) {
-                File caCert = new File(certFile);
+                File jar = new File(DeployUtilities.detectJarPath());
+                File caCert = new File(jar.getParent(), certFile);
                 if (caCert.exists()) {
                     try {
                         trustedRootCert = new Certificate(FileUtilities.readLocalFile(caCert.getPath()));

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -79,10 +79,10 @@ public class Certificate {
 
     static {
         try {
-            File caCert = new File("ca.pem");
-            if (caCert.exists()) {
+            String overridePath = System.getProperty("trustedRootCert");
+            if (overridePath != null) {
                 try {
-                    trustedRootCert = new Certificate(FileUtilities.readLocalFile(caCert.getPath()));
+                    trustedRootCert = new Certificate(FileUtilities.readLocalFile(overridePath));
                     overrideTrustedRootCert = true;
                 }
                 catch(IOException e) {

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -79,10 +79,10 @@ public class Certificate {
 
     static {
         try {
-            String overridePath = System.getProperty("trustedRootCert");
-            if (overridePath != null) {
+            File caCert = new File("ca.pem");
+            if (caCert.exists()) {
                 try {
-                    trustedRootCert = new Certificate(FileUtilities.readLocalFile(overridePath));
+                    trustedRootCert = new Certificate(FileUtilities.readLocalFile(caCert.getPath()));
                     overrideTrustedRootCert = true;
                 }
                 catch(IOException e) {

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -84,7 +84,7 @@ public class Certificate {
             Properties sslProperties = DeployUtilities.loadSSLProperties();
             String certFile = sslProperties.getProperty("ca.certificate");
             if (certFile != null) {
-                File jar = new File(DeployUtilities.detectJarPath());
+                File jar = new File(DeployUtilities.fixWhitespaces(DeployUtilities.detectJarPath()));
                 File caCert = new File(jar.getParent(), certFile);
                 log.debug("Using certificate in: " + caCert.getPath());
                 if (caCert.exists()) {

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -86,6 +86,7 @@ public class Certificate {
             if (certFile != null) {
                 File jar = new File(DeployUtilities.detectJarPath());
                 File caCert = new File(jar.getParent(), certFile);
+                log.debug("Using certificate in: " + caCert.getPath());
                 if (caCert.exists()) {
                     try {
                         trustedRootCert = new Certificate(FileUtilities.readLocalFile(caCert.getPath()));


### PR DESCRIPTION
Changing Java system properties for launch is not an easy and also it cannot be preserved when tray is set to start automatically at start. Instead custom CA certificate can be obtained from a file in the same directory.