### PR TITLE
Autostart improvements

### DIFF
--- a/ant/apple/apple-launcher.sh.in
+++ b/ant/apple/apple-launcher.sh.in
@@ -17,8 +17,8 @@
 installpath=$(echo "$0" | rev | cut -d/ -f4- | rev)
 jarpath=$installpath/${project.filename}.jar
 iconpath=$installpath/${apple.resources}/${apple.icon}
-localautostart="${apple.datadir.local}/autostart"
-globalautostart="${apple.datadir.shared}/autostart"
+localautostart="${apple.datadir.local}/${autostart.name}"
+globalautostart="${apple.datadir.shared}/${autostart.name}"
 ${apple.jvmver} > /dev/null 2>&1
 fallback=$?
 

--- a/ant/apple/apple-launcher.sh.in
+++ b/ant/apple/apple-launcher.sh.in
@@ -23,24 +23,16 @@ ${apple.jvmver} > /dev/null 2>&1
 fallback=$?
 
 # If launched at startup, check override first
-if [ "$1" = "-A" ]
-then
-    if [ -f "$localAutostart" ];
-    then
-        if [ "$(head -n 1 $localautostart)" = "0" ]
-        then
-           echo "Skipping autostart"
-           exit 0
-        fi
+if [ "$1" = "-A" ]; then
+    echo "Autostart switch '-A' was provided"
+    if [ -f "$localautostart" ] && [ "$(head -n 1 "$localautostart")" = "0" ]; then
+        echo "Skipping autostart per '$localautostart'"
+        exit 0
+    elif [ -f "$globalautostart" ] && [ "$(head -n 1 "$globalautostart")" = "0" ]; then
+        echo "Skipping autostart per '$globalautostart'"
+        exit 0
     else
-        if [ -f "$globalautostart" ];
-        then
-            if [ "$(head -n 1 $globalautostart)" = "0" ]
-            then
-                echo "Skipping autostart"
-                exit 0
-            fi
-        fi
+        echo "No autostart conflicts found in '$localautostart' or '$globalautostart'.  Starting."
     fi
 fi
 

--- a/ant/apple/apple-launcher.sh.in
+++ b/ant/apple/apple-launcher.sh.in
@@ -17,13 +17,31 @@
 installpath=$(echo "$0" | rev | cut -d/ -f4- | rev)
 jarpath=$installpath/${project.filename}.jar
 iconpath=$installpath/${apple.resources}/${apple.icon}
+localautostart="${apple.datadir.local}/autostart"
+globalautostart="${apple.datadir.shared}/autostart"
 ${apple.jvmver} > /dev/null 2>&1
 fallback=$?
 
 # If launched at startup, check override first
-if [[ "$1" == "--autostart" ]] && [[ "$(cat "$installpath/.autostart")" == "0" ]]; then
-    echo "Skipping autostart"
-    exit 0
+if [ "$1" = "-A" ]
+then
+    if [ -f "$localAutostart" ];
+    then
+        if [ "$(head -n 1 $localautostart)" = "0" ]
+        then
+           echo "Skipping autostart"
+           exit 0
+        fi
+    else
+        if [ -f "$globalautostart" ];
+        then
+            if [ "$(head -n 1 $globalautostart)" = "0" ]
+            then
+                echo "Skipping autostart"
+                exit 0
+            fi
+        fi
+    fi
 fi
 
 # Fallback on Internet Plug-Ins version if needed

--- a/ant/apple/apple-postinstall.sh.in
+++ b/ant/apple/apple-postinstall.sh.in
@@ -38,18 +38,15 @@ cat > /Library/LaunchAgents/$package.plist << EOT
     <key>ProgramArguments</key>
     <array>
         <string>${apple.installdir}/${apple.macos}/${project.name}</string>
-        <string>--autostart</string>
+        <string>-A</string>
     </array>
 </dict>
 </plist>
 EOT
 
-printf 1 > "${apple.installdir}/.autostart"
-chmod 777 "${apple.installdir}/.autostart"
-
 # Shared directory for FileIO operations
-mkdir -p "/Library/Application Support/${vendor.name}" 2>&1
-chmod 666 "/Library/Application Support/${vendor.name}"
+mkdir -p "${apple.datadir.shared}" 2>&1
+chmod 777 "${apple.datadir.shared}"
 
 # Cleanup resources from previous versions
 rm -rf "${apple.installdir}/demo/js/3rdparty"

--- a/ant/apple/apple.properties
+++ b/ant/apple/apple.properties
@@ -38,6 +38,8 @@ apple.launcher.in=${basedir}/ant/apple/apple-launcher.sh.in
 apple.launcher.out=${dist.dir}/${apple.macos}/${project.name}
 
 apple.installdir=/Applications/${project.name}.app
+apple.datadir.local=$HOME/Library/Application Support/${project.datadir}
+apple.datadir.shared=/Library/Application Support/${project.datadir}
 
 apple.keychain=/Library/Keychains/System.keychain
 

--- a/ant/linux/linux-installer.sh.in
+++ b/ant/linux/linux-installer.sh.in
@@ -38,6 +38,7 @@ mask=755
 destdir="${linux.installdir}"
 shortcut="/usr/share/applications/${project.filename}.desktop"
 jarfile="${destdir}/${project.filename}.jar"
+launcher="${destdir}/launcher"
 
 # Confirmation dialog
 height=8; width=41
@@ -79,7 +80,7 @@ function progress_dialog() {
 
 # Check minimum java version
 function check_java() {
-   curver=$(java -version 2>&1 | grep -i version | awk -F"\"" '{ print $2 }' | awk -F"." '{ print $1 "." $2 }') 
+   curver=$(java -version 2>&1 | grep -i version | awk -F"\"" '{ print $2 }' | awk -F"." '{ print $1 "." $2 }')
    minver="${javac.target}"
 
    if [ -z "$curver" ]; then
@@ -116,7 +117,6 @@ mkdir -p "${destdir}" > /dev/null 2>&1
 mkdir -p "/srv/${vendor.name}" 2>&1
 chmod 666 "/srv/${vendor.name}"
 
-
 progress_dialog 30 "Installing new version..."
 cp -R ./ "${destdir}"
 rm "${destdir}/`basename $0`"
@@ -125,7 +125,7 @@ progress_dialog 40 "Creating desktop shortcut..."
 echo "[Desktop Entry]
 Type=Application
 Name=${project.name}
-Exec=java ${launch.opts} -jar \"${jarfile}\"
+Exec="${launcher}"
 Path=${destdir}
 Icon=${destdir}/${linux.icon}
 MimeType=application/x-qz;x-scheme-handler/qz;
@@ -219,7 +219,7 @@ else
 fi
 
 progress_dialog 90 "Setting permissions..."
-chmod -R $mask "${destdir}" 
+chmod -R $mask "${destdir}"
 
 progress_dialog 92 "Installing usb/udev rules..."
 rm -f "/lib/udev/rules.d/${linux.udev.name}" > /dev/null 2>&1
@@ -233,13 +233,21 @@ for i in /home/* ; do
     if [ -n "${project.filename}" ]; then
     	rm "$i/.config/autostart/${project.filename}.desktop" > /dev/null 2>&1
     fi
-    if [ -n "${project.name}" ]; then 
+    if [ -n "${project.name}" ]; then
     	rm "$i/.config/autostart/${project.name}.desktop" > /dev/null 2>&1
     fi
 done
 
 progress_dialog 94 "Adding startup entry..."
-cp "${shortcut}" "/etc/xdg/autostart/${project.filename}.desktop"
+echo "[Desktop Entry]
+Type=Application
+Name=${project.name}
+Exec="${launcher} -A"
+Path=${destdir}
+Icon=${destdir}/${linux.icon}
+MimeType=application/x-qz;x-scheme-handler/qz;
+Terminal=false
+Comment=${project.name}" > "/etc/xdg/autostart/${project.filename}.desktop"
 
 # Allow oridinary users to write
 chmod 777 "/etc/xdg/autostart/${project.filename}.desktop"

--- a/ant/linux/linux-installer.sh.in
+++ b/ant/linux/linux-installer.sh.in
@@ -38,7 +38,7 @@ mask=755
 destdir="${linux.installdir}"
 shortcut="/usr/share/applications/${project.filename}.desktop"
 jarfile="${destdir}/${project.filename}.jar"
-launcher="${destdir}/launcher"
+launcher="${destdir}/${linux.launcher.name}"
 
 # Confirmation dialog
 height=8; width=41

--- a/ant/linux/linux-installer.sh.in
+++ b/ant/linux/linux-installer.sh.in
@@ -114,8 +114,8 @@ progress_dialog 25 "Creating directories..."
 mkdir -p "${destdir}" > /dev/null 2>&1
 
 # Shared directory for FileIO operations
-mkdir -p "/srv/${vendor.name}" 2>&1
-chmod 666 "/srv/${vendor.name}"
+mkdir -p "${linux.datadir.shared}" 2>&1
+chmod 777 "${linux.datadir.shared}"
 
 progress_dialog 30 "Installing new version..."
 cp -R ./ "${destdir}"

--- a/ant/linux/linux-launcher.sh.in
+++ b/ant/linux/linux-launcher.sh.in
@@ -16,8 +16,8 @@
 
 destdir="${linux.installdir}"
 jarfile="${destdir}/${project.filename}.jar"
-localautostart="${linux.datadir.local}/autostart"
-globalautostart="${linux.datadir.shared}/autostart"
+localautostart="${linux.datadir.local}/${autostart.name}"
+globalautostart="${linux.datadir.shared}/${autostart.name}"
 
 if [ "$1" = "-A" ]
 then

--- a/ant/linux/linux-launcher.sh.in
+++ b/ant/linux/linux-launcher.sh.in
@@ -1,0 +1,29 @@
+#!/bin/bash
+##########################################################################################
+#                            ${project.name} Linux Launcher                                      #
+##########################################################################################
+#  Description:                                                                          #
+#    1. Determines if program should autostart (if applicable)                           #
+#    2. Launch application                                                               #                                                                         #
+#                                                                                        #
+#  Usage:                                                                                #
+#    $ ./launcher                                                                        #
+#                                                                                        #
+#  Options:                                                                              #
+#    -A    Check autostart file to determine if ${project.name} should launch            #
+#                                                                                        #
+##########################################################################################
+
+jarfile="${destdir}/${project.filename}.jar"
+
+if [ "$1" = "-A" ]
+then
+   line=$(head -n 1 "$HOME/${linux.datadir}/autostart")
+   if [ "$line" = "1" ]
+   then
+       eval "java ${launch.opts} -jar \"${jarfile}\"
+   fi
+else
+   eval "java ${launch.opts} -jar \"${jarfile}\"
+fi
+exit 0

--- a/ant/linux/linux-launcher.sh.in
+++ b/ant/linux/linux-launcher.sh.in
@@ -19,25 +19,19 @@ jarfile="${destdir}/${project.filename}.jar"
 localautostart="${linux.datadir.local}/${autostart.name}"
 globalautostart="${linux.datadir.shared}/${autostart.name}"
 
-if [ "$1" = "-A" ]
-then
-    if [ -f "$localautostart" ];
-    then
-        if [ "$(head -n 1 $localautostart)" = "0" ]
-        then
-           echo "Skipping autostart"
-           exit 0
-        fi
+# If launched at startup, check override first
+if [ "$1" = "-A" ]; then
+    echo "Autostart switch '-A' was provided"
+    if [ -f "$localautostart" ] && [ "$(head -n 1 "$localautostart")" = "0" ]; then
+        echo "Skipping autostart per '$localautostart'"
+        exit 0
+    elif [ -f "$globalautostart" ] && [ "$(head -n 1 "$globalautostart")" = "0" ]; then
+        echo "Skipping autostart per '$globalautostart'"
+        exit 0
     else
-        if [ -f "$globalautostart" ];
-        then
-            if [ "$(head -n 1 $globalautostart)" = "0" ]
-            then
-                echo "Skipping autostart"
-                exit 0
-            fi
-        fi
+        echo "No autostart conflicts found in '$localautostart' or '$globalautostart'.  Starting."
     fi
 fi
+
 eval java ${launch.opts} -jar \"${jarfile}\"
 exit 0

--- a/ant/linux/linux-launcher.sh.in
+++ b/ant/linux/linux-launcher.sh.in
@@ -14,6 +14,7 @@
 #                                                                                        #
 ##########################################################################################
 
+destdir="${linux.installdir}"
 jarfile="${destdir}/${project.filename}.jar"
 
 if [ "$1" = "-A" ]
@@ -21,9 +22,9 @@ then
    line=$(head -n 1 "$HOME/${linux.datadir}/autostart")
    if [ "$line" = "1" ]
    then
-       eval "java ${launch.opts} -jar \"${jarfile}\"
+       eval java ${launch.opts} -jar \"${jarfile}\"
    fi
 else
-   eval "java ${launch.opts} -jar \"${jarfile}\"
+   eval java ${launch.opts} -jar \"${jarfile}\"
 fi
 exit 0

--- a/ant/linux/linux-launcher.sh.in
+++ b/ant/linux/linux-launcher.sh.in
@@ -16,15 +16,28 @@
 
 destdir="${linux.installdir}"
 jarfile="${destdir}/${project.filename}.jar"
+localautostart="${linux.datadir.local}/autostart"
+globalautostart="${linux.datadir.shared}/autostart"
 
 if [ "$1" = "-A" ]
 then
-   line=$(head -n 1 "$HOME/${linux.datadir}/autostart")
-   if [ "$line" = "1" ]
-   then
-       eval java ${launch.opts} -jar \"${jarfile}\"
-   fi
-else
-   eval java ${launch.opts} -jar \"${jarfile}\"
+    if [ -f "$localautostart" ];
+    then
+        if [ "$(head -n 1 $localautostart)" = "0" ]
+        then
+           echo "Skipping autostart"
+           exit 0
+        fi
+    else
+        if [ -f "$globalautostart" ];
+        then
+            if [ "$(head -n 1 $globalautostart)" = "0" ]
+            then
+                echo "Skipping autostart"
+                exit 0
+            fi
+        fi
+    fi
 fi
+eval java ${launch.opts} -jar \"${jarfile}\"
 exit 0

--- a/ant/linux/linux.properties
+++ b/ant/linux/linux.properties
@@ -21,7 +21,8 @@ linux.uninstall.in=${basedir}/ant/linux/linux-uninstall.sh.in
 linux.uninstall.out=${dist.dir}/uninstall
 
 linux.installdir=/opt/${project.filename}
-linux.datadir=.qz
+linux.datadir.local=$HOME/.${project.datadir}
+linux.datadir.shared=/srv/${project.datadir}
 
 linux.packager.name=linux-packager.sh
 linux.packager.in=${basedir}/ant/linux/${linux.packager.name}.in

--- a/ant/linux/linux.properties
+++ b/ant/linux/linux.properties
@@ -13,10 +13,15 @@ linux.installer.name=linux-installer.sh
 linux.installer.in=${basedir}/ant/linux/${linux.installer.name}.in
 linux.installer.out=${dist.dir}/${linux.installer.name}
 
+linux.launcher.name=linux-launcher.sh
+linux.launcher.in=${basedir}/ant/linux/${linux.launcher.name}.in
+linux.launcher.out=${dist.dir}/${linux.launcher.name}
+
 linux.uninstall.in=${basedir}/ant/linux/linux-uninstall.sh.in
 linux.uninstall.out=${dist.dir}/uninstall
 
 linux.installdir=/opt/${project.filename}
+linux.datadir=.qz
 
 linux.packager.name=linux-packager.sh
 linux.packager.in=${basedir}/ant/linux/${linux.packager.name}.in

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -27,6 +27,7 @@ dist.jar=${dist.dir}/${project.filename}.jar
 authcert.name=override.crt
 authcert.build=${dist.dir}/${authcert.name}
 authcert.install=!install/${authcert.name}
+autostart.name=.autostart
 
 jar.compress=true
 jar.index=true

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -5,6 +5,7 @@ vendor.email=support@qz.io
 
 project.name=QZ Tray
 project.filename=qz-tray
+project.datadir=qz
 
 launch.opts=-Xms512m
 

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -7,6 +7,7 @@
 !include LogicLib.nsh
 !addincludedir "${windows.nsis.addons}/Include"
 !include StdUtils.nsh
+!include FileFunc.nsh
 
 ; Run this exe as non-admin
 RequestExecutionLevel user
@@ -24,7 +25,16 @@ ShowInstDetails nevershow
 ; Full path to jar
 !define JAR "$EXEDIR\${project.filename}.jar"
 
+; Autostart variable
+Var AUTOSTART
+
 Section ""  
+  Call DetermineAutostart
+  ${If} $AUTOSTART != "1"
+    Abort
+  ${EndIf}
+
+
   ${If} ${RunningX64}
   ${DisableX64FSRedirection}
   ${EndIf}
@@ -83,6 +93,36 @@ Function FindJRE
  JreFound:
   Pop $R1
   Exch $R0
+FunctionEnd
+
+Function DetermineAutostart
+  ClearErrors
+  ${GetParameters} $0
+  ${GetOptions} "$0" "/A" $3
+  IfErrors 0 +3
+  StrCpy $AUTOSTART "1"
+  Return
+  ClearErrors
+  ReadEnvStr $R0 "APPDATA"
+  FileOpen $1 "$R0\${vendor.name}\autostart" r
+  FileSeek $1 0
+  FileRead $1 $AUTOSTART
+  FileClose $1
+
+  IfErrors SharedAutostart 0
+
+  ${If} $AUTOSTART != "2"
+    Return
+  ${EndIf}
+
+  SharedAutostart:
+  ClearErrors
+  ReadEnvStr $R0 "PROGRAMDATA"
+  FileOpen $2 "$R0\${vendor.name}\autostart" r
+  FileSeek $2 0
+  FileRead $2 $AUTOSTART
+  FileClose $2  
+
 FunctionEnd
 
 Function .onInit

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -106,7 +106,7 @@ Function DetermineAutostart
   LocalAutostart:
   ClearErrors
   ReadEnvStr $R0 "APPDATA"
-  FileOpen $1 "$R0\${project.datadir}\autostart" r
+  FileOpen $1 "$R0\${project.datadir}\${autostart.name}" r
   FileSeek $1 0
   FileRead $1 $AUTOSTART
   FileClose $1
@@ -117,7 +117,7 @@ Function DetermineAutostart
   SharedAutostart:
   ClearErrors
   ReadEnvStr $R0 "PROGRAMDATA"
-  FileOpen $2 "$R0\${project.datadir}\autostart" r
+  FileOpen $2 "$R0\${project.datadir}\${autostart.name}" r
   FileSeek $2 0
   FileRead $2 $AUTOSTART
   FileClose $2

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -98,30 +98,32 @@ FunctionEnd
 Function DetermineAutostart
   ClearErrors
   ${GetParameters} $0
-  ${GetOptions} "$0" "/A" $3
-  IfErrors 0 +3
+  ${GetOptions} "$0" "-A" $3
+  IfErrors 0 LocalAutostart
   StrCpy $AUTOSTART "1"
   Return
+
+  LocalAutostart:
   ClearErrors
   ReadEnvStr $R0 "APPDATA"
-  FileOpen $1 "$R0\${vendor.name}\autostart" r
+  FileOpen $1 "$R0\${project.datadir}\autostart" r
   FileSeek $1 0
   FileRead $1 $AUTOSTART
   FileClose $1
 
   IfErrors SharedAutostart 0
-
-  ${If} $AUTOSTART != "2"
-    Return
-  ${EndIf}
+  Return
 
   SharedAutostart:
   ClearErrors
   ReadEnvStr $R0 "PROGRAMDATA"
-  FileOpen $2 "$R0\${vendor.name}\autostart" r
+  FileOpen $2 "$R0\${project.datadir}\autostart" r
   FileSeek $2 0
   FileRead $2 $AUTOSTART
-  FileClose $2  
+  FileClose $2
+
+  IfErrors 0 +2
+  StrCpy $AUTOSTART "1"
 
 FunctionEnd
 

--- a/ant/windows/windows-packager.nsi.in
+++ b/ant/windows/windows-packager.nsi.in
@@ -125,7 +125,7 @@ Section
   ${EndIf}
 
   CreateShortCut "$SMPROGRAMS\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "" "$INSTDIR\${windows.icon}" 0
-  CreateShortCut "$SMSTARTUP\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "/A" "$INSTDIR\${windows.icon}" 0
+  CreateShortCut "$SMSTARTUP\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "-A" "$INSTDIR\${windows.icon}" 0
 
   ; Shared directory
   ReadEnvStr $R0 "PROGRAMDATA"

--- a/ant/windows/windows-packager.nsi.in
+++ b/ant/windows/windows-packager.nsi.in
@@ -125,14 +125,13 @@ Section
   ${EndIf}
 
   CreateShortCut "$SMPROGRAMS\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "" "$INSTDIR\${windows.icon}" 0
-  CreateShortCut "$SMSTARTUP\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "" "$INSTDIR\${windows.icon}" 0
+  CreateShortCut "$SMSTARTUP\${project.name}.lnk" "$INSTDIR\${project.filename}.exe" "/A" "$INSTDIR\${windows.icon}" 0
 
-  ; Shared directory for FileIO operations
+  ; Shared directory
   ReadEnvStr $R0 "PROGRAMDATA"
   CreateDirectory "$R0\${vendor.name}"
 
   ; Grant R+W to Authenticated Users (S-1-5-11)
-  AccessControl::GrantOnFile "$SMSTARTUP\${project.name}.lnk" "(S-1-5-11)" "GenericRead + GenericWrite"
   AccessControl::GrantOnFile "$R0\${vendor.name}" "(S-1-5-11)" "GenericRead + GenericWrite"
 
   ; Delete matching firewall rules

--- a/build.xml
+++ b/build.xml
@@ -366,6 +366,10 @@
             <filterchain><expandproperties/></filterchain>
         </copy>
 
+        <copy file="${linux.launcher.in}" tofile="${linux.launcher.out}" >
+            <filterchain><expandproperties/></filterchain>
+        </copy>
+
         <copy file="${linux.keygen.in}" tofile="${linux.keygen.out}" >
             <filterchain><expandproperties/></filterchain>
         </copy>

--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
     public static final String LOG_FILE = "debug";
     public static final String PROPS_FILE = "qz-tray"; // .properties extension is assumed
     public static final String PREFS_FILE = "prefs"; // .properties extension is assumed
+    public static final String AUTOSTART_FILE = ".autostart";
     public static final String DATA_DIR = "qz";
     public static final String SHARED_DATA_DIR = "shared";
     public static final int LOG_SIZE = 524288;

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -226,6 +226,11 @@ public class TrayManager {
         startupItem.setMnemonic(KeyEvent.VK_S);
         startupItem.setState(shortcutCreator.isAutostart());
         startupItem.addActionListener(startupListener());
+        if (!shortcutCreator.hasStartupShortcut()) {
+            startupItem.setEnabled(false);
+            startupItem.setState(false);
+            startupItem.setToolTipText("Autostart has been disabled by the administrator");
+        }
 
         JMenuItem exitItem = new JMenuItem("Exit", iconCache.getIcon(IconCache.Icon.EXIT_ICON));
         exitItem.addActionListener(exitListener);

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -226,7 +226,7 @@ public class TrayManager {
         startupItem.setMnemonic(KeyEvent.VK_S);
         startupItem.setState(shortcutCreator.isAutostart());
         startupItem.addActionListener(startupListener());
-        if (!shortcutCreator.hasStartupShortcut()) {
+        if (!shortcutCreator.canAutoStart()) {
             startupItem.setEnabled(false);
             startupItem.setState(false);
             startupItem.setToolTipText("Autostart has been disabled by the administrator");

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -301,20 +301,14 @@ public class TrayManager {
     private ActionListener startupListener() {
         return e -> {
             JCheckBoxMenuItem source = (JCheckBoxMenuItem)e.getSource();
-            if (!source.getState()) {
-                if (confirmDialog.prompt("Remove " + name + " from startup?")) {
-                    if (!shortcutCreator.setAutostart(false)) {
-                        displayInfoMessage("Successfully disabled autostart");
-                    } else {
-                        displayErrorMessage("Error disabling autostart");
-                    }
-                }
+            if (!source.getState() && !confirmDialog.prompt("Remove " + name + " from startup?")) {
+                source.setState(true);
+                return;
+            }
+            if (shortcutCreator.setAutostart(source.getState())) {
+                displayInfoMessage("Successfully " + (source.getState() ? "enabled" : "disabled") + " autostart");
             } else {
-                if (shortcutCreator.setAutostart(true)) {
-                    displayInfoMessage("Successfully enabled autostart");
-                } else {
-                    displayErrorMessage("Error enabling autostart");
-                }
+                displayErrorMessage("Error " + (source.getState() ? "enabling" : "disabling") + " autostart");
             }
             source.setState(shortcutCreator.isAutostart());
         };

--- a/src/qz/deploy/DeployUtilities.java
+++ b/src/qz/deploy/DeployUtilities.java
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Properties;
 
 /**

--- a/src/qz/deploy/DeployUtilities.java
+++ b/src/qz/deploy/DeployUtilities.java
@@ -39,30 +39,8 @@ public abstract class DeployUtilities {
     private String jarPath;
     private String shortcutName;
 
-    /**
-     * Creates a startup item for the current OS. Automatically detects the OS
-     * and places the startup item in the user's startup area respectively; to
-     * be auto-launched when the user first logs in to the desktop.
-     *
-     * @return Returns <code>true</code> if the startup item was created
-     */
-    public abstract boolean createStartupShortcut();
-
-    /**
-     * Test whether or not a startup shortcut for the specified shortcutName
-     * exists on this system
-     *
-     * @return true if a startup shortcut exists on this system, false otherwise
-     */
-    public abstract boolean hasStartupShortcut();
-
-    /**
-     * Test whether or not a desktop shortcut for the specified shortcutName
-     * exists on this system
-     *
-     * @return true if a desktop shortcut exists on this system, false otherwise
-     */
-    public abstract boolean hasDesktopShortcut();
+    public abstract boolean setAutostart(boolean autostart);
+    public abstract boolean isAutostart();
 
     /**
      * Creates a startup for the current OS. Automatically detects the OS and
@@ -71,85 +49,6 @@ public abstract class DeployUtilities {
      * @return Returns <code>true</code> if the startup item was created
      */
     public abstract boolean createDesktopShortcut();
-
-    /**
-     * Removes a startup item for the current OS. Automatically detects the OS
-     * and removes the startup item from the user's startup area respectively.
-     *
-     * @return Returns <code>true</code> if the startup item was removed
-     */
-    public abstract boolean removeStartupShortcut();
-
-    /**
-     * Removes a desktop shortcut for the current OS. Automatically detects the
-     * OS and removes the shortcut from the current user's Desktop.
-     *
-     * @return Returns <code>true</code> if the Desktop shortcut item was
-     * removed
-     */
-    public abstract boolean removeDesktopShortcut();
-
-    /**
-     * Single function to be used to dynamically create various shortcut types
-     *
-     * @param toggleType ToggleType.STARTUP or ToggleType.DESKTOP
-     * @return Whether or not the shortcut creation was successful
-     */
-    public boolean createShortcut(ToggleType toggleType) {
-        switch(toggleType) {
-            case STARTUP:
-                return hasShortcut(ToggleType.STARTUP) || createStartupShortcut();
-            case DESKTOP:
-                return hasShortcut(ToggleType.DESKTOP) || createDesktopShortcut();
-            default:
-                log.warn("Sorry, creating {} shortcuts are not yet supported", toggleType);
-                return false;
-        }
-    }
-
-    /**
-     * Single function to be used to dynamically check if a shortcut already exists
-     *
-     * @param toggleType Shortcut type, i.e. <code>ToggleType.STARTUP</code> or <code>ToggleType.DESKTOP</code>
-     * @return Whether or not the shortcut already exists
-     */
-    private boolean hasShortcut(ToggleType toggleType) {
-        boolean hasShortcut = false;
-        switch(toggleType) {
-            case STARTUP:
-                hasShortcut = hasStartupShortcut();
-                break;
-            case DESKTOP:
-                hasShortcut = hasDesktopShortcut();
-                break;
-            default:
-                log.warn("Sorry, checking for {} shortcuts are not yet supported", toggleType);
-        }
-
-        if (hasShortcut) {
-            log.info("The {} shortcut for {} ({}) exists", toggleType, getShortcutName(), getJarPath());
-        }
-
-        return hasShortcut;
-    }
-
-    /**
-     * Single function to be used to dynamically remove various shortcut types
-     *
-     * @param toggleType ToggleType.STARTUP or ToggleType.DESKTOP
-     * @return Whether or not the shortcut removal was successful
-     */
-    public boolean removeShortcut(ToggleType toggleType) {
-        switch(toggleType) {
-            case STARTUP:
-                return !hasShortcut(ToggleType.STARTUP) || removeStartupShortcut();
-            case DESKTOP:
-                return !hasShortcut(ToggleType.DESKTOP) || removeDesktopShortcut();
-            default:
-                log.warn("Sorry, removing {} shortcuts are not yet supported", toggleType);
-                return false;
-        }
-    }
 
     /**
      * Parses the parent directory from an absolute file URL. This will not work
@@ -174,7 +73,6 @@ public abstract class DeployUtilities {
     public String getParentDirectory() {
         return getParentDirectory(getJarPath());
     }
-
 
     public void setShortcutName(String shortcutName) {
         if (shortcutName != null) {

--- a/src/qz/deploy/DeployUtilities.java
+++ b/src/qz/deploy/DeployUtilities.java
@@ -154,7 +154,7 @@ public abstract class DeployUtilities {
     private static boolean writeStartupFile(String mode) throws IOException {
         Path autostartFile = Paths.get(SystemUtilities.getDataDirectory() , "autostart");
         Files.write(autostartFile, mode.getBytes(), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        return mode.equals("1");
+        return readStartupFile().equals(mode);
     }
 
     private static String readStartupFile() throws IOException {

--- a/src/qz/deploy/DeployUtilities.java
+++ b/src/qz/deploy/DeployUtilities.java
@@ -16,6 +16,10 @@ import qz.common.Constants;
 import qz.utils.SystemUtilities;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -39,8 +43,23 @@ public abstract class DeployUtilities {
     private String jarPath;
     private String shortcutName;
 
-    public abstract boolean setAutostart(boolean autostart);
-    public abstract boolean isAutostart();
+    public boolean setAutostart(boolean autostart) {
+        try {
+            return writeStartupFile(autostart ? "1": "0");
+        }
+        catch(IOException e) {
+            return false;
+        }
+    }
+
+    public boolean isAutostart() {
+        try {
+            return readStartupFile().equals("1");
+        }
+        catch(IOException e) {
+            return false;
+        }
+    }
 
     /**
      * Creates a startup for the current OS. Automatically detects the OS and
@@ -131,6 +150,18 @@ public abstract class DeployUtilities {
         }
         return false;
     }
+
+    private static boolean writeStartupFile(String mode) throws IOException {
+        Path autostartFile = Paths.get(SystemUtilities.getDataDirectory() , "autostart");
+        Files.write(autostartFile, mode.getBytes(), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+        return mode.equals("1");
+    }
+
+    private static String readStartupFile() throws IOException {
+        Path autostartFile = Paths.get(SystemUtilities.getDataDirectory() ,"autostart");
+        return Files.readAllLines(autostartFile).get(0);
+    }
+
 
     /**
      * Writes the contents of <code>String[] array</code> to the specified

--- a/src/qz/deploy/LinuxDeploy.java
+++ b/src/qz/deploy/LinuxDeploy.java
@@ -33,7 +33,7 @@ class LinuxDeploy extends DeployUtilities {
     private String appLauncher = "/usr/share/applications/" + getShortcutName();
 
     @Override
-    public boolean hasStartupShortcut() {
+    public boolean canAutoStart() {
         return Files.exists(Paths.get(STARTUP, getShortcutName()));
     }
 

--- a/src/qz/deploy/LinuxDeploy.java
+++ b/src/qz/deploy/LinuxDeploy.java
@@ -11,7 +11,13 @@
 package qz.deploy;
 
 import java.awt.Toolkit;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qz.common.Constants;
@@ -24,54 +30,13 @@ class LinuxDeploy extends DeployUtilities {
 
     private static final Logger log = LoggerFactory.getLogger(LinuxDeploy.class);
 
-    private static String STARTUP = "/etc/xdg/autostart/";
     private static String DESKTOP = System.getProperty("user.home") + "/Desktop/";
-    private static String DELETED_ICON = "process-stop";
 
     private String appLauncher = "/usr/share/applications/" + getShortcutName();
-
-    //@Override
-    //public boolean createStartupShortcut() {
-    //    return copyShortcut(appLauncher, STARTUP);
-    //}
 
     @Override
     public boolean createDesktopShortcut() {
         return copyShortcut(appLauncher, DESKTOP);
-    }
-
-    //@Override
-    //public boolean removeStartupShortcut() {
-    //    return writeArrayToFile(STARTUP + getShortcutName(), new String[]{
-    //            "[Desktop Entry]",
-    //            "Type=Application",
-    //            "Name=" + Constants.ABOUT_TITLE + " (Disabled)",
-    //            "Exec=/bin/true",
-    //            "Icon=" + DELETED_ICON,
-    //            "Terminal=false",
-    //    });
-    //}
-
-
-    //@Override
-    //public boolean hasStartupShortcut() {
-    //    try {
-    //        String contents = FileUtilities.readLocalFile(STARTUP + getShortcutName());
-    //        return !contents.contains("Icon=" + DELETED_ICON);
-    //    } catch (Exception ex) {
-    //        log.warn("Unable to read startup shortcut {}", STARTUP + getShortcutName(), ex);
-    //    }
-    //    return false;
-    //}
-
-    @Override
-    public boolean setAutostart(boolean autostart) {
-        return false;
-    }
-
-    @Override
-    public boolean isAutostart() {
-        return false;
     }
 
     private static boolean copyShortcut(String source, String target) {

--- a/src/qz/deploy/LinuxDeploy.java
+++ b/src/qz/deploy/LinuxDeploy.java
@@ -30,9 +30,15 @@ class LinuxDeploy extends DeployUtilities {
 
     private static final Logger log = LoggerFactory.getLogger(LinuxDeploy.class);
 
+    private static String STARTUP = "/etc/xdg/autostart/";
     private static String DESKTOP = System.getProperty("user.home") + "/Desktop/";
 
     private String appLauncher = "/usr/share/applications/" + getShortcutName();
+
+    @Override
+    public boolean hasStartupShortcut() {
+        return Files.exists(Paths.get(STARTUP, getShortcutName()));
+    }
 
     @Override
     public boolean createDesktopShortcut() {

--- a/src/qz/deploy/LinuxDeploy.java
+++ b/src/qz/deploy/LinuxDeploy.java
@@ -11,12 +11,9 @@
 package qz.deploy;
 
 import java.awt.Toolkit;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/qz/deploy/LinuxDeploy.java
+++ b/src/qz/deploy/LinuxDeploy.java
@@ -30,55 +30,48 @@ class LinuxDeploy extends DeployUtilities {
 
     private String appLauncher = "/usr/share/applications/" + getShortcutName();
 
-    @Override
-    public boolean createStartupShortcut() {
-        return copyShortcut(appLauncher, STARTUP);
-    }
+    //@Override
+    //public boolean createStartupShortcut() {
+    //    return copyShortcut(appLauncher, STARTUP);
+    //}
 
     @Override
     public boolean createDesktopShortcut() {
         return copyShortcut(appLauncher, DESKTOP);
     }
 
-    @Override
-    public boolean removeStartupShortcut() {
-        return writeArrayToFile(STARTUP + getShortcutName(), new String[]{
-                "[Desktop Entry]",
-                "Type=Application",
-                "Name=" + Constants.ABOUT_TITLE + " (Disabled)",
-                "Exec=/bin/true",
-                "Icon=" + DELETED_ICON,
-                "Terminal=false",
-        });
-    }
-
-    @Override
-    public boolean removeDesktopShortcut() {
-        return deleteFile(DESKTOP + getShortcutName());
-    }
+    //@Override
+    //public boolean removeStartupShortcut() {
+    //    return writeArrayToFile(STARTUP + getShortcutName(), new String[]{
+    //            "[Desktop Entry]",
+    //            "Type=Application",
+    //            "Name=" + Constants.ABOUT_TITLE + " (Disabled)",
+    //            "Exec=/bin/true",
+    //            "Icon=" + DELETED_ICON,
+    //            "Terminal=false",
+    //    });
+    //}
 
 
+    //@Override
+    //public boolean hasStartupShortcut() {
+    //    try {
+    //        String contents = FileUtilities.readLocalFile(STARTUP + getShortcutName());
+    //        return !contents.contains("Icon=" + DELETED_ICON);
+    //    } catch (Exception ex) {
+    //        log.warn("Unable to read startup shortcut {}", STARTUP + getShortcutName(), ex);
+    //    }
+    //    return false;
+    //}
+
     @Override
-    public boolean hasStartupShortcut() {
-        try {
-            String contents = FileUtilities.readLocalFile(STARTUP + getShortcutName());
-            return !contents.contains("Icon=" + DELETED_ICON);
-        } catch (Exception ex) {
-            log.warn("Unable to read startup shortcut {}", STARTUP + getShortcutName(), ex);
-        }
+    public boolean setAutostart(boolean autostart) {
         return false;
     }
 
     @Override
-    public boolean hasDesktopShortcut() {
-        // Upgrade legacy "QZ Tray.desktop" shortcuts
-        String shortcut = DESKTOP + Constants.ABOUT_TITLE + ".desktop";
-        if (fileExists(shortcut)) {
-            if (ShellUtilities.execute(new String[] { "rm", shortcut })) {
-                copyShortcut(appLauncher, DESKTOP);
-            }
-        }
-        return fileExists(DESKTOP + getShortcutName());
+    public boolean isAutostart() {
+        return false;
     }
 
     private static boolean copyShortcut(String source, String target) {

--- a/src/qz/deploy/MacDeploy.java
+++ b/src/qz/deploy/MacDeploy.java
@@ -12,15 +12,17 @@ package qz.deploy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 import qz.common.Constants;
 import qz.utils.ShellUtilities;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.file.Files;
@@ -53,42 +55,57 @@ class MacDeploy extends DeployUtilities {
         return new File(getJarPath()).getName();
     }
 
+    /**
+     * Verify LaunchAgents plist file exists and parse it to verify it's enabled
+     */
     @Override
-    public boolean hasStartupShortcut() {
+    public boolean canAutoStart() {
+        // FIXME: removeLegacyStartup should only run once per machine
         removeLegacyStartup();
 
+        // plist is stored as io.qz.plist
         String parent = "/Library/LaunchAgents";
         String[] parts = Constants.ABOUT_URL.split("/");
         parts = parts[parts.length - 1].split("\\.");
-        String pListName = parts[1] + "." + parts[0] + "." + Constants.PROPS_FILE + ".plist";
+        String plist = parts[1] + "." + parts[0] + "." + Constants.PROPS_FILE + ".plist";
+        Path plistPath = Paths.get(parent, plist);
 
-        Path p = Paths.get(parent, pListName);
+        if (Files.exists(plistPath)) {
+            try {
+                DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+                Document doc = dBuilder.parse(plistPath.toFile());
+                doc.getDocumentElement().normalize();
 
-        if (!Files.exists(p)) {
-            log.warn("No plist file found");
-            return false;
-        }
-        try {
-            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-            Document doc = dBuilder.parse(p.toFile());
-            doc.getDocumentElement().normalize();
+                NodeList dictList = doc.getElementsByTagName("dict");
 
-            NodeList nList = doc.getElementsByTagName("dict");
-            nList = nList.item(0).getChildNodes();
-
-            for (int n = 0; n < nList.getLength(); n++) {
-                Node nNode = nList.item(n);
-                if (nNode.getTextContent().equals("RunAtLoad") && nNode.getNodeName().equals("key")) {
-                    //If we get an index out of bounds here, who cares, it will fall into the catch.
-                    return nList.item(n+1).getNodeName().equals("true");
+                // Loop to find "RunAtLoad" key, then the adjacent key
+                boolean foundItem = false;
+                if (dictList.getLength() > 0) {
+                    NodeList children = dictList.item(0).getChildNodes();
+                    for(int n = 0; n < children.getLength(); n++) {
+                        Node item = children.item(n);
+                        // Apple stores booleans as adjacent tags to their owner
+                        if (foundItem) {
+                            String nodeName = children.item(n).getNodeName();
+                            log.debug("Found RunAtLoad value {}", nodeName);
+                            return "true".equals(nodeName);
+                        }
+                        if (item.getNodeName().equals("key") && item.getTextContent().equals("RunAtLoad")) {
+                            log.debug("Found RunAtLoad key in {}", plistPath);
+                            foundItem = true;
+                        }
+                    }
                 }
+                log.warn("RunAtLoad was not in plist {}, autostart will not work.", plistPath);
             }
-        } catch(Exception e) {
-            log.error("Error reading plist file");
-            return false;
+            catch(SAXException | IOException | ParserConfigurationException e) {
+                log.warn("Error reading plist {}, autostart will not work.", plistPath, e);
+            }
+        } else {
+            log.warn("No plist {} found, autostart will not work", plistPath);
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/src/qz/deploy/MacDeploy.java
+++ b/src/qz/deploy/MacDeploy.java
@@ -27,24 +27,7 @@ class MacDeploy extends DeployUtilities {
 
     private static final Logger log = LoggerFactory.getLogger(MacDeploy.class);
 
-    private String autostartToggle = getAppPath() + "/.autostart";
     private String desktopShortcut = System.getProperty("user.home") + "/Desktop/" + getShortcutName();
-
-    @Override
-    public boolean setAutostart(boolean autostart) {
-        return writeAutostart(autostart ? "0" : "1");
-    }
-
-    @Override
-    public boolean isAutostart() {
-        removeLegacyStartup();
-        try {
-            return FileUtilities.readLocalFile(autostartToggle).contains("1");
-        } catch (Exception err) {
-            log.warn("Could not read .autostart file", err);
-        }
-        return false;
-    }
 
     @Override
     public String getJarPath() {
@@ -64,6 +47,13 @@ class MacDeploy extends DeployUtilities {
     }
 
     @Override
+    public boolean hasStartupShortcut() {
+        removeLegacyStartup();
+        //todo check for startup flag in LaunchAgents
+        return true;
+    }
+
+    @Override
     public boolean createDesktopShortcut() {
         return ShellUtilities.execute(new String[] {"ln", "-sf", getAppPath(), desktopShortcut});
     }
@@ -74,16 +64,6 @@ class MacDeploy extends DeployUtilities {
                         + "every login item where name is \"" + getShortcutName() + "\" or "
                         + "name is \"" + getJarName() + "\""
         );
-    }
-
-    private boolean writeAutostart(String mode) {
-        try(BufferedWriter w = new BufferedWriter(new FileWriter(autostartToggle))) {
-            w.write(mode);
-            return true;
-        } catch(Exception err) {
-            log.warn("Could not write to .autostart", err);
-        }
-        return false;
     }
 
     /**

--- a/src/qz/deploy/MacDeploy.java
+++ b/src/qz/deploy/MacDeploy.java
@@ -30,31 +30,21 @@ class MacDeploy extends DeployUtilities {
     private String autostartToggle = getAppPath() + "/.autostart";
     private String desktopShortcut = System.getProperty("user.home") + "/Desktop/" + getShortcutName();
 
-    //@Override
-    //public boolean hasStartupShortcut() {
-    //    removeLegacyStartup();
-    //    try {
-    //        return FileUtilities.readLocalFile(autostartToggle).contains("1");
-    //    } catch (Exception err) {
-    //        log.warn("Could not read .autostart file", err);
-    //    }
-    //    return false;
-    //}
-
     @Override
     public boolean setAutostart(boolean autostart) {
-        return false;
+        return writeAutostart(autostart ? "0" : "1");
     }
 
     @Override
     public boolean isAutostart() {
+        removeLegacyStartup();
+        try {
+            return FileUtilities.readLocalFile(autostartToggle).contains("1");
+        } catch (Exception err) {
+            log.warn("Could not read .autostart file", err);
+        }
         return false;
     }
-
-    //@Override
-    //public boolean createStartupShortcut() {
-    //    return writeAutostart(1);
-    //}
 
     @Override
     public String getJarPath() {
@@ -78,11 +68,6 @@ class MacDeploy extends DeployUtilities {
         return ShellUtilities.execute(new String[] {"ln", "-sf", getAppPath(), desktopShortcut});
     }
 
-    //@Override
-    //public boolean removeStartupShortcut() {
-    //    return writeAutostart(0);
-    //}
-
     private boolean removeLegacyStartup() {
         return ShellUtilities.executeAppleScript(
                 "tell application \"System Events\" to delete "
@@ -91,9 +76,9 @@ class MacDeploy extends DeployUtilities {
         );
     }
 
-    private boolean writeAutostart(int i) {
+    private boolean writeAutostart(String mode) {
         try(BufferedWriter w = new BufferedWriter(new FileWriter(autostartToggle))) {
-            w.write("" + i);
+            w.write(mode);
             return true;
         } catch(Exception err) {
             log.warn("Could not write to .autostart", err);

--- a/src/qz/deploy/MacDeploy.java
+++ b/src/qz/deploy/MacDeploy.java
@@ -30,26 +30,31 @@ class MacDeploy extends DeployUtilities {
     private String autostartToggle = getAppPath() + "/.autostart";
     private String desktopShortcut = System.getProperty("user.home") + "/Desktop/" + getShortcutName();
 
+    //@Override
+    //public boolean hasStartupShortcut() {
+    //    removeLegacyStartup();
+    //    try {
+    //        return FileUtilities.readLocalFile(autostartToggle).contains("1");
+    //    } catch (Exception err) {
+    //        log.warn("Could not read .autostart file", err);
+    //    }
+    //    return false;
+    //}
+
     @Override
-    public boolean hasStartupShortcut() {
-        removeLegacyStartup();
-        try {
-            return FileUtilities.readLocalFile(autostartToggle).contains("1");
-        } catch (Exception err) {
-            log.warn("Could not read .autostart file", err);
-        }
+    public boolean setAutostart(boolean autostart) {
         return false;
     }
 
     @Override
-    public boolean hasDesktopShortcut() {
-        return FileUtilities.isSymlink(desktopShortcut);
+    public boolean isAutostart() {
+        return false;
     }
 
-    @Override
-    public boolean createStartupShortcut() {
-        return writeAutostart(1);
-    }
+    //@Override
+    //public boolean createStartupShortcut() {
+    //    return writeAutostart(1);
+    //}
 
     @Override
     public String getJarPath() {
@@ -73,15 +78,10 @@ class MacDeploy extends DeployUtilities {
         return ShellUtilities.execute(new String[] {"ln", "-sf", getAppPath(), desktopShortcut});
     }
 
-    @Override
-    public boolean removeStartupShortcut() {
-        return writeAutostart(0);
-    }
-
-    @Override
-    public boolean removeDesktopShortcut() {
-        return ShellUtilities.execute(new String[] {"unlink", desktopShortcut});
-    }
+    //@Override
+    //public boolean removeStartupShortcut() {
+    //    return writeAutostart(0);
+    //}
 
     private boolean removeLegacyStartup() {
         return ShellUtilities.executeAppleScript(

--- a/src/qz/deploy/WindowsDeploy.java
+++ b/src/qz/deploy/WindowsDeploy.java
@@ -13,7 +13,6 @@ package qz.deploy;
 
 import mslinks.ShellLink;
 import qz.utils.ShellUtilities;
-import qz.utils.SystemUtilities;
 
 import java.io.IOException;
 import java.nio.file.*;

--- a/src/qz/deploy/WindowsDeploy.java
+++ b/src/qz/deploy/WindowsDeploy.java
@@ -33,6 +33,11 @@ public class WindowsDeploy extends DeployUtilities {
         return createShortcut(System.getenv("userprofile") + "\\Desktop\\");
     }
 
+    @Override
+    public boolean hasStartupShortcut() {
+        return Files.exists(Paths.get(getStartupDirectory(), getShortcutName() + ".lnk"));
+    }
+
     /**
      * Remove flag "Include all local (intranet) sites not listed in other zones". Requires CheckNetIsolation
      * to be effective; Has no effect on domain networks with "Automatically detect intranet network" checked.
@@ -86,5 +91,14 @@ public class WindowsDeploy extends DeployUtilities {
      */
     private String getAppPath() {
         return fixWhitespaces(getJarPath()).replaceAll(".jar$", ".exe");
+    }
+
+
+    private static String getStartupDirectory() {
+        if (System.getenv("programdata") == null) {
+            // XP
+            return System.getenv("allusersprofile") + "\\Start Menu\\Programs\\Startup\\";
+        }
+        return System.getenv("programdata") + "\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\";
     }
 }

--- a/src/qz/deploy/WindowsDeploy.java
+++ b/src/qz/deploy/WindowsDeploy.java
@@ -33,26 +33,6 @@ public class WindowsDeploy extends DeployUtilities {
         return createShortcut(System.getenv("userprofile") + "\\Desktop\\");
     }
 
-    @Override
-    public boolean setAutostart(boolean autostart) {
-        try {
-            return writeStartupFile(autostart ? "1": "0");
-        }
-        catch(IOException e) {
-            return false;
-        }
-    }
-
-    @Override
-    public boolean isAutostart() {
-        try {
-            return readStartupFile().equals("1");
-        }
-        catch(IOException e) {
-            return false;
-        }
-    }
-
     /**
      * Remove flag "Include all local (intranet) sites not listed in other zones". Requires CheckNetIsolation
      * to be effective; Has no effect on domain networks with "Automatically detect intranet network" checked.
@@ -82,17 +62,6 @@ public class WindowsDeploy extends DeployUtilities {
         // If the above value does not exist, add it using bitwise OR, thus enabling this setting
         int data = ShellUtilities.getRegistryDWORD(path, name);
         return data != -1 && ((data & value) == value || ShellUtilities.setRegistryDWORD(path, name, data | value));
-    }
-
-    private static boolean writeStartupFile(String mode) throws IOException {
-        Path autostartFile = Paths.get(SystemUtilities.getDataDirectory() , "autostart");
-        Files.write(autostartFile, mode.getBytes(), StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        return mode.equals("1");
-    }
-
-    private static String readStartupFile() throws IOException {
-        Path autostartFile = Paths.get(SystemUtilities.getDataDirectory() ,"autostart");
-        return Files.readAllLines(autostartFile).get(0);
     }
 
     /**

--- a/src/qz/deploy/WindowsDeploy.java
+++ b/src/qz/deploy/WindowsDeploy.java
@@ -33,7 +33,7 @@ public class WindowsDeploy extends DeployUtilities {
     }
 
     @Override
-    public boolean hasStartupShortcut() {
+    public boolean canAutoStart() {
         return Files.exists(Paths.get(getStartupDirectory(), getShortcutName() + ".lnk"));
     }
 

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -75,9 +75,9 @@ public class SystemUtilities {
 
     /**
      * Retrieve OS-specific Application Data directory such as:
-     * {@code C:\Users\John\AppData\Roaming\.qz} on Windows
+     * {@code C:\Users\John\AppData\Roaming\qz} on Windows
      * -- or --
-     * {@code /Users/John/Library/Application Support/.qz} on Mac
+     * {@code /Users/John/Library/Application Support/qz} on Mac
      * -- or --
      * {@code /home/John/.qz} on Linux
      *


### PR DESCRIPTION
Adds some consistency improvements to the 2.1 autostart logic.
* Uses a consistent `-A` switch against the launchers
* Better handling of non-working autostart
* Tightens security with existing 2.1 approach
* Adds a global off switch in the new shared data directory (not provided by the GUI yet)

Closes #4