### PR TITLE
Make reload more friendly: reload properties and keystore

### DIFF
--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -332,6 +332,11 @@ public class TrayManager {
 
     public void exit(int returnCode) {
         prefs.save();
+        try {
+            PrintSocketServer.stopServer();
+        } catch (Exception e) {
+            log.error("Error while stopping server", e);
+        }
         System.exit(returnCode);
     }
 
@@ -437,11 +442,9 @@ public class TrayManager {
      * Sets the WebSocket Server instance for displaying port information and restarting the server
      *
      * @param server            The Server instance contain to bind the reload action to
-     * @param running           Object used to notify PrintSocket to reiterate its main while loop
-     * @param securePortIndex   Object used to notify PrintSocket to reset its port array counter
      * @param insecurePortIndex Object used to notify PrintSocket to reset its port array counter
      */
-    public void setServer(final Server server, final AtomicBoolean running, final AtomicInteger securePortIndex, final AtomicInteger insecurePortIndex) {
+    public void setServer(final Server server, final AtomicInteger insecurePortIndex) {
         if (server != null && server.getConnectors().length > 0) {
             singleInstanceCheck(PrintSocketServer.INSECURE_PORTS, insecurePortIndex.get());
 
@@ -454,11 +457,7 @@ public class TrayManager {
                 public void run() {
                     try {
                         setDangerIcon();
-                        running.set(false);
-                        securePortIndex.set(0);
-                        insecurePortIndex.set(0);
-
-                        server.stop();
+                        PrintSocketServer.reloadServer();
                     }
                     catch(Exception e) {
                         displayErrorMessage("Error stopping print socket: " + e.getLocalizedMessage());


### PR DESCRIPTION
Pull request as mentioned in #208. To answer the question there, `StatisticsHandler` is used because it is required in order to use `Server.setStopTimeout`, as per [the documentation](https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/Server.html#setStopTimeout-long-).

The main change is to move the reload logic to `PrintSocketServer.reloadServer()` so that it can easily be called programmatically from other parts of the code that may need to reload QZ. This may have other potential uses I hadn't thought of, such as if `wss.host` is `0.0.0.0` maybe QZ would automatically reload on a network change so it could bind on any new network interface (not sure if it does that already, or if `0.0.0.0` only binds once on all network interfaces available when it is called).