### PR TITLE
Add Firefox policies.json support for Linux

### DIFF
--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -168,7 +168,7 @@ fi
 # Use policy file
 if [ -n "$policy" ]; then
 	"$locationdir/${jsonwriter.name}" "$policypath" "$policy"
-	chmod 644 "$policypath"
+	chmod go+r "$policypath"
 	chmod go+rx "$(dirname "$policypath")"
 	echo -e "${bash.success} Installed $policypath"
 	exit 0

--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -4,12 +4,14 @@
 ###############################################################################
 #  Description:                                                               #
 #   INSTALL:                                                                  #
-#     1. Searches for Firefox installation path                               #
-#     2. Parses defaults/pref for potential Firefox AutoConfig conflicts      #
-#     3. Imports certificate into Firefox web browser using AutoConfig file   #
+#     * Searches for Firefox installation path                                #
+#     * Automatically installs (or toggles on) the use of a custom SSL        #
+#       certificate based on Firefox version and OS using a combination of    #
+#       legacy AutoConfig or polcies.json                                     #
 #                                                                             #
 #   UNINSTALL:                                                                #
-#     1. Deletes certificate from Firefox web browser using AutoConfig file   #
+#     * If necessary, automatically deletes the custom SSL certificate using  #
+#       a combination of legacy AutoConfig or policies.json                   #
 #                                                                             #
 #  Depends:                                                                   #
 #    - lsregister (Apple-only, provided by launch services)                   #
@@ -48,7 +50,7 @@ echo "Searching for Firefox..."
 
 ffdir=""
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	# Mac OSX
+	# macOS
 	locationdir=$(cd "$(dirname "$0")"; pwd)
 	get_ffdir
 
@@ -112,10 +114,24 @@ configpath=$(echo "${firefoxconfig.install}" | sed -e "s|\!install|$installdir|g
 if [ "$1" == "uninstall" ]; then
     # Newer Firefox versions don't use AutoConfig
     if [ -n "$policy" ]; then
-        echo -e "${bash.skipped} Configured via policies.json, no uninstall needed"
-        exit 0
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # macOS
+            echo -e "${bash.skipped} Configured via policies.json, no uninstall needed"
+            exit 0
+        else
+            # Linux, etc
+            echo -e "\nSearching for $policypath..."
+            if [ -f "$policypath" ]; then
+                # Delete cert entry
+                "$locationdir/${jsonwriter.name}" "$policypath" "$policy" "true"
+                echo -e "${bash.success} Deleted cert entry"
+                exit 0
+            else
+                echo -e "${bash.skipped} $policypath not found"
+                exit 0
+            fi
+        fi
     fi
-
     echo -e "\nSearching for ${project.name} AutoConfig..."
     if [ -f "$bindir/${firefoxconfig.name}" ]; then
         echo -e "${bash.success} Check Firefox config exists"

--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -79,10 +79,10 @@ else
 	dercertpath=$(echo "${ca.crt}" | sed -e "s|\!install|$installdir|g")
 	trayapp=""  # skip
 
-	# Use policies.json deployment (Firefox 64+)
+	# Use policies.json deployment (Firefox 65+)
 	if [ -n "$ffdir" ]; then
 		version=$(HOME=/tmp XAUTHORITY=/tmp $ffdir/firefox --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
-		if [ "$version" -ge "64" ]; then
+		if [ "$version" -ge "65" ]; then
 			policy='{ "policies": { "Certificates": { "Install": ["'$dercertpath'"] } } }'
 			policypath="$ffdir/distribution/policies.json"
 		fi
@@ -169,6 +169,7 @@ fi
 if [ -n "$policy" ]; then
 	"$locationdir/${jsonwriter.name}" "$policypath" "$policy"
 	chmod 644 "$policypath"
+	chmod go+rx "$(dirname "$policypath")"
 	echo -e "${bash.success} Installed $policypath"
 	exit 0
 fi

--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -123,7 +123,7 @@ if [ "$1" == "uninstall" ]; then
             echo -e "\nSearching for $policypath..."
             if [ -f "$policypath" ]; then
                 # Delete cert entry
-                "$locationdir/${jsonwriter.name}" "$policypath" "$policy" "true"
+                "$locationdir/${jsonwriter.name}" "$policypath" "$policy" "" "true"
                 echo -e "${bash.success} Deleted cert entry"
                 exit 0
             else

--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -52,38 +52,39 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	locationdir=$(cd "$(dirname "$0")"; pwd)
 	get_ffdir
 
-	# Use policies.json deployment (Firefox 63+)
-	if [ -n "$ffdir" ]; then
-        version=$(HOME=/tmp "$ffdir/Contents/MacOS/firefox" --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
-        if [ "$version" -ge "63" ]; then
-            policy='{ "policies": { "Certificates": { "ImportEnterpriseRoots": true } } }'
-            policypath="$ffdir/Contents/Resources/distribution/policies.json"
-        fi
-    fi
-
 	bindir="$ffdir/Contents/Resources/"
 	prefdir="$ffdir/Contents/Resources/defaults/pref"
 	installdir="${apple.installdir}"
 	trayapp="$installdir"  # use .app package
+
+	# Use policies.json deployment (Firefox 63+)
+	if [ -n "$ffdir" ]; then
+        version=$(HOME=/tmp "$ffdir/Contents/MacOS/firefox" --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
+		if [ "$version" -ge "63" ]; then
+			policy='{ "policies": { "Certificates": { "ImportEnterpriseRoots": true } } }'
+			policypath="$ffdir/Contents/Resources/distribution/policies.json"
+		fi
+	fi
 else
 	# Linux, etc
 	location=$(readlink -f "$0")
 	locationdir=$(dirname "$location")
 	get_ffdir
 
-	# Use policies.json deployment (Firefox 64+)
-	if [ -n "$ffdir" ]; then
-        version=$(HOME=/tmp XAUTHORITY=/tmp $ffdir/firefox --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
-        if [ "$version" -ge "64" ]; then
-            policy='' # TODO
-            policypath="$ffdir/distribution/policies.json"
-        fi
-    fi
-
 	bindir="$ffdir"
 	prefdir="$ffdir/defaults/pref"
 	installdir="${linux.installdir}"
+	dercertpath=$(echo "${ca.crt}" | sed -e "s|\!install|$installdir|g")
 	trayapp=""  # skip
+
+	# Use policies.json deployment (Firefox 64+)
+	if [ -n "$ffdir" ]; then
+        version=$(HOME=/tmp XAUTHORITY=/tmp $ffdir/firefox --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
+		if [ "$version" -ge "64" ]; then
+			policy='{ "policies": { "Certificates": { "Install": ["'$dercertpath'"] } } }'
+			policypath="$ffdir/distribution/policies.json"
+		fi
+	fi
 fi
 
 # Firefox was not found, skip Firefox certificate installation
@@ -151,6 +152,7 @@ fi
 # Use policy file
 if [ -n "$policy" ]; then
 	"$locationdir/${jsonwriter.name}" "$policypath" "$policy"
+	chmod 644 "$policypath"
 	echo -e "${bash.success} Installed $policypath"
 	exit 0
 fi

--- a/ant/firefox/firefox-cert.sh.in
+++ b/ant/firefox/firefox-cert.sh.in
@@ -59,7 +59,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
 	# Use policies.json deployment (Firefox 63+)
 	if [ -n "$ffdir" ]; then
-        version=$(HOME=/tmp "$ffdir/Contents/MacOS/firefox" --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
+		version=$(HOME=/tmp "$ffdir/Contents/MacOS/firefox" --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
 		if [ "$version" -ge "63" ]; then
 			policy='{ "policies": { "Certificates": { "ImportEnterpriseRoots": true } } }'
 			policypath="$ffdir/Contents/Resources/distribution/policies.json"
@@ -79,7 +79,7 @@ else
 
 	# Use policies.json deployment (Firefox 64+)
 	if [ -n "$ffdir" ]; then
-        version=$(HOME=/tmp XAUTHORITY=/tmp $ffdir/firefox --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
+		version=$(HOME=/tmp XAUTHORITY=/tmp $ffdir/firefox --version|rev|cut -d' ' -f1|rev|cut -d. -f1)
 		if [ "$version" -ge "64" ]; then
 			policy='{ "policies": { "Certificates": { "Install": ["'$dercertpath'"] } } }'
 			policypath="$ffdir/distribution/policies.json"

--- a/ant/firefox/firefox-json-writer.py
+++ b/ant/firefox/firefox-json-writer.py
@@ -51,7 +51,9 @@ def merge_json(base, append):
             base[key] = val
         elif type(base_val) is list and type(val) is list:
             # merge list if not overwritten
-            base[key] = base_val + val
+            for v in val:
+                if v not in base_val:
+                    base_val.append(v)
 
 
 policy = load_json(path)

--- a/build.xml
+++ b/build.xml
@@ -503,6 +503,9 @@
         </copy>
         <chmod perm="u+x" file="${locator.out}"/>
 
+        <copy file="${jsonwriter.in}" tofile="${jsonwriter.out}" ></copy>
+        <chmod perm="u+x" file="${jsonwriter.out}"/>
+
         <exec executable="${linux.packager.out}" failonerror="true" />
 
         <!-- Cleanup lingering icon (for other OS installers) -->


### PR DESCRIPTION
Closes #403

Remaining items:
* [x] Request out to Firefox dev team; new `"Install":` key is failing;  `about:policies` [shows just fine](https://user-images.githubusercontent.com/6345473/51653989-d6f34000-1f63-11e9-8a64-6acc1b255bce.png).  *Edit:* Turns out this was Firefox 65+ only feature.  Fixed.
* [x] `firefox-json-writer.py` needs to be patched to handle duplicates.  (done via 696698a)
* [x] `firefox-json-writer.py` needs delete support (done via bf358d2, 75b41bb, af40392)