### PR TITLE
Cannot read property 'promise' of null

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -175,7 +175,7 @@ var qz = (function() {
                         _qz.log.info("Closed connection with QZ Tray");
 
                         //if this is set, then an explicit close call was made
-                        if (_qz.websocket.connection.promise != undefined) {
+                        if (_qz.websocket.connection && _qz.websocket.connection.promise != undefined) {
                             _qz.websocket.connection.promise.resolve();
                         }
 


### PR DESCRIPTION
This error appears after an user is closing or is clicking on "Block" in the "Action Required" window. (https://drive.google.com/open?id=1CBQ8Ent29SPfhgVrK8QRH9Rs_2ZwLBZc)