### PR TITLE
Fix encoded jar paths

### DIFF
--- a/src/qz/deploy/DeployUtilities.java
+++ b/src/qz/deploy/DeployUtilities.java
@@ -16,6 +16,7 @@ import qz.common.Constants;
 import qz.utils.SystemUtilities;
 
 import java.io.*;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -324,10 +325,7 @@ public abstract class DeployUtilities {
 
         String jarPath = detectJarPath();
         String propFile = Constants.PROPS_FILE + ".properties";
-
-        // Use relative path based on qz-tray.jar, fix %20
-        // TODO:  Find a better way to fix the unicode chars?
-        return fixWhitespaces(getParentDirectory(jarPath) + File.separator + propFile);
+        return getParentDirectory(jarPath) + File.separator + propFile;
     }
 
     /**
@@ -358,8 +356,10 @@ public abstract class DeployUtilities {
      */
     public static String detectJarPath() {
         try {
-            return new File(DeployUtilities.class.getProtectionDomain()
+            String jarPath = new File(DeployUtilities.class.getProtectionDomain()
                                     .getCodeSource().getLocation().getPath()).getCanonicalPath();
+            // Fix characters that get URL encoded when calling getPath()
+            return URLDecoder.decode(jarPath, "UTF-8");
         }
         catch(IOException ex) {
             log.error("Unable to determine Jar path", ex);
@@ -413,17 +413,4 @@ public abstract class DeployUtilities {
             return this.name() == null? null:this.name().toLowerCase();
         }
     }
-
-    /**
-     * Attempts to correct URL path conversions that occur on old JREs and older
-     * Windows versions.  For now, just addresses %20 spaces, but
-     * there could be other URLs which will need special consideration.
-     *
-     * @param filePath The absolute file path to convert
-     * @return The converted path
-     */
-    public static String fixWhitespaces(String filePath) {
-        return filePath.replace("%20", " ");
-    }
-
 }

--- a/src/qz/deploy/WindowsDeploy.java
+++ b/src/qz/deploy/WindowsDeploy.java
@@ -38,11 +38,6 @@ public class WindowsDeploy extends DeployUtilities {
     }
 
     @Override
-    public String getParentDirectory() {
-        return fixWhitespaces(super.getParentDirectory());
-    }
-
-    @Override
     public boolean createDesktopShortcut() {
         return createShortcut(System.getenv("userprofile") + "\\Desktop\\");
     }
@@ -153,6 +148,6 @@ public class WindowsDeploy extends DeployUtilities {
      * Returns path to executable jar or windows executable
      */
     private String getAppPath() {
-        return fixWhitespaces(getJarPath()).replaceAll(".jar$", ".exe");
+        return getJarPath().replaceAll(".jar$", ".exe");
     }
 }


### PR DESCRIPTION
On Windows, if a path has brackets `[`, `]`, the `qz-tray.properties` path will be encoded into the JAR path as `%5d` and HTTPS will fail.

This replaces the `%20` logic which was originally created for Windows XP and expands it to handle edge-cases.  Affects white-label customers as they can choose virtually any product name for branding and installation.

Previous versions of QZ Tray re-used the URL-encoding for publishing the `.desktop` and `.url` desktop files, but this logic is long gone, so this should be relatively safe.

@tresf tested with:

- ✅ PASS: Windows: `C:\Program Files\[test]\qz-tray.jar`
- ✅ PASS: Windows: `C:\Program Files\%20\qz-tray.jar`
- ✅ PASS: Ubuntu 14.04 (default install)
- ✅ PASS: MacOS: `/Applications/[test]/qz-tray.jar`

Should be tested with Linux and MacOS desktop installers and regression test against desktop shortcuts just to be safe.