### PR TITLE
Various fixes to orientation

### DIFF
--- a/src/qz/printer/BookBundle.java
+++ b/src/qz/printer/BookBundle.java
@@ -23,28 +23,11 @@ public class BookBundle extends Book implements Printable {
 
     private static final Logger log = LoggerFactory.getLogger(BookBundle.class);
 
-    private List<PDDocument> refDocs = new ArrayList<>();
-    private OrientationRequested orient = null;
-    private boolean scale = false;
-
     private Printable lastPrint;
     private int lastStarted;
 
-    public BookBundle(PrintOptions.Orientation orientation, boolean scaled) {
+    public BookBundle() {
         super();
-
-        if (orientation != null) {
-            orient = orientation.getAsAttribute();
-        }
-        scale = scaled;
-    }
-
-    public void append(PDDocument doc, Printable painter, PageFormat page, int numPages) {
-        for(int i = 0; i < numPages; i++) {
-            refDocs.add(doc);
-        }
-
-        append(painter, page, numPages);
     }
 
     @Override
@@ -58,48 +41,10 @@ public class BookBundle extends Book implements Printable {
                 lastStarted = pageIndex;
             }
 
-            log.debug("Paper area: {},{}:{},{}", (int)format.getImageableX(), (int)format.getImageableY(),
-                      (int)format.getImageableWidth(), (int)format.getImageableHeight());
-
-            if (SystemUtilities.isMac()) {
-                adjustPrintForOrientation(g, format, pageIndex);
-            }
-
             return printable.print(g, format, pageIndex - lastStarted);
         }
 
         return NO_SUCH_PAGE;
-    }
-
-    /** Fixes landscape orientations on OSX */
-    private void adjustPrintForOrientation(Graphics g, PageFormat format, int pageIndex) {
-        PDRectangle bounds = refDocs.get(pageIndex).getPage(pageIndex - lastStarted).getBBox();
-        double topAdjust = 0, leftAdjust = 0;
-
-        if (orient == OrientationRequested.LANDSCAPE) {
-            //adjust down page to account for wrong origin corner
-            if (scale) {
-                //only adjusts vertically, so only check if scale affects width
-                if ((bounds.getWidth() / bounds.getHeight()) < (format.getImageableWidth() / format.getImageableHeight())) {
-                    leftAdjust = format.getImageableHeight() - (bounds.getWidth() * (format.getImageableWidth() / bounds.getHeight()));
-                }
-            } else {
-                leftAdjust = format.getImageableHeight() - bounds.getWidth();
-            }
-        } else if (orient == OrientationRequested.REVERSE_LANDSCAPE) {
-            //adjust across page to account for wrong origin corner
-            if (scale) {
-                //only adjusts horizontally, so only check is scale affects height
-                if ((bounds.getWidth() / bounds.getHeight()) >= (format.getImageableWidth() / format.getImageableHeight())) {
-                    topAdjust = format.getImageableWidth() - (bounds.getHeight() * (format.getImageableHeight() / bounds.getWidth()));
-                }
-            } else {
-                topAdjust = format.getImageableWidth() - bounds.getHeight();
-            }
-        }
-
-        //landscape will have only rotated doc, this adjusts page so [0,0] appears to come from correct corner
-        g.translate((int)topAdjust, (int)leftAdjust);
     }
 
     /**

--- a/src/qz/printer/BookBundle.java
+++ b/src/qz/printer/BookBundle.java
@@ -1,13 +1,19 @@
 package qz.printer;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qz.utils.SystemUtilities;
 
+import javax.print.attribute.standard.OrientationRequested;
 import java.awt.*;
 import java.awt.print.Book;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Wrapper of the {@code Book} class as a {@code Printable} type,
@@ -17,11 +23,28 @@ public class BookBundle extends Book implements Printable {
 
     private static final Logger log = LoggerFactory.getLogger(BookBundle.class);
 
+    private List<PDDocument> refDocs = new ArrayList<>();
+    private OrientationRequested orient = null;
+    private boolean scale = false;
+
     private Printable lastPrint;
     private int lastStarted;
 
-    public BookBundle() {
+    public BookBundle(PrintOptions.Orientation orientation, boolean scaled) {
         super();
+
+        if (orientation != null) {
+            orient = orientation.getAsAttribute();
+        }
+        scale = scaled;
+    }
+
+    public void append(PDDocument doc, Printable painter, PageFormat page, int numPages) {
+        for(int i = 0; i < numPages; i++) {
+            refDocs.add(doc);
+        }
+
+        append(painter, page, numPages);
     }
 
     @Override
@@ -35,10 +58,48 @@ public class BookBundle extends Book implements Printable {
                 lastStarted = pageIndex;
             }
 
+            log.debug("Paper area: {},{}:{},{}", (int)format.getImageableX(), (int)format.getImageableY(),
+                      (int)format.getImageableWidth(), (int)format.getImageableHeight());
+
+            if (SystemUtilities.isMac()) {
+                adjustPrintForOrientation(g, format, pageIndex);
+            }
+
             return printable.print(g, format, pageIndex - lastStarted);
         }
 
         return NO_SUCH_PAGE;
+    }
+
+    /** Fixes landscape orientations on OSX */
+    private void adjustPrintForOrientation(Graphics g, PageFormat format, int pageIndex) {
+        PDRectangle bounds = refDocs.get(pageIndex).getPage(pageIndex - lastStarted).getBBox();
+        double topAdjust = 0, leftAdjust = 0;
+
+        if (orient == OrientationRequested.LANDSCAPE) {
+            //adjust down page to account for wrong origin corner
+            if (scale) {
+                //only adjusts vertically, so only check if scale affects width
+                if ((bounds.getWidth() / bounds.getHeight()) < (format.getImageableWidth() / format.getImageableHeight())) {
+                    leftAdjust = format.getImageableHeight() - (bounds.getWidth() * (format.getImageableWidth() / bounds.getHeight()));
+                }
+            } else {
+                leftAdjust = format.getImageableHeight() - bounds.getWidth();
+            }
+        } else if (orient == OrientationRequested.REVERSE_LANDSCAPE) {
+            //adjust across page to account for wrong origin corner
+            if (scale) {
+                //only adjusts horizontally, so only check is scale affects height
+                if ((bounds.getWidth() / bounds.getHeight()) >= (format.getImageableWidth() / format.getImageableHeight())) {
+                    topAdjust = format.getImageableWidth() - (bounds.getHeight() * (format.getImageableHeight() / bounds.getWidth()));
+                }
+            } else {
+                topAdjust = format.getImageableWidth() - bounds.getHeight();
+            }
+        }
+
+        //landscape will have only rotated doc, this adjusts page so [0,0] appears to come from correct corner
+        g.translate((int)topAdjust, (int)leftAdjust);
     }
 
     /**

--- a/src/qz/printer/BookBundle.java
+++ b/src/qz/printer/BookBundle.java
@@ -35,9 +35,6 @@ public class BookBundle extends Book implements Printable {
                 lastStarted = pageIndex;
             }
 
-            log.debug("Paper area: {},{}:{},{}", (int)format.getImageableX(), (int)format.getImageableY(),
-                      (int)format.getImageableWidth(), (int)format.getImageableHeight());
-
             return printable.print(g, format, pageIndex - lastStarted);
         }
 

--- a/src/qz/printer/PDFWrapper.java
+++ b/src/qz/printer/PDFWrapper.java
@@ -1,0 +1,34 @@
+package qz.printer;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.printing.PDFPrintable;
+import org.apache.pdfbox.printing.Scaling;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+
+public class PDFWrapper implements Printable {
+
+    private static final Logger log = LoggerFactory.getLogger(PDFWrapper.class);
+
+    private PDFPrintable printable;
+
+    public PDFWrapper(PDDocument document, Scaling scaling, boolean showPageBorder, float dpi, boolean center) {
+        printable = new PDFPrintable(document, scaling, showPageBorder, dpi, center);
+    }
+
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        log.debug("Paper area: {},{}:{},{}", (int)pageFormat.getImageableX(), (int)pageFormat.getImageableY(),
+                  (int)pageFormat.getImageableWidth(), (int)pageFormat.getImageableHeight());
+
+        graphics.drawString(" ", 0, 0);
+
+        return printable.print(graphics, pageFormat, pageIndex);
+    }
+}

--- a/src/qz/printer/PDFWrapper.java
+++ b/src/qz/printer/PDFWrapper.java
@@ -1,11 +1,14 @@
 package qz.printer;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.printing.PDFPrintable;
 import org.apache.pdfbox.printing.Scaling;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qz.utils.SystemUtilities;
 
+import javax.print.attribute.standard.OrientationRequested;
 import java.awt.*;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
@@ -15,20 +18,74 @@ public class PDFWrapper implements Printable {
 
     private static final Logger log = LoggerFactory.getLogger(PDFWrapper.class);
 
+    private PDDocument document;
+    private Scaling scaling;
+    private OrientationRequested orientation = OrientationRequested.PORTRAIT;
+
     private PDFPrintable printable;
 
-    public PDFWrapper(PDDocument document, Scaling scaling, boolean showPageBorder, float dpi, boolean center) {
+    public PDFWrapper(PDDocument document, Scaling scaling, boolean showPageBorder, float dpi, boolean center, PrintOptions.Orientation orientation) {
+        this.document = document;
+        this.scaling = scaling;
+        if (orientation != null) {
+            this.orientation = orientation.getAsAttribute();
+        }
+
         printable = new PDFPrintable(document, scaling, showPageBorder, dpi, center);
     }
 
 
     @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        if ("sun.print.PeekGraphics".equals(graphics.getClass().getCanonicalName())) {
+            //java uses class only to query if a page needs printed - save memory/time by short circuiting
+            return PAGE_EXISTS;
+        }
+
         log.debug("Paper area: {},{}:{},{}", (int)pageFormat.getImageableX(), (int)pageFormat.getImageableY(),
                   (int)pageFormat.getImageableWidth(), (int)pageFormat.getImageableHeight());
 
         graphics.drawString(" ", 0, 0);
 
+        //reverse fix for OSX
+        if (SystemUtilities.isMac() && orientation == OrientationRequested.REVERSE_LANDSCAPE) {
+            adjustPrintForOrientation(graphics, pageFormat, pageIndex);
+        }
+
         return printable.print(graphics, pageFormat, pageIndex);
     }
+
+    private void adjustPrintForOrientation(Graphics g, PageFormat format, int page) {
+        PDRectangle bounds = document.getPage(page).getBBox();
+        double docWidth = bounds.getWidth();
+        double docHeight = bounds.getHeight();
+
+        //reports dimensions flipped if rotated
+        if (document.getPage(page).getRotation() % 180 == 90) {
+            docWidth = bounds.getHeight();
+            docHeight = bounds.getWidth();
+        }
+
+        //adjust across page to account for wrong origin corner
+        double leftAdjust, topAdjust;
+
+        if (scaling != Scaling.ACTUAL_SIZE) {
+            if ((docWidth / docHeight) >= (format.getImageableWidth() / format.getImageableHeight())) {
+                leftAdjust = 0;
+                topAdjust = format.getImageableHeight() - (docHeight / (docWidth / format.getImageableWidth()));
+            } else {
+                leftAdjust = format.getImageableWidth() - (docWidth / (docHeight / format.getImageableHeight()));
+                topAdjust = 0;
+            }
+        } else {
+            leftAdjust = format.getImageableWidth() - docWidth;
+            topAdjust = format.getImageableHeight() - docHeight;
+        }
+
+        log.info("Adjusting image by {},{} for selected orientation", leftAdjust, topAdjust);
+
+        //reverse landscape will have only rotated doc, this adjusts page so [0,0] appears to come from correct corner
+        g.translate((int)leftAdjust, (int)topAdjust);
+    }
+
 }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -20,10 +20,12 @@ import qz.common.Constants;
 import qz.printer.PrintOptions;
 import qz.printer.PrintOutput;
 import qz.utils.PrintingUtilities;
+import qz.utils.SystemUtilities;
 
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.OrientationRequested;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
@@ -53,7 +55,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
     protected boolean scaleImage = false;
     protected Object interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;
     protected double imageRotation = 0;
-
+    protected boolean manualReverse = false;
 
     public PrintImage() {
         images = new ArrayList<>();
@@ -116,6 +118,12 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         interpolation = pxlOpts.getInterpolation();
         imageRotation = pxlOpts.getRotation();
 
+        if (SystemUtilities.isMac() && pxlOpts.getOrientation() != null
+                && pxlOpts.getOrientation().getAsAttribute() == OrientationRequested.REVERSE_LANDSCAPE) {
+            imageRotation += 180;
+            manualReverse = true;
+        }
+
         job.setJobName(pxlOpts.getJobName(Constants.IMAGE_PRINT));
         job.setPrintable(this, job.validatePage(page));
 
@@ -133,7 +141,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         }
         log.trace("Requested page {} for printing", pageIndex);
 
-        if (graphics.getClass().getCanonicalName().equals("sun.print.PeekGraphics")) {
+        if ("sun.print.PeekGraphics".equals(graphics.getClass().getCanonicalName())) {
             //java uses class only to query if a page needs printed - save memory/time by short circuiting
             return PAGE_EXISTS;
         }
@@ -189,8 +197,13 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
 
         log.debug("Memory: {}m/{}m", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576, Runtime.getRuntime().maxMemory() / 1048576);
 
-        graphics2D.drawImage(imgToPrint, (int)boundX, (int)boundY, (int)(boundX + imgW), (int)(boundY + imgH),
-                             0, 0, imgToPrint.getWidth(), imgToPrint.getHeight(), null);
+        if (!manualReverse) {
+            graphics2D.drawImage(imgToPrint, (int)boundX, (int)boundY, (int)(boundX + imgW), (int)(boundY + imgH),
+                                 0, 0, imgToPrint.getWidth(), imgToPrint.getHeight(), null);
+        } else {
+            graphics2D.drawImage(imgToPrint, (int)(boundW + boundX - imgW), (int)(boundH + boundY - imgH), (int)(boundW + boundX), (int)(boundH + boundY),
+                                 0, 0, imgToPrint.getWidth(), imgToPrint.getHeight(), null);
+        }
 
         // Valid page
         return PAGE_EXISTS;
@@ -248,6 +261,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         scaleImage = false;
         imageRotation = 0;
         interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;
+        manualReverse = false;
     }
 
 }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -139,6 +139,9 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         }
 
 
+        //allows pages view to rotate in different orientations
+        graphics.drawString(" ", 0, 0);
+
         BufferedImage imgToPrint = fixColorModel(images.get(pageIndex));
         if (imageRotation % 360 != 0) {
             imgToPrint = rotate(imgToPrint, imageRotation);

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -118,6 +118,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         interpolation = pxlOpts.getInterpolation();
         imageRotation = pxlOpts.getRotation();
 
+        //reverse fix for OSX
         if (SystemUtilities.isMac() && pxlOpts.getOrientation() != null
                 && pxlOpts.getOrientation().getAsAttribute() == OrientationRequested.REVERSE_LANDSCAPE) {
             imageRotation += 180;

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -114,7 +114,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
 
         Scaling scale = (pxlOpts.isScaleContent()? Scaling.SCALE_TO_FIT:Scaling.ACTUAL_SIZE);
 
-        BookBundle bundle = new BookBundle();
+        BookBundle bundle = new BookBundle(pxlOpts.getOrientation(), pxlOpts.isScaleContent());
 
         for(PDDocument doc : printables) {
             PageFormat page = job.getPageFormat(null);
@@ -139,7 +139,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                 }
             }
 
-            bundle.append(new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false), page, doc.getNumberOfPages());
+            bundle.append(doc, new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false), page, doc.getNumberOfPages());
         }
 
         job.setJobName(pxlOpts.getJobName(Constants.PDF_PRINT));

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -79,8 +79,11 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
 
     @Override
     public PrintRequestAttributeSet applyDefaultSettings(PrintOptions.Pixel pxlOpts, PageFormat page) {
-        //page orient does not set properly on pdfs with orientation requested attribute
-        page.setOrientation(pxlOpts.getOrientation().getAsFormat());
+        if (pxlOpts.getOrientation() != null) {
+            //page orient does not set properly on pdfs with orientation requested attribute
+            page.setOrientation(pxlOpts.getOrientation().getAsFormat());
+        }
+
         return super.applyDefaultSettings(pxlOpts, page);
     }
 

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -114,7 +114,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
 
         Scaling scale = (pxlOpts.isScaleContent()? Scaling.SCALE_TO_FIT:Scaling.ACTUAL_SIZE);
 
-        BookBundle bundle = new BookBundle(pxlOpts.getOrientation(), pxlOpts.isScaleContent());
+        BookBundle bundle = new BookBundle();
 
         for(PDDocument doc : printables) {
             PageFormat page = job.getPageFormat(null);
@@ -136,10 +136,15 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                     Paper repap = page.getPaper();
                     repap.setImageableArea(repap.getImageableX(), repap.getImageableY(), repap.getImageableHeight(), repap.getImageableWidth());
                     page.setPaper(repap);
+
+                    //reverse fix for OSX
+                    if (SystemUtilities.isMac() && pxlOpts.getOrientation() == PrintOptions.Orientation.REVERSE_LANDSCAPE) {
+                        pd.setRotation(pd.getRotation() + 180);
+                    }
                 }
             }
 
-            bundle.append(doc, new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false), page, doc.getNumberOfPages());
+            bundle.append(new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false, pxlOpts.getOrientation()), page, doc.getNumberOfPages());
         }
 
         job.setJobName(pxlOpts.getJobName(Constants.PDF_PRINT));

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -117,7 +117,12 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                     rotatePage(doc, pd, pxlOpts.getRotation());
                 }
 
-                if (pxlOpts.getOrientation() != null && pxlOpts.getOrientation() != PrintOptions.Orientation.PORTRAIT) {
+                if (pxlOpts.getOrientation() == null) {
+                    if ((pd.getRotation() / 90) % 2 == 1) {
+                        log.info("Adjusting orientation to print landscape PDF source");
+                        page.setOrientation(PrintOptions.Orientation.LANDSCAPE.getAsFormat());
+                    }
+                } else if (pxlOpts.getOrientation() != PrintOptions.Orientation.PORTRAIT) {
                     //flip imageable area dimensions when in landscape
                     Paper repap = page.getPaper();
                     repap.setImageableArea(repap.getImageableX(), repap.getImageableY(), repap.getImageableHeight(), repap.getImageableWidth());


### PR DESCRIPTION
Includes:
- Fix to landscape documents to appear landscape in supported previews
- Auto-rotation on PDF's
- Split PDF's to ensure each page is treated properly
- Support for reverse-landscape on OSX

Succeeds #202 