### PR TITLE
File communication interface.

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -45,7 +45,7 @@ var qz = (function() {
 
         //stream types
         streams: {
-            serial: 'SERIAL', usb: 'USB', hid: 'HID'
+            serial: 'SERIAL', usb: 'USB', hid: 'HID', file: 'FILE'
         },
 
 
@@ -253,6 +253,8 @@ var qz = (function() {
                                     case _qz.streams.hid:
                                         _qz.hid.callHid(JSON.parse(returned.event));
                                         break;
+                                    case _qz.streams.file:
+                                        _qz.file.callFile(JSON.parse(returned.event));
                                     default:
                                         _qz.log.warn("Cannot determine stream type for callback", returned);
                                         break;
@@ -414,6 +416,20 @@ var qz = (function() {
                     }
                 } else {
                     _qz.hid.hidCallbacks(streamEvent);
+                }
+            }
+        },
+
+
+        file: {
+            fileCallbacks: [],
+            callFile: function(streamEvent) {
+                if (Array.isArray(_qz.file.fileCallbacks)) {
+                      for(var i = 0; i < _qz.file.fileCallbacks.length; i++) {
+                          _qz.file.fileCallbacks[i](streamEvent);
+                      }
+                } else {
+                    _qz.file.fileCallbacks(streamEvent);
                 }
             }
         },
@@ -881,6 +897,33 @@ var qz = (function() {
             return _qz.websocket.dataPromise('print', params, signature, signingTimestamp);
         },
 
+
+        file: {
+          setFileCallbacks: function(calls) {
+              _qz.file.fileCallbacks = calls;
+          },
+
+          open: function(path, receiveCallbacks) {
+              var rc = typeof receiveCallbacks !== 'undefined' ? receiveCallbacks : true;
+              var params = {
+                  path: path,
+                  receiveCallbacks: rc
+              }
+              return _qz.websocket.dataPromise('file.open', params);
+          },
+
+          sendData: function(path, data, append) {
+              var params = {
+                  path: path,
+                  data: data,
+                  append: append || false
+              };
+              return _qz.websocket.dataPromise('file.sendData', params);
+          },
+          close: function(path) {
+              return _qz.websocket.dataPromise('file.close', { path: path });
+          }
+        },
 
         /**
          * Calls related to interaction with serial ports.

--- a/src/qz/communication/FileIO.java
+++ b/src/qz/communication/FileIO.java
@@ -1,0 +1,120 @@
+package qz.communication;
+
+import qz.utils.FileUpdateHandler;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+
+public class FileIO {
+
+  private static final Logger log = LoggerFactory.getLogger(FileIO.class);
+
+  private String filePath;
+	private FileWatcher watcher;
+	private FileUpdateHandler fileUpdateHandler;
+	private Boolean receiveCallbacks;
+
+	public FileIO(String filePath, Boolean receiveCallbacks) throws IOException {
+		this.filePath = filePath;
+		this.receiveCallbacks = receiveCallbacks;
+		if (receiveCallbacks) {
+			this.watcher = new FileWatcher(new File(this.filePath));
+			this.watcher.start();
+		}
+		log.debug(String.format("new FileIO for %s", filePath));
+	}
+
+	public void setFileUpdateHandler(FileUpdateHandler fuh) {
+		this.fileUpdateHandler = fuh;
+	}
+
+	/**
+	 * Writes the buffered data to the File.
+	 */
+	public void sendData(String data, Boolean append) {
+		try (BufferedWriter bw = new BufferedWriter(new FileWriter(filePath, append))) {
+			bw.write(data);
+		} catch (IOException e) {
+			log.error(String.format("Exception writing data to file %s", filePath), e);
+		}
+	}
+
+	/**
+	 * Closes the file, if open.
+	 *
+	 * @return Boolean indicating success.
+	 * @throws IOException
+	 */
+	public void close() {
+		if (receiveCallbacks) {
+			try {
+				this.watcher.stopWatching();
+			} catch (IOException e) {
+				log.error(String.format("Exception while stop watching %s", filePath),e);
+			}
+		}
+	}
+
+	public class FileWatcher extends Thread {
+		private final File file;
+		private AtomicBoolean run = new AtomicBoolean(true);
+		private final WatchService watchService;
+
+		public FileWatcher(File file) throws IOException {
+			this.file = file;
+			final Path path = this.file.toPath().getParent();
+			log.debug(String.format("Watching %s", path.toString()));
+			this.watchService = FileSystems.getDefault().newWatchService();
+			path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+		}
+
+		public void stopWatching() throws IOException {
+			this.run.set(false);
+			this.watchService.close();
+		}
+
+		@Override
+		public void run() {
+			while (run.get()) {
+				try {
+					final WatchKey wk = watchService.take();
+					for (WatchEvent<?> event : wk.pollEvents()) {
+						final Path changed = (Path) event.context();
+						final WatchEvent.Kind<?> kind = event.kind();
+						if (kind == StandardWatchEventKinds.ENTRY_MODIFY && changed.toString().equals(file.getName())) {
+							log.debug(String.format("file %s %s", file.getName(), kind.toString()));
+							if (fileUpdateHandler != null) {
+								fileUpdateHandler.handleFileUpdate(file);
+							}
+						}
+					}
+					// reset the key
+					boolean valid = wk.reset();
+					if (!valid) {
+						log.debug("Key has been unregistered");
+					}
+					Thread.yield();
+				} catch (InterruptedException ex) {
+				} catch (ClosedWatchServiceException ex) {
+					if (run.get()) {
+						throw ex;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/qz/utils/FileIoUtilities.java
+++ b/src/qz/utils/FileIoUtilities.java
@@ -1,0 +1,59 @@
+package qz.utils;
+
+import qz.communication.FileIO;
+import qz.utils.FileUpdateHandler;
+import qz.ws.PrintSocketClient;
+import qz.ws.SocketConnection;
+import qz.ws.StreamEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.eclipse.jetty.websocket.api.Session;
+
+import java.io.File;
+
+public class FileIoUtilities {
+
+    private static final Logger log = LoggerFactory.getLogger(FileIoUtilities.class);
+
+	public static void setupFile(final Session session, final String UID, SocketConnection connection, JSONObject params)
+			throws JSONException {
+		final String filePath = params.getString("path");
+		if (connection.getFile(filePath) != null) {
+			PrintSocketClient.sendError(session, UID, String.format("File [%s] is already open.", filePath));
+			return;
+		}
+
+		try {
+			log.debug(String.format("setupFile with params: %s", params.toString()));
+			FileIO file = new FileIO(filePath, params.getBoolean("receiveCallbacks"));
+			connection.addFile(filePath, file);
+			file.setFileUpdateHandler(new FileUpdateHandler() {
+				private String fileContents(File file) throws IOException {
+					byte[] encoded = Files.readAllBytes(file.toPath());
+					return new String(encoded, "UTF-8");
+				}
+
+				public void handleFileUpdate(File file) {
+					try {
+						String output = fileContents(file);
+						StreamEvent event = new StreamEvent(StreamEvent.Stream.FILE, StreamEvent.Type.RECEIVE)
+								.withData("filePath", file.getPath()).withData("output", output);
+						log.debug("sendStream");
+						PrintSocketClient.sendStream(session, event);
+
+					} catch (IOException ex) {
+						PrintSocketClient.sendError(session, UID, ex);
+					}
+				}
+			});
+			PrintSocketClient.sendResult(session, UID, null);
+		} catch (IOException ex) {
+			PrintSocketClient.sendError(session, UID, ex);
+		}
+
+	}
+}

--- a/src/qz/utils/FileUpdateHandler.java
+++ b/src/qz/utils/FileUpdateHandler.java
@@ -1,0 +1,8 @@
+package qz.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface FileUpdateHandler {
+    public void handleFileUpdate(File file);
+}

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -47,6 +47,10 @@ public class PrintSocketClient {
         SERIAL_SEND_DATA("serial.sendData", true, "send data over a serial port"),
         SERIAL_CLOSE_PORT("serial.closePort", true, "close a serial port"),
 
+        FILE_OPEN("file.open", true, "open a file"),
+        FILE_SEND_DATA("file.sendData", true, "send data to a file"),
+        FILE_CLOSE("file.close", true, "close a file"),
+
         USB_LIST_DEVICES("usb.listDevices", true, "access USB devices"),
         USB_LIST_INTERFACES("usb.listInterfaces", true, "access USB devices"),
         USB_LIST_ENDPOINTS("usb.listEndpoints", true, "access USB devices"),
@@ -286,6 +290,30 @@ public class PrintSocketClient {
                 PrintingUtilities.processPrintRequest(session, UID, params);
                 break;
 
+            case FILE_OPEN:
+                FileIoUtilities.setupFile(session, UID, connection, params);
+                break;
+            case FILE_SEND_DATA: {
+                FileIO file = connection.getFile(params.optString("path"));
+                if (file != null) {
+                    file.sendData(params.optString("data"), params.getBoolean("append"));
+                    sendResult(session, UID, null);
+                } else {
+                    sendError(session, UID, String.format("File [%s] must be opened first.", params.optString("path")));
+                }
+                break;
+            }
+            case FILE_CLOSE: {
+               FileIO file = connection.getFile(params.optString("path"));
+                if (file != null) {
+                    file.close();
+                    connection.removeFile(params.optString("path"));
+                    sendResult(session, UID, null);
+                } else {
+                    sendError(session, UID, String.format("File [%s] is not open.", params.optString("path")));
+                }
+                break;
+            }
             case SERIAL_FIND_PORTS:
                 sendResult(session, UID, SerialUtilities.getSerialPortsJSON());
                 break;

--- a/src/qz/ws/SocketConnection.java
+++ b/src/qz/ws/SocketConnection.java
@@ -7,6 +7,7 @@ import qz.auth.Certificate;
 import qz.communication.DeviceException;
 import qz.communication.DeviceIO;
 import qz.communication.DeviceListener;
+import qz.communication.FileIO;
 import qz.communication.SerialIO;
 import qz.utils.UsbUtilities;
 
@@ -27,6 +28,7 @@ public class SocketConnection {
     //vendor id -> product id -> open DeviceIO
     private final HashMap<Short,HashMap<Short,DeviceIO>> openDevices = new HashMap<>();
 
+    private final HashMap<String,FileIO> openFiles = new HashMap<>();
 
     public SocketConnection(Certificate cert) {
         certificate = cert;
@@ -110,10 +112,14 @@ public class SocketConnection {
     }
 
     /**
-     * Explicitly closes all open serial and usb connections setup through this object
+     * Explicitly closes all open files, serial and usb connections setup through this object
      */
     public synchronized void disconnect() throws SerialPortException, DeviceException {
         log.info("Closing all communication channels for {}", certificate.getCommonName());
+
+        for(String f : openFiles.keySet()) {
+          openFiles.get(f).close();
+        }
 
         for(String p : openSerialPorts.keySet()) {
             openSerialPorts.get(p).close();
@@ -128,5 +134,17 @@ public class SocketConnection {
 
         stopListening();
     }
+
+	public FileIO getFile(String filePath) {
+		return openFiles.get(filePath);
+	}
+
+	public void addFile(String filePath, FileIO file) {
+		openFiles.put(filePath, file);
+	}
+	
+	public void removeFile(String filePath) {
+		openFiles.remove(filePath);
+	}
 
 }

--- a/src/qz/ws/StreamEvent.java
+++ b/src/qz/ws/StreamEvent.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 public class StreamEvent {
 
     public enum Stream {
-        SERIAL, USB, HID
+        SERIAL, USB, HID, FILE
     }
 
     public enum Type {


### PR DESCRIPTION
Allow qz-tray to read/write from files.
Writing to a file will either overwrite or append to contents of a file
depending on configuration.
Reading a file involves registering for notifications of file
modifications and recieving file contents in notification of file
modification.

For simplicity of implementation a FileWatcher is created for each File
that modification notifications are wanted for.