### PR TITLE
Tighten up 'processPrintRequest' a little

### DIFF
--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -155,7 +155,7 @@ public class PrintingUtilities {
             PrintOutput output = new PrintOutput(params.optJSONObject("printer"));
             PrintOptions options = new PrintOptions(params.optJSONObject("options"), output);
 
-            processor.parseData(params.optJSONArray("data"), options);
+            processor.parseData(params.getJSONArray("data"), options);
             processor.print(output, options);
             log.info("Printing complete");
 
@@ -169,8 +169,9 @@ public class PrintingUtilities {
             log.error("Failed to print", e);
             PrintSocketClient.sendError(session, UID, e);
         }
-
-        PrintingUtilities.releasePrintProcessor(processor);
+        finally {
+            PrintingUtilities.releasePrintProcessor(processor);
+        }
     }
 
 }


### PR DESCRIPTION
`data` is not optional in `processPrintRequest` and `releasePrintProcessor` should always execute no matter what.