### PR TITLE
Don't silently disable secure ports

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -617,7 +617,7 @@ var qz = (function() {
                         if (options == undefined) { options = {}; }
 
                         //respect forcing secure ports if it is defined, otherwise disable
-                        if (options.usingSecure === 'undefined') {
+                        if (options.usingSecure === undefined) {
                             _qz.log.trace("Disabling secure ports due to insecure page");
                             options.usingSecure = false;
                         }

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -615,7 +615,12 @@ var qz = (function() {
                     //disable secure ports if page is not secure
                     if (typeof location === 'undefined' || location.protocol !== 'https:') {
                         if (options == undefined) { options = {}; }
-                        options.usingSecure = false;
+
+                        //respect forcing secure ports if it is defined, otherwise disable
+                        if (options.usingSecure === 'undefined') {
+                            _qz.log.trace("Disabling secure ports due to insecure page");
+                            options.usingSecure = false;
+                        }
                     }
 
                     var attempt = function(count) {


### PR DESCRIPTION
I ran into this during development, and had to use breakpoints to find why insecure ports kept being attempted even when `usingSecure` was set to true.

I understand the reasoning for the disabling, but it makes development a PITA since in this case I was trying to update the JavaScript code and test it with an existing QZ Tray deployment and wanted to verify the use of secure ports and request signing.