### PR TITLE
ZPL Image width needs to be divisible by 8, enforce this like EPL

### DIFF
--- a/src/qz/printer/LanguageType.java
+++ b/src/qz/printer/LanguageType.java
@@ -20,8 +20,8 @@ import java.util.List;
  */
 public enum LanguageType {
 
-    ZPLII(false, false, "ZEBRA", "ZPL2"),
-    ZPL(false, false),
+    ZPLII(false, true, "ZEBRA", "ZPL2"),
+    ZPL(false, true),
     EPL2(true, true, "EPLII"),
     EPL(true, true),
     CPCL(false, true),


### PR DESCRIPTION
I investigated the option of performing ZB64 Encoding and Compression, however it only applies to ZPL II, not ZPL. This change is sufficient and is what others do when utilizing ````^GFA```` tag.

This was tested with both a raw PNG, as well as base64 ````data:image/png;base64,```` to ensure there were no discrepancies. 