### PR TITLE
Allow exclusion of demo assets using a build property

### DIFF
--- a/ant/project.properties
+++ b/ant/project.properties
@@ -22,7 +22,6 @@ branding.dir=${asset.dir}/branding
 
 dist.dir=${out.dir}/dist
 dist.jar=${dist.dir}/${project.filename}.jar
-dist.include_demo=true
 
 authcert.name=override.crt
 authcert.build=${dist.dir}/${authcert.name}

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -22,6 +22,7 @@ branding.dir=${asset.dir}/branding
 
 dist.dir=${out.dir}/dist
 dist.jar=${dist.dir}/${project.filename}.jar
+dist.include_demo=true
 
 authcert.name=override.crt
 authcert.build=${dist.dir}/${authcert.name}

--- a/build.xml
+++ b/build.xml
@@ -141,7 +141,7 @@
         <property name="build.type" value="-community"/>
     </target>
 
-    <target name="include-assets" depends="init,get-version" if="${dist.include_demo}">
+    <target name="include-assets" depends="init,get-version" unless="dist.minimal">
         <echo>Copying resource files to output</echo>
 
         <copy todir="${dist.dir}/${demo.dir}/${asset.dir}">

--- a/build.xml
+++ b/build.xml
@@ -58,7 +58,6 @@
             <fileset dir="${src.dir}" excludes="**/*.java"/>
         </copy>
 
-        <!-- Distribute socket with LICENSE only -->
         <copy todir="${dist.dir}">
             <fileset file="${basedir}/LICENSE.txt"/>
         </copy>

--- a/build.xml
+++ b/build.xml
@@ -57,6 +57,11 @@
         <copy todir="${build.project.dir}">
             <fileset dir="${src.dir}" excludes="**/*.java"/>
         </copy>
+
+        <!-- Distribute socket with LICENSE only -->
+        <copy todir="${dist.dir}">
+            <fileset file="${basedir}/LICENSE.txt"/>
+        </copy>
     </target>
 
     <target name="build-jar" depends="compile-socket">
@@ -136,7 +141,7 @@
         <property name="build.type" value="-community"/>
     </target>
 
-    <target name="include-assets" depends="init,get-version" >
+    <target name="include-assets" depends="init,get-version" if="${dist.include_demo}">
         <echo>Copying resource files to output</echo>
 
         <copy todir="${dist.dir}/${demo.dir}/${asset.dir}">
@@ -164,12 +169,6 @@
         <copy todir="${dist.dir}/${demo.dir}">
             <fileset file="sample.html"/>
         </copy>
-
-        <!-- Distribute socket with LICENSE only -->
-        <copy todir="${dist.dir}">
-            <fileset file="${basedir}/LICENSE.txt"/>
-        </copy>
-
     </target>
 
     <!--


### PR DESCRIPTION
I have added a build property to optionally exclude demo files from installers. These files are not needed on most of client computers and excluding them reduces install file size by ~6%, which makes a difference when deploying to lots of computers over slow networks.

The default is to include demo files, so I believe it is an acceptable feature.