### PR TITLE
Use URL instead of constructing link element

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -501,10 +501,8 @@ var qz = (function() {
             ws: typeof WebSocket !== 'undefined' ? WebSocket : null,
 
             absolute: function(loc) {
-                if (typeof window !== 'undefined' && typeof document.createElement === 'function') {
-                    var a = document.createElement("a");
-                    a.href = loc;
-                    return a.href;
+                if (typeof window !== 'undefined' && typeof URL !== 'undefined') {
+                    return new URL(loc, window.location).href;
                 }
                 return loc;
             },


### PR DESCRIPTION
@tresf, just a suggestion, I haven't tested it for cross-browser compatibility on older browsers, but creating a temporary element is a bit icky, so this feels cleaner.