### PR TITLE
Change sample label text from qz-print to qz-tray

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -960,7 +960,7 @@
 
         var printData = [
             { type: 'raw', format: 'image', data: 'assets/img/image_sample_bw.png', options: { language: 'ESCP', dotDensity: 'single' } },
-            { type: 'raw', data: '\nPrinted using qz-print plugin.\n\n\n\n\n\n' }
+            { type: 'raw', data: '\nPrinted using qz-tray plugin.\n\n\n\n\n\n' }
         ];
 
         qz.print(config, printData).catch(displayError);


### PR DESCRIPTION
Seems like a holdover from the old `qz-print` project, might as well make it accurate.