### PR TITLE
Use English locale for string case conversion

### DIFF
--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -15,6 +15,7 @@ import java.awt.*;
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import java.util.Locale;
 
 public class PrintOptions {
 
@@ -60,7 +61,7 @@ public class PrintOptions {
         //check for pixel options
         if (!configOpts.isNull("colorType")) {
             try {
-                psOptions.colorType = ColorType.valueOf(configOpts.optString("colorType").toUpperCase());
+                psOptions.colorType = ColorType.valueOf(configOpts.optString("colorType").toUpperCase(Locale.ENGLISH));
             }
             catch(IllegalArgumentException e) {
                 warn("valid value", "colorType", configOpts.opt("colorType"));
@@ -127,7 +128,7 @@ public class PrintOptions {
         }
         if (!configOpts.isNull("orientation")) {
             try {
-                psOptions.orientation = Orientation.valueOf(configOpts.optString("orientation").replaceAll("\\-", "_").toUpperCase());
+                psOptions.orientation = Orientation.valueOf(configOpts.optString("orientation").replaceAll("\\-", "_").toUpperCase(Locale.ENGLISH));
             }
             catch(IllegalArgumentException e) {
                 warn("valid value", "orientation", configOpts.opt("orientation"));

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -20,6 +20,7 @@ import qz.utils.PrintingUtilities;
 
 import java.awt.print.Printable;
 import java.io.IOException;
+import java.util.Locale;
 
 public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
 
@@ -46,7 +47,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
                 if (data.optBoolean("processed")) { continue; } //in cases of failed captures on multi-pages
                 String source = data.getString("data");
 
-                PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase());
+                PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase(Locale.ENGLISH));
 
                 double pageZoom = (pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()) / 72.0;
                 if (pageZoom <= 1 || data.optBoolean("forceOriginal")) { pageZoom = 1; }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 
 /**
@@ -68,7 +69,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         for(int i = 0; i < printData.length(); i++) {
             JSONObject data = printData.getJSONObject(i);
 
-            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase());
+            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase(Locale.ENGLISH));
 
             try {
                 BufferedImage bi;

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -28,6 +28,7 @@ import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class PrintPDF extends PrintPixel implements PrintProcessor {
 
@@ -50,7 +51,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
         for(int i = 0; i < printData.length(); i++) {
             JSONObject data = printData.getJSONObject(i);
 
-            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase());
+            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "FILE").toUpperCase(Locale.ENGLISH));
 
             try {
                 PDDocument doc;

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -82,7 +82,7 @@ public class PrintRaw implements PrintProcessor {
             JSONObject opt = data.optJSONObject("options");
             if (opt == null) { opt = new JSONObject(); }
 
-            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "PLAIN").toUpperCase());
+            PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "PLAIN").toUpperCase(Locale.ENGLISH));
             PrintOptions.Raw rawOpts = options.getRawOptions();
 
             encoding = rawOpts.getEncoding();

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -18,6 +18,7 @@ import javax.print.PrintService;
 import javax.print.attribute.standard.PrinterResolution;
 import java.awt.print.PrinterAbortException;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class PrintingUtilities {
 
@@ -47,7 +48,7 @@ public class PrintingUtilities {
         if (data == null) {
             type = Type.RAW;
         } else {
-            type = Type.valueOf(data.optString("type", "RAW").toUpperCase());
+            type = Type.valueOf(data.optString("type", "RAW").toUpperCase(Locale.ENGLISH));
         }
 
         try {


### PR DESCRIPTION
This commit fixes a bug when the application runs on an environment with Turkish locale. Turkish have two separate "i" character dotted and dotless. Per the Unicode standard, our lowercase "i" becomes "İ" (U+0130 "Latin Capital Letter I With Dot Above") when it moves to uppercase. Similarly, our uppercase "I" becomes "ı" (U+0131 "Latin Small Letter Dotless I") when it moves to lowercase. Using English locale prevents case conversion with an incorrect locale.

For additional info, you can check out the links below:
http://www.moserware.com/2008/02/does-your-code-pass-turkey-test.html
https://blog.codinghorror.com/whats-wrong-with-turkey/
http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug