### PR TITLE
Build Constants.java from ant properties, get project version from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.idea/compiler.xml
 /README.md
 .DS_Store
+src/qz/common/Constants.java
+out

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -5,6 +5,7 @@ vendor.email=support@qz.io
 
 project.name=QZ Tray
 project.filename=qz-tray
+project.version=2.0.2
 
 launch.opts=-Xms512m
 

--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
         <delete dir="${out.dir}"/>
     </target>
 
-    <target name="compile-socket" depends="init">
+    <target name="compile-socket" depends="init,constants.java">
         <mkdir dir="${build.project.dir}"/>
 
         <javac destdir="${build.project.dir}" source="${javac.source}" target="${javac.target}" includeantruntime="false" encoding="UTF-8">
@@ -91,16 +91,39 @@
                 />
     </target>
 
-    <!-- Get version information from JAR -->
+    <!-- Get version information from git -->
+    <available file=".git" type="dir" property="git.present"/>
+
+    <target name="git.revision" description="Store git revision in ${repository.version}" if="git.present">
+        <!-- http://stackoverflow.com/questions/2974106/how-to-lookup-the-latest-git-commit-hash-from-an-ant-build-script -->
+        <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="">
+            <arg value="describe"/>
+            <arg value="--tags"/>
+            <arg value="--always"/>
+            <arg value="HEAD"/>
+        </exec>
+        <script language="javascript">
+            rev = project.getProperty('git.revision').trim() || "v0.0.0-0";
+            rev = rev.slice(1); // Remove 'v' prefix
+            rev = rev.split('-');
+            project.setProperty('git.lastTag', rev[0]);
+            project.setProperty('git.commitsSinceLastTag', rev[1]);
+            project.setProperty('build.version', rev[0]+"-"+rev[1]);
+        </script>
+        <echo>Version ${build.version}</echo>
+    </target>
+
+    <target name="constants.java" depends="git.revision" description="build Constants.java from template">
+        <copy file="src/qz/common/Constants.java.template" tofile="src/qz/common/Constants.java" overwrite="yes">
+            <filterchain>
+                <expandproperties/>
+            </filterchain>
+        </copy>
+    </target>
+
     <target name="get-version" depends="build-jar">
         <property file="ant/project.properties"/>
-        <java jar="${dist.jar}" fork="true" outputproperty="build.version">
-            <arg value="--version"/>
-        </java>
-		
-        <!-- Fallback to a bogus version number if the above command failed -->
-        <property name="build.version" value="0.0.0" />
-        <echo>Version ${build.version}</echo>
+
         <!-- Calculate installation size -->
         <length property="build.bytes" mode="all">
             <fileset dir="${dist.dir}" includes="**/*"/>

--- a/build.xml
+++ b/build.xml
@@ -92,12 +92,9 @@
     </target>
 
     <!-- Get version information from git -->
-    <property environment="env"/>
-    <available file="git" filepath="${env.PATH}" property="git.present"/>
-
-    <target name="git.revision" description="Store git revision in ${repository.version}" if="git.present">
+    <target name="git.revision" description="Store git revision in ${repository.version}">
         <!-- http://stackoverflow.com/questions/2974106/how-to-lookup-the-latest-git-commit-hash-from-an-ant-build-script -->
-        <exec executable="git" outputproperty="git.revision" failifexecutionfails="false">
+        <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" failonerror="false" resultproperty="git.returncode">
             <arg value="describe"/>
             <arg value="--tags"/>
             <arg value="--always"/>
@@ -108,7 +105,7 @@
         <script language="javascript">
             var rev = project.getProperty('git.revision');
             var version;
-            if (rev) {
+            if (rev &amp;&amp; project.getProperty('git.returncode') === "0") {
                 rev = rev.trim().slice(1); // Remove 'v' prefix
                 rev = rev.split('-');
                 project.setProperty('git.lastTag', rev[0]);
@@ -126,6 +123,7 @@
         </script>
         <property name="build.version" value="${build.version}"/>
         <echo message="Version ${build.version}"/>
+        <echo message="RC ${git.returncode}"/>
   </target>
 
     <target name="constants.java" depends="build.version" description="build Constants.java from template">

--- a/build.xml
+++ b/build.xml
@@ -92,28 +92,43 @@
     </target>
 
     <!-- Get version information from git -->
-    <available file=".git" type="dir" property="git.present"/>
+    <property environment="env"/>
+    <available file="git" filepath="${env.PATH}" property="git.present"/>
 
     <target name="git.revision" description="Store git revision in ${repository.version}" if="git.present">
         <!-- http://stackoverflow.com/questions/2974106/how-to-lookup-the-latest-git-commit-hash-from-an-ant-build-script -->
-        <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="">
+        <exec executable="git" outputproperty="git.revision" failifexecutionfails="false">
             <arg value="describe"/>
             <arg value="--tags"/>
             <arg value="--always"/>
             <arg value="HEAD"/>
         </exec>
-        <script language="javascript">
-            rev = project.getProperty('git.revision').trim() || "v0.0.0-0";
-            rev = rev.slice(1); // Remove 'v' prefix
-            rev = rev.split('-');
-            project.setProperty('git.lastTag', rev[0]);
-            project.setProperty('git.commitsSinceLastTag', rev[1]);
-            project.setProperty('build.version', rev[0]+"-"+rev[1]);
-        </script>
-        <echo>Version ${build.version}</echo>
     </target>
+    <target name="build.version" description="Store git revision in ${repository.version}" depends="git.revision">
+        <script language="javascript">
+            var rev = project.getProperty('git.revision');
+            var version;
+            if (rev) {
+                rev = rev.trim().slice(1); // Remove 'v' prefix
+                rev = rev.split('-');
+                project.setProperty('git.lastTag', rev[0]);
+                project.setProperty('git.commitsSinceLastTag', rev[1]);
 
-    <target name="constants.java" depends="git.revision" description="build Constants.java from template">
+                version = rev[0];
+                if (rev[1]) {
+                    version += "-" + rev[1];
+                }
+            } else {
+                version = project.getProperty('project.version');
+            }
+
+            project.setProperty('build.version', version);
+        </script>
+        <property name="build.version" value="${build.version}"/>
+        <echo message="Version ${build.version}"/>
+  </target>
+
+    <target name="constants.java" depends="build.version" description="build Constants.java from template">
         <copy file="src/qz/common/Constants.java.template" tofile="src/qz/common/Constants.java" overwrite="yes">
             <filterchain>
                 <expandproperties/>

--- a/src/qz/common/Constants.java.template
+++ b/src/qz/common/Constants.java.template
@@ -9,26 +9,26 @@ public class Constants {
     public static final String HEXES = "0123456789ABCDEF";
     public static final char[] HEXES_ARRAY = HEXES.toCharArray();
     public static final int BYTE_BUFFER_SIZE = 8192;
-    public static final String VERSION = "2.0.2";
+    public static final String VERSION = "${build.version}";
 
     /* QZ-Tray Constants */
     public static final String BLOCK_FILE = "blocked";
     public static final String ALLOW_FILE = "allowed";
     public static final String TEMP_FILE = "temp";
     public static final String LOG_FILE = "debug";
-    public static final String PROPS_FILE = "qz-tray"; // .properties extension is assumed
+    public static final String PROPS_FILE = "${project.filename}"; // .properties extension is assumed
     public static final String PREFS_FILE = "prefs"; // .properties extension is assumed
-    public static final String DATA_DIR = "qz";
+    public static final String DATA_DIR = "${vendor.name}";
     public static final int LOG_SIZE = 524288;
     public static final int LOG_ROTATIONS = 5;
 
     public static final int BORDER_PADDING = 10;
 
-    public static final String ABOUT_TITLE = "QZ Tray";
-    public static final String ABOUT_URL = "https://qz.io";
-    public static final String ABOUT_COMPANY = "QZ Industries, LLC";
+    public static final String ABOUT_TITLE = "${project.name}";
+    public static final String ABOUT_URL = "${vendor.website}";
+    public static final String ABOUT_COMPANY = "${vendor.company}";
 
-    public static final String TRUSTED_PUBLISHER = String.format("Verified by %s", Constants.ABOUT_COMPANY);
+    public static final String TRUSTED_PUBLISHER = "Verified by ${vendor.company}";
     public static final String UNTRUSTED_PUBLISHER = "Untrusted website";
 
     public static final String PROBE_REQUEST = "getProgramName";


### PR DESCRIPTION
Moved Constants.java to Constants.java.template, which is now being processed by ant's `expandproperties` filter. The project version is read using `git describe` (formatted as e.g. `2.0.1-14` when building from a branch 14 commits ahead of the tag v2.0.1). We may still want to have the current release hard-coded somewhere as a fallback when git is not available.