### PR TITLE
Add legacy HTML support

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -379,6 +379,7 @@ var qz = (function() {
                 fallbackDensity: null,
                 interpolation: 'bicubic',
                 jobName: null,
+                legacy: false,
                 margins: 0,
                 orientation: null,
                 paperThickness: null,
@@ -820,6 +821,7 @@ var qz = (function() {
              *  @param {number} [options.fallbackDensity=null] Value used when default density value cannot be read, or in cases where reported as "Normal" by the driver, (in DPI, DPMM, or DPCM depending on <code>[options.units]</code>).
              *  @param {string} [options.interpolation='bicubic'] Valid values <code>[bicubic | bilinear | nearest-neighbor]</code>. Controls how images are handled when resized.
              *  @param {string} [options.jobName=null] Name to display in print queue.
+             *  @param {boolean} [options.legacy=false] If legacy style printing should be used.
              *  @param {Object|number} [options.margins=0] If just a number is provided, it is used as the margin for all sides.
              *   @param {number} [options.margins.top=0]
              *   @param {number} [options.margins.right=0]

--- a/sample.html
+++ b/sample.html
@@ -955,7 +955,7 @@
             { type: 'raw', format: 'image', data: 'assets/img/image_sample_bw.png', options: { language: 'ZPLII' } },
 	    '^FS\n',
 	    '^FO50,300^ADN,36,20^FDPRINTED USING^FS\n',
-            '^FO50,350^ADN,36,20^FDQZ-TRAY ^FS\n',
+	    '^FO50,350^ADN,36,20^FDQZ-TRAY ^FS\n', 
 	    '^FO50,400^ADN,36,20^FDVERSION ' + qzVersion + '^FS\n' + '\n',
 	    '^XZ\n'
         ];

--- a/sample.html
+++ b/sample.html
@@ -306,6 +306,11 @@
                                         </div>
 
                                         <div class="form-group form-inline">
+                                            <label for="pxlLegacy">Legacy Printing</label>
+                                            <input type="checkbox" id="pxlLegacy" class="pull-right" />
+                                        </div>
+
+                                        <div class="form-group form-inline">
                                             <label for="pxlOrientation">Orientation</label>
                                             <select id="pxlOrientation" class="form-control pull-right">
                                                 <option value="">Default</option>
@@ -950,7 +955,7 @@
             { type: 'raw', format: 'image', data: 'assets/img/image_sample_bw.png', options: { language: 'ZPLII' } },
 	    '^FS\n',
 	    '^FO50,300^ADN,36,20^FDPRINTED USING^FS\n',
-	    '^FO50,350^ADN,36,20^FDQZ-TRAY ^FS\n', 
+            '^FO50,350^ADN,36,20^FDQZ-TRAY ^FS\n',
 	    '^FO50,400^ADN,36,20^FDVERSION ' + qzVersion + '^FS\n' + '\n',
 	    '^XZ\n'
         ];
@@ -1416,6 +1421,7 @@
         $("#pxlDuplex").prop('checked', false);
         $("#pxlInterpolation").val("");
         $("#pxlJobName").val("");
+        $("#pxlLegacy").prop('checked', false);
         $("#pxlOrientation").val("");
         $("#pxlPaperThickness").val(null);
         $("#pxlPrinterTray").val(null);
@@ -1824,6 +1830,7 @@
                             duplex: $("#pxlDuplex").prop('checked'),
                             interpolation: $("#pxlInterpolation").val(),
                             jobName: jobName,
+                            legacy: $("#pxlLegacy").prop('checked'),
                             margins: pxlMargins,
                             orientation: $("#pxlOrientation").val(),
                             paperThickness: $("#pxlPaperThickness").val(),

--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -129,6 +129,9 @@ public class PrintOptions {
         if (!configOpts.isNull("jobName")) {
             psOptions.jobName = configOpts.optString("jobName", null);
         }
+        if (!configOpts.isNull("legacy")) {
+            psOptions.legacy = configOpts.optBoolean("legacy", false);
+        }
         if (!configOpts.isNull("margins")) {
             Margins m = new Margins();
             JSONObject subMargins = configOpts.optJSONObject("margins");
@@ -318,6 +321,7 @@ public class PrintOptions {
         private boolean duplex = false;                                             //Double/single sided
         private Object interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;  //Image interpolation
         private String jobName = null;                                              //Job name
+        private boolean legacy = false;                                             //Legacy printing
         private Margins margins = new Margins();                                    //Page margins
         private Orientation orientation = null;                                     //Page orientation
         private double paperThickness = -1;                                         //Paper thickness
@@ -351,6 +355,10 @@ public class PrintOptions {
 
         public String getJobName(String defaultVal) {
             return jobName == null || jobName.isEmpty()? defaultVal:jobName;
+        }
+
+        public boolean isLegacy() {
+            return legacy;
         }
 
         public Margins getMargins() {

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -199,6 +199,8 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
             log.trace("Requested page {} for printing", pageIndex);
 
             Graphics2D graphics2D = super.withRenderHints((Graphics2D)graphics, interpolation);
+            graphics2D.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+            graphics2D.scale(pageFormat.getImageableWidth() / pageFormat.getWidth(), pageFormat.getImageableHeight() / pageFormat.getHeight());
             legacyLabel.paint(graphics2D);
 
             return PAGE_EXISTS;

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -15,20 +15,35 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qz.common.Constants;
 import qz.printer.PrintOptions;
+import qz.printer.PrintOutput;
 import qz.utils.PrintingUtilities;
 
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.print.PageFormat;
 import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
 
     private static final Logger log = LoggerFactory.getLogger(PrintHTML.class);
 
+    private List<WebAppModel> models;
+
+    private JLabel legacyLabel = null;
+
 
     public PrintHTML() {
         super();
+        models = new ArrayList<>();
     }
 
     @Override
@@ -57,44 +72,25 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
 
                 // web dimension use 96dpi (or equivalent dp/metric)
                 if (options.getDefaultOptions().getPageSize() != null) {
-                    pageWidth = options.getDefaultOptions().getPageSize().getWidth() * (96.0 / 72.0);
-                    //pageHeight = options.getDefaultOptions().getPageSize().getHeight() * (96.0 / 72.0);
+                    pageWidth = options.getDefaultOptions().getPageSize().getWidth();
+                    //pageHeight = options.getDefaultOptions().getPageSize().getHeight();
                 }
+
                 if (!data.isNull("options")) {
                     JSONObject dataOpt = data.getJSONObject("options");
-                    if (!dataOpt.isNull("pageWidth")) {
-                        pageWidth = data.optJSONObject("options").getDouble("pageWidth") * (96.0 / pxlOpts.getUnits().as1Inch());
+
+                    if (!dataOpt.isNull("pageWidth") && dataOpt.optDouble("pageWidth") > 0) {
+                        pageWidth = dataOpt.optDouble("pageWidth") * (72.0 / pxlOpts.getUnits().as1Inch());
                     }
-                    if (!dataOpt.isNull("pageHeight")) {
-                        pageHeight = data.optJSONObject("options").getDouble("pageHeight") * (96.0 / pxlOpts.getUnits().as1Inch());
+                    if (!dataOpt.isNull("pageHeight") && dataOpt.optDouble("pageHeight") > 0) {
+                        pageHeight = dataOpt.optDouble("pageHeight") * (72.0 / pxlOpts.getUnits().as1Inch());
                     }
                 }
 
-                try {
-                    images.add(WebApp.capture(source, (format == PrintingUtilities.Format.FILE), pageWidth, pageHeight, pageZoom));
-                    data.put("processed", true);
-                }
-                catch(IOException e) {
-                    //JavaFX image loader becomes null if webView is too large, throwing an IllegalArgumentException on screen capture attempt
-                    if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
-                        if (data.optBoolean("forceOriginal")) {
-                            throw new UnsupportedOperationException("Image or Density is too large for HTML printing", e);
-                        } else {
-                            log.warn("HTML capture failed due to size, attempting at default zoom");
-                            data.put("forceOriginal", true);
-                            parseData(printData, options);
-                            return;
-                        }
-                    }
-
-                    throw new UnsupportedOperationException(String.format("Cannot parse (%s)%s as HTML", format, source), e);
-                }
-                catch(Throwable t) {
-                    throw new UnsupportedOperationException("Failed to capture HTML", t);
-                }
+                models.add(new WebAppModel(source, (format != PrintingUtilities.Format.FILE), pageWidth, pageHeight, pxlOpts.isScaleContent(), pageZoom));
             }
 
-            log.debug("Parsed {} html records", images.size());
+            log.debug("Parsed {} html records", models.size());
         }
         catch(IOException e) {
             throw new UnsupportedOperationException("Unable to start JavaFX service", e);
@@ -102,6 +98,108 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
         catch(NoClassDefFoundError e) {
             throw new UnsupportedOperationException("JavaFX libraries not found", e);
         }
+    }
+
+    @Override
+    public void print(PrintOutput output, PrintOptions options) throws PrinterException {
+        if (options.getPixelOptions().isLegacy()) {
+            printLegacy(output, options);
+        } else {
+            for(WebAppModel model : models) {
+                try {
+                    images.add(WebApp.capture(model));
+                }
+                catch(IOException e) {
+                    //JavaFX image loader becomes null if webView is too large, throwing an IllegalArgumentException on screen capture attempt
+                    if (e.getCause() != null && e.getCause() instanceof IllegalArgumentException) {
+                        try {
+                            log.warn("HTML capture failed due to size, attempting at default zoom");
+                            model.setZoom(1.0);
+                            images.add(WebApp.capture(model));
+                        }
+                        catch(IOException re) {
+                            throw new UnsupportedOperationException("Image or Density is too large for HTML printing", re);
+                        }
+                    } else {
+                        throw new PrinterException(e.getMessage());
+                    }
+                }
+                catch(Throwable t) {
+                    throw new UnsupportedOperationException("Failed to capture HTML", t);
+                }
+            }
+
+            super.print(output, options);
+        }
+    }
+
+    private void printLegacy(PrintOutput output, PrintOptions options) throws PrinterException {
+        PrintOptions.Pixel pxlOpts = options.getPixelOptions();
+
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setPrintService(output.getPrintService());
+        PageFormat page = job.getPageFormat(null);
+
+        PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page);
+
+        //setup swing ui
+        JFrame legacyFrame = new JFrame(pxlOpts.getJobName(Constants.HTML_PRINT));
+        legacyFrame.setUndecorated(true);
+        legacyFrame.setLayout(new FlowLayout());
+        legacyFrame.setExtendedState(Frame.ICONIFIED);
+
+        legacyLabel = new JLabel();
+        legacyLabel.setOpaque(true);
+        legacyLabel.setBackground(Color.WHITE);
+        legacyLabel.setBorder(null);
+        legacyLabel.setDoubleBuffered(false);
+
+        legacyFrame.add(legacyLabel);
+
+        try {
+            for(WebAppModel model : models) {
+                legacyLabel.setText(model.getSource());
+
+                legacyFrame.pack();
+                legacyFrame.setVisible(true);
+
+                job.setPrintable(this);
+                printCopies(output, pxlOpts, job, attributes);
+
+                legacyFrame.setVisible(false);
+            }
+        }
+        finally {
+            legacyFrame.dispose();
+        }
+    }
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        if (legacyLabel == null) {
+            return super.print(graphics, pageFormat, pageIndex);
+        } else {
+            if (graphics == null) { throw new PrinterException("No graphics specified"); }
+            if (pageFormat == null) { throw new PrinterException("No page format specified"); }
+
+            if (pageIndex + 1 > models.size()) {
+                return NO_SUCH_PAGE;
+            }
+            log.trace("Requested page {} for printing", pageIndex);
+
+            Graphics2D graphics2D = super.withRenderHints((Graphics2D)graphics, interpolation);
+            legacyLabel.paint(graphics2D);
+
+            return PAGE_EXISTS;
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+
+        models.clear();
+        legacyLabel = null;
     }
 
 }

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -120,7 +120,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
                             model.setZoom(1.0);
                             images.add(WebApp.capture(model));
                         }
-                        catch(IOException re) {
+                        catch(Throwable re) {
                             throw new UnsupportedOperationException("Image or Density is too large for HTML printing", re);
                         }
                     } else {

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -165,7 +165,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
                     legacyLabel.setText(model.getSource());
                 } else {
                     try(InputStream fis = new URL(model.getSource()).openStream()) {
-                        String webPage = IOUtils.toString(fis).replaceAll("^[\\s\\S]+<(HTML|html)\\b.*?>", "<html>");
+                        String webPage = IOUtils.toString(fis, "UTF-8").replaceAll("^[\\s\\S]+<(HTML|html)\\b.*?>", "<html>");
                         legacyLabel.setText(webPage);
                     }
                 }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -243,7 +243,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         return result;
     }
 
-    private Graphics2D withRenderHints(Graphics2D g2d, Object interpolation) {
+    protected Graphics2D withRenderHints(Graphics2D g2d, Object interpolation) {
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
         g2d.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -178,11 +178,10 @@ public class WebApp extends Application {
     /**
      * Sets up capture to run on JavaFX thread and returns snapshot of rendered page
      *
-     * @param source   The html to be rendered for capture
-     * @param fromFile If the passed {@code source} is from a url/file location
+     * @param model Data about the html to be rendered for capture
      * @return BufferedImage of the rendered html
      */
-    public static synchronized BufferedImage capture(final String source, final boolean fromFile, final double width, final double height, final double zoom) throws Throwable {
+    public static synchronized BufferedImage capture(final WebAppModel model) throws Throwable {
         final AtomicReference<BufferedImage> capture = new AtomicReference<>();
         complete.set(false);
         thrown.set(null);
@@ -196,9 +195,9 @@ public class WebApp extends Application {
         Platform.runLater(new Thread() {
             public void run() {
                 try {
-                    pageWidth = width;
-                    pageHeight = height;
-                    pageZoom = zoom;
+                    pageWidth = model.getWebWidth();
+                    pageHeight = model.getWebHeight();
+                    pageZoom = model.getZoom();
 
                     webView.setMinSize(100, 100);
                     webView.setPrefSize(100, 100);
@@ -230,10 +229,10 @@ public class WebApp extends Application {
                     });
 
                     //actually begin loading the html
-                    if (fromFile) {
-                        webView.getEngine().load(source);
+                    if (model.isPlainText()) {
+                        webView.getEngine().loadContent(model.getSource(), "text/html");
                     } else {
-                        webView.getEngine().loadContent(source, "text/html");
+                        webView.getEngine().load(model.getSource());
                     }
                 }
                 catch(Throwable t) {

--- a/src/qz/printer/action/WebAppModel.java
+++ b/src/qz/printer/action/WebAppModel.java
@@ -1,0 +1,53 @@
+package qz.printer.action;
+
+public class WebAppModel {
+
+    private String source;
+    private boolean plainText = false;
+
+    private double webWidth = 0.0;
+    private double webHeight = 0.0;
+    private boolean isScaled = true;
+    private double zoom = 1.0;
+
+    public WebAppModel(String source, boolean plainText, double webWidth, double webHeight, boolean isScaled, double zoom) {
+        //values supplied are at print dpi, scale up to web dpi here
+        double increase = 96d / 72d;
+
+        this.source = source;
+        this.plainText = plainText;
+        this.webWidth = webWidth * increase;
+        this.webHeight = webHeight * increase;
+        this.isScaled = isScaled;
+        this.zoom = zoom;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public boolean isPlainText() {
+        return plainText;
+    }
+
+    public double getWebWidth() {
+        return webWidth;
+    }
+
+    public double getWebHeight() {
+        return webHeight;
+    }
+
+    public boolean isScaled() {
+        return isScaled;
+    }
+
+    public double getZoom() {
+        return zoom;
+    }
+
+    public void setZoom(double zoom) {
+        this.zoom = zoom;
+    }
+
+}


### PR DESCRIPTION
Adds HTML support from QZ Tray 1.9 for backwards compatibility.

Closes #277.