### PR TITLE
Gracefully handle certificate renewals

### DIFF
--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -264,11 +264,6 @@ public class Certificate {
         if (existsInFile(previousFingerprint, allowed)) {
             FileUtilities.printLineToFile(Constants.ALLOW_FILE, data());
         }
-        // Add this certificate to the backlist if the previous certificate was blacklisted
-        File blocked = FileUtilities.getFile(Constants.BLOCK_FILE);
-        if (existsInFile(previousFingerprint, blocked)) {
-            FileUtilities.printLineToFile(Constants.BLOCK_FILE, data());
-        }
     }
 
     /**

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -147,18 +147,16 @@ public class Certificate {
 
             //Strip beginning and end
             String[] split = in.split("--START INTERMEDIATE CERT--");
-            byte[] serverCertificate = Base64.decode(split[0].replaceAll(X509Constants.BEGIN_CERT, "").replaceAll(X509Constants.END_CERT, ""));
 
             X509Certificate theIntermediateCertificate;
             if (split.length == 2) {
-                byte[] intermediateCertificate = Base64.decode(split[1].replaceAll(X509Constants.BEGIN_CERT, "").replaceAll(X509Constants.END_CERT, ""));
-                theIntermediateCertificate = (X509Certificate)cf.generateCertificate(new ByteArrayInputStream(intermediateCertificate));
+                theIntermediateCertificate = (X509Certificate)cf.generateCertificate(new StringBufferInputStream(split[1]));
             } else {
                 theIntermediateCertificate = null; //Self-signed
             }
 
             //Generate cert
-            theCertificate = (X509Certificate)cf.generateCertificate(new ByteArrayInputStream(serverCertificate));
+            theCertificate = (X509Certificate)cf.generateCertificate(new StringBufferInputStream(split[0]));
             commonName = String.valueOf(PrincipalUtil.getSubjectX509Principal(theCertificate).getValues(X509Name.CN).get(0));
             fingerprint = makeThumbPrint(theCertificate);
             organization = String.valueOf(PrincipalUtil.getSubjectX509Principal(theCertificate).getValues(X509Name.O).get(0));

--- a/src/qz/auth/X509Constants.java
+++ b/src/qz/auth/X509Constants.java
@@ -4,8 +4,6 @@ package qz.auth;
  * Created by Tres on 3/3/2015.
  */
 public class X509Constants {
-    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
-    public static final String END_CERT = "-----END CERTIFICATE-----";
     public static final String INTERMEDIATE_CERT = "--START INTERMEDIATE CERT--";
     public static final String BEGIN_CRL = "-----BEGIN X509 CRL-----";
     public static final String END_CRL = "-----END X509 CRL-----";

--- a/src/qz/auth/X509Constants.java
+++ b/src/qz/auth/X509Constants.java
@@ -5,6 +5,8 @@ package qz.auth;
  */
 public class X509Constants {
     public static final String INTERMEDIATE_CERT = "--START INTERMEDIATE CERT--";
+    public static final String RENEWAL_INFO = "--START RENEWAL INFO--";
+    public static final String RENEWAL_SIGNATURE = "--START RENEWAL SIGNATURE--";
     public static final String BEGIN_CRL = "-----BEGIN X509 CRL-----";
     public static final String END_CRL = "-----END X509 CRL-----";
 }

--- a/src/qz/utils/ByteUtilities.java
+++ b/src/qz/utils/ByteUtilities.java
@@ -65,17 +65,21 @@ public class ByteUtilities {
         return bytesToHex(bytes, true);
     }
 
+    public static String bytesToHex(byte[] bytes, boolean upperCase) {
+        return bytesToHex(bytes, upperCase, 0,  bytes.length);
+    }
+
     /**
      * Converts an array of bytes to its hexadecimal form.
      *
      * @param bytes     Bytes to be converted.
      * @param upperCase Whether the hex string should be UPPER or lower case.
      */
-    public static String bytesToHex(byte[] bytes, boolean upperCase) {
-        char[] hexChars = new char[bytes.length * 2];
+    public static String bytesToHex(byte[] bytes, boolean upperCase, int offset, int length) {
+        char[] hexChars = new char[length * 2];
         int v;
-        for(int j = 0; j < bytes.length; j++) {
-            v = bytes[j] & 0xFF;
+        for(int j = 0; j < length; j++) {
+            v = bytes[offset + j] & 0xFF;
             hexChars[j * 2] = Constants.HEXES_ARRAY[v >>> 4];
             hexChars[j * 2 + 1] = Constants.HEXES_ARRAY[v & 0x0F];
         }


### PR DESCRIPTION
This adds support for reading the renewal information from `digital-certificate.txt` that will be generated by the website. The renewal information contains a signature that is verified using the intermediate certificate's public key. If a certificate is a renewal and the previous certificate is whitelisted, the renewal will be whitelisted automatically. Same goes for blacklists.

Unfortunately, because of the way certificates used to be parsed, the new certificates are not backwards compatible. This means that certificates containing renewal information will be recognised as untrusted by Tray versions that don't contain this PR's patch f66606b. The current implementation is not able to ignore additional data at the end of the file, so parsing the intermediate certificate will fail in this case. I'm not sure about the severity of this. Is a warning on the website's certificate generation page sufficient? Something along the lines of "Be sure to update QZ Tray to version 2.0.9 or later to use any newly generated certificates".