### PR TITLE
Set User-Agent for Requests

### DIFF
--- a/src/qz/auth/CRL.java
+++ b/src/qz/auth/CRL.java
@@ -3,10 +3,11 @@ package qz.auth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import qz.utils.ConnectionUtilities;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.util.ArrayList;
 
 /**
@@ -37,8 +38,7 @@ public class CRL {
                 public void run() {
                     log.info("Loading CRL from {}", CRL_URL);
 
-
-                    try(BufferedReader br = new BufferedReader(new InputStreamReader(new URL(CRL_URL).openStream()))) {
+                    try(BufferedReader br = new BufferedReader(new InputStreamReader(ConnectionUtilities.getInputStream(CRL_URL)))) {
                         String line;
                         while((line = br.readLine()) != null) {
                             //Ignore empty and commented lines

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import qz.common.Constants;
 import qz.printer.PrintOptions;
 import qz.printer.PrintOutput;
+import qz.utils.ConnectionUtilities;
 import qz.utils.PrintingUtilities;
 
 import javax.imageio.IIOException;
@@ -35,7 +36,6 @@ import java.awt.print.PrinterJob;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -77,7 +77,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
                 if (flavor == PrintingUtilities.Flavor.BASE64) {
                     bi = ImageIO.read(new ByteArrayInputStream(Base64.decodeBase64(data.getString("data"))));
                 } else {
-                    bi = ImageIO.read(new URL(data.getString("data")));
+                    bi = ImageIO.read(ConnectionUtilities.getInputStream(data.getString("data")));
                 }
 
                 images.add(bi);

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import qz.common.Constants;
 import qz.printer.PrintOptions;
 import qz.printer.PrintOutput;
+import qz.utils.ConnectionUtilities;
 import qz.utils.PrintingUtilities;
 import qz.utils.SystemUtilities;
 
@@ -30,7 +31,6 @@ import java.awt.print.Paper;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.io.*;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -76,7 +76,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                 if (flavor == PrintingUtilities.Flavor.BASE64) {
                     doc = PDDocument.load(new ByteArrayInputStream(Base64.decodeBase64(data.getString("data"))));
                 } else {
-                    doc = PDDocument.load(new URL(data.getString("data")).openStream());
+                    doc = PDDocument.load(ConnectionUtilities.getInputStream(data.getString("data")));
                 }
 
                 pdfs.add(doc);

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -28,6 +28,7 @@ import qz.printer.LanguageType;
 import qz.printer.PrintOptions;
 import qz.printer.PrintOutput;
 import qz.utils.ByteUtilities;
+import qz.utils.ConnectionUtilities;
 import qz.utils.FileUtilities;
 import qz.utils.PrintingUtilities;
 import qz.utils.ShellUtilities;
@@ -42,7 +43,6 @@ import javax.print.event.PrintJobListener;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.Socket;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -139,7 +139,7 @@ public class PrintRaw implements PrintProcessor {
         BufferedImage bi;
 
         if (fromFile) {
-            bi = ImageIO.read(new URL(data));
+            bi = ImageIO.read(ConnectionUtilities.getInputStream(data));
         } else {
             bi = ImageIO.read(new ByteArrayInputStream(Base64.decodeBase64(data)));
         }
@@ -151,7 +151,7 @@ public class PrintRaw implements PrintProcessor {
         PDDocument doc;
 
         if (fromFile) {
-            doc = PDDocument.load(new URL(data).openStream());
+            doc = PDDocument.load(ConnectionUtilities.getInputStream(data));
         } else {
             doc = PDDocument.load(new ByteArrayInputStream(Base64.decodeBase64(data)));
         }

--- a/src/qz/utils/ConnectionUtilities.java
+++ b/src/qz/utils/ConnectionUtilities.java
@@ -1,0 +1,43 @@
+/**
+ * @author Ewan McDougall
+ *
+ * Copyright (C) 2017 Tres Finocchiaro, QZ Industries, LLC
+ *
+ * LGPL 2.1 This is free software.  This software and source code are released under
+ * the "LGPL 2.1 License".  A copy of this license should be distributed with
+ * this software. http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package qz.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import qz.common.Constants;
+
+public final class ConnectionUtilities {
+
+    private static final String USER_AGENT = String.format("%s/%s (%s; %s) Java/%s (%s)",
+        Constants.ABOUT_TITLE.replaceAll("[^a-zA-Z]", ""),
+        StringUtils.join(ArrayUtils.subarray(StringUtils.split(Constants.VERSION, "."), 0, 2), "."),
+        System.getProperty("os.name"),
+        System.getProperty("os.version"),
+        StringUtils.join(ArrayUtils.subarray(StringUtils.split(System.getProperty("java.version"), "."), 0, 2), "."),
+        System.getProperty("java.vendor"));
+
+    /**
+     * Returns an input stream that reads from the URL.
+     * While setting the underlying URLConnections User-Agent.
+     *
+     * @param url an absolute URL giving location of resource to read.
+     */
+    public static InputStream getInputStream(String urlString) throws IOException {
+        URLConnection urlConn = new URL(urlString).openConnection();
+        urlConn.setRequestProperty("User-Agent", USER_AGENT);
+        return urlConn.getInputStream();
+    }
+}

--- a/src/qz/utils/ConnectionUtilities.java
+++ b/src/qz/utils/ConnectionUtilities.java
@@ -21,13 +21,14 @@ import qz.common.Constants;
 
 public final class ConnectionUtilities {
 
-    private static final String USER_AGENT = String.format("%s/%s (%s; %s) Java/%s (%s)",
+    private static final String USER_AGENT = String.format("%s/%s (%s; %s; %s) Java/%s (%s)",
         Constants.ABOUT_TITLE.replaceAll("[^a-zA-Z]", ""),
         StringUtils.join(ArrayUtils.subarray(StringUtils.split(Constants.VERSION, "."), 0, 2), "."),
         System.getProperty("os.name"),
         System.getProperty("os.version"),
+        System.getProperty("os.arch"),
         StringUtils.join(ArrayUtils.subarray(StringUtils.split(System.getProperty("java.version"), "."), 0, 2), "."),
-        System.getProperty("java.vendor"));
+        System.getProperty("java.vm.name"));
 
     /**
      * Returns an input stream that reads from the URL.

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -19,11 +19,11 @@ import org.xml.sax.SAXException;
 import qz.common.ByteArrayBuilder;
 import qz.common.Constants;
 import qz.exception.NullCommandException;
+import qz.utils.ConnectionUtilities;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
-import java.net.URL;
 import java.util.HashMap;
 
 
@@ -121,7 +121,7 @@ public class FileUtilities {
     }
 
     public static byte[] readRawFile(String url) throws IOException {
-        return readFile(new DataInputStream(new URL(url).openStream()));
+        return readFile(new DataInputStream(ConnectionUtilities.getInputStream(url)));
     }
 
     private static byte[] readFile(DataInputStream in) throws IOException {


### PR DESCRIPTION
Currently defaults to Java version for example `Java/1.8.0_121`, instead
use `QZTray/2.0.2 (Linux; 4.4.0-63-generic) Java/1.8.0_121 (Oracle
Corporation)`

Useful for analytics and resolving issues.

see https://tools.ietf.org/html/rfc7231#section-5.5.3