### PR TITLE
Gracefully handle certificate renewals

### DIFF
--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -147,18 +147,16 @@ public class Certificate {
 
             //Strip beginning and end
             String[] split = in.split("--START INTERMEDIATE CERT--");
-            byte[] serverCertificate = Base64.decode(split[0].replaceAll(X509Constants.BEGIN_CERT, "").replaceAll(X509Constants.END_CERT, ""));
 
             X509Certificate theIntermediateCertificate;
             if (split.length == 2) {
-                byte[] intermediateCertificate = Base64.decode(split[1].replaceAll(X509Constants.BEGIN_CERT, "").replaceAll(X509Constants.END_CERT, ""));
-                theIntermediateCertificate = (X509Certificate)cf.generateCertificate(new ByteArrayInputStream(intermediateCertificate));
+                theIntermediateCertificate = (X509Certificate)cf.generateCertificate(new StringBufferInputStream(split[1]));
             } else {
                 theIntermediateCertificate = null; //Self-signed
             }
 
             //Generate cert
-            theCertificate = (X509Certificate)cf.generateCertificate(new ByteArrayInputStream(serverCertificate));
+            theCertificate = (X509Certificate)cf.generateCertificate(new StringBufferInputStream(split[0]));
             commonName = String.valueOf(PrincipalUtil.getSubjectX509Principal(theCertificate).getValues(X509Name.CN).get(0));
             fingerprint = makeThumbPrint(theCertificate);
             organization = String.valueOf(PrincipalUtil.getSubjectX509Principal(theCertificate).getValues(X509Name.O).get(0));

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -7,6 +7,7 @@ import com.estontorise.simplersa.interfaces.RSATool;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.ssl.X509CertificateChainBuilder;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x509.*;
 import org.bouncycastle.jce.PrincipalUtil;
 import org.slf4j.Logger;
@@ -26,10 +27,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * Created by Steven on 1/27/2015. Package: qz.auth Project: qz-print
@@ -182,6 +180,12 @@ public class Certificate {
                 }
             }
 
+            try {
+                readRenewalInfo();
+            } catch (Exception e) {
+                log.error("Error reading certificate renewal info", e);
+            }
+
             // Only do CRL checks on QZ-issued certificates
             if (trustedRootCert != null && !overrideTrustedRootCert) {
                 CRL qzCrl = CRL.getInstance();
@@ -200,6 +204,29 @@ public class Certificate {
             CertificateParsingException certificateParsingException = new CertificateParsingException();
             certificateParsingException.initCause(e);
             throw certificateParsingException;
+        }
+    }
+
+    private void readRenewalInfo() throws Exception {
+        Vector values = PrincipalUtil.getSubjectX509Principal(theCertificate).getValues(new ASN1ObjectIdentifier("2.5.4.13"));
+        if (values.isEmpty()) {
+            return;
+        }
+        String renewalInfo = String.valueOf(values.get(0));
+
+        String renewalPrefix = "renewal-of-";
+        if (! renewalInfo.startsWith(renewalPrefix)) {
+            throw new CertificateParsingException("Illformed renewal info");
+        }
+        String previousFingerprint = renewalInfo.substring(renewalPrefix.length());
+        if (previousFingerprint.length() != 40) {
+            throw new CertificateParsingException("Illformed renewal fingerprint");
+        }
+
+        // Add this certificate to the whitelist if the previous certificate was whitelisted
+        File allowed = FileUtilities.getFile(Constants.ALLOW_FILE);
+        if (existsInFile(previousFingerprint, allowed)) {
+            FileUtilities.printLineToFile(Constants.ALLOW_FILE, data());
         }
     }
 
@@ -279,22 +306,22 @@ public class Certificate {
     /** Checks if the certificate has been added to the local trusted store */
     public boolean isSaved() {
         File allowed = FileUtilities.getFile(Constants.ALLOW_FILE);
-        return existsInFile(allowed);
+        return existsInFile(getFingerprint(), allowed);
     }
 
     /** Checks if the certificate has been added to the local blocked store */
     public boolean isBlocked() {
         File blocks = FileUtilities.getFile(Constants.BLOCK_FILE);
-        return existsInFile(blocks);
+        return existsInFile(getFingerprint(), blocks);
     }
 
-    private boolean existsInFile(File file) {
+    private static boolean existsInFile(String fingerprint, File file) {
         try(BufferedReader br = new BufferedReader(new FileReader(file))) {
             String line;
             while((line = br.readLine()) != null) {
                 if (line.contains("\t")) {
                     String print = line.substring(0, line.indexOf("\t"));
-                    if (print.equals(getFingerprint())) {
+                    if (print.equals(fingerprint)) {
                         return true;
                     }
                 }

--- a/src/qz/auth/X509Constants.java
+++ b/src/qz/auth/X509Constants.java
@@ -4,8 +4,6 @@ package qz.auth;
  * Created by Tres on 3/3/2015.
  */
 public class X509Constants {
-    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
-    public static final String END_CERT = "-----END CERTIFICATE-----";
     public static final String INTERMEDIATE_CERT = "--START INTERMEDIATE CERT--";
     public static final String BEGIN_CRL = "-----BEGIN X509 CRL-----";
     public static final String END_CRL = "-----END X509 CRL-----";

--- a/src/qz/auth/X509Constants.java
+++ b/src/qz/auth/X509Constants.java
@@ -4,6 +4,8 @@ package qz.auth;
  * Created by Tres on 3/3/2015.
  */
 public class X509Constants {
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
     public static final String INTERMEDIATE_CERT = "--START INTERMEDIATE CERT--";
     public static final String BEGIN_CRL = "-----BEGIN X509 CRL-----";
     public static final String END_CRL = "-----END X509 CRL-----";


### PR DESCRIPTION
This is like #391 but the renewal info is stored in the certificate itself as was decided in https://github.com/qzind/tray/pull/391#issuecomment-444286171. The format of `digital-certificate.txt` is not changed, so certificates will remain backwards compatible. I still included eb96fc4c98e200db60910a2e5a616ffb3f7126e2 which ensures that changes to the certificate file will be possible in the future.

Closes #43