### PR TITLE
Initial JDK11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /.idea/workspace.xml
 /.idea/uiDesigner.xml
 /.idea/compiler.xml
+/fx.zip
 /README.md
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /out/
 /js/node_modules
+/lib/javafx*
 /.idea/workspace.xml
 /.idea/uiDesigner.xml
 /.idea/compiler.xml

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+  </component>
+</project>

--- a/.idea/runConfigurations/download_javafx.xml
+++ b/.idea/runConfigurations/download_javafx.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="download-javafx" type="AntRunConfiguration" activateToolWindowBeforeRun="false" singleton="false">
+    <antsettings antfile="file://$PROJECT_DIR$/build.xml" target="download-javafx" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/startup.xml
+++ b/.idea/startup.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectStartupSharedConfiguration">
+    <configurations>
+      <configuration id="Ant Target.download-javafx" name="download-javafx" />
+    </configurations>
+  </component>
+</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ matrix:
       env: TARGET=makeself
     - os: osx
       env: TARGET=pkgbuild
+    - jdk: oraclejdk11
+      env: TARGET=nsis
+    - jdk: oraclejdk11
+      env: TARGET=makeself
+    - os: osx
+      jdk: oraclejdk11
+      env: TARGET=pkgbuild
 language: java
 before_script: 
     - sw_vers -productVersion && brew update && brew install ant; ant -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
       env: TARGET=nsis
     - jdk: oraclejdk8
       env: TARGET=makeself
-    - jdk: openjdk7
-      env: TARGET=makeself
     - os: osx
       env: TARGET=pkgbuild
 language: java

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ QZ Tray
 
 Browser plugin for sending documents and raw commands to a printer or attached device
 
-## Getting Started
+# Getting Started
   * Download here https://qz.io/download/
   * See our [Getting Started](../../wiki/2.0-getting-started) guide.
   * Visit our home page https://qz.io.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ QZ Tray
 
 Browser plugin for sending documents and raw commands to a printer or attached device
 
-# Getting Started
+## Getting Started
   * Download here https://qz.io/download/
   * See our [Getting Started](../../wiki/2.0-getting-started) guide.
   * Visit our home page https://qz.io.

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -33,6 +33,8 @@ jar.index=true
 
 javac.source=1.7
 javac.target=1.7
+javafx.version=11.0.2
+javafx.mirror=http://gluonhq.com/download
 
 manifest.application.name=${project.name}
 manifest.main.class=qz.ws.PrintSocketServer

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -34,7 +34,7 @@ jar.index=true
 javac.source=1.7
 javac.target=1.7
 javafx.version=11.0.2
-javafx.mirror=http://gluonhq.com/download
+javafx.mirror=https://gluonhq.com/download
 
 manifest.application.name=${project.name}
 manifest.main.class=qz.ws.PrintSocketServer

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
 <project name="qz" default="distribute" basedir=".">
 
-    <target name="distribute" depends="init,clean,sign-jar,override-authcert,include-assets">
+    <target name="distribute" depends="init,clean,sign-jar,copy-native,override-authcert,include-assets">
         <echo message="Process complete" />
     </target>
 
@@ -154,6 +154,22 @@
         <echo>Size: ${build.size} KB</echo>
     </target>
 
+    <target name="copy-native">
+        <condition property="native.extension" value="*.dll">
+            <os family="windows"/>
+        </condition>
+        <condition property="native.extension" value="*.dylib">
+            <os family="mac"/>
+        </condition>
+        <condition property="native.extension" value="*.so">
+            <os family="unix"/>
+        </condition>
+        <!-- Copy JavaFX native libs -->
+        <copy todir="${dist.dir}/libs" flatten="true">
+            <fileset dir="lib/" includes ="javafx*/**/${native.extension}"/>
+        </copy>
+    </target>
+
     <target name="internal-authcert" unless="authcert.use">
         <echo>Using internal cert for signing auth</echo>
         <property name="build.type" value=""/>
@@ -247,11 +263,6 @@
             <filterchain><expandproperties/></filterchain>
         </copy>
         <copy file="${windows.jsonparser.in}" tofile="${windows.jsonparser.out}" ></copy>
-
-		<!-- Copy JavaFX native libs -->
-		<copy todir="${dist.dir}/libs">
-			<fileset dir="lib/javafx/bin" includes ="*.dll"/>
-		</copy>
 
         <exec executable="${nsisbin}" failonerror="true" >
             <arg value="${windows.launcher.out}"/>
@@ -389,7 +400,7 @@
         <delete file="${dist.dir}/${apple.plist.out}" />
     </target>
 
-    <target name="codesign" depends="init,prepackage" if="codesign.mac">
+    <target name="codesign" depends="init,copy-native,prepackage" if="codesign.mac">
         <property file="ant/apple/apple.properties"/>
         <exec executable="security">
             <arg value="add-certificates"/>
@@ -420,6 +431,14 @@
             <param name="signing.jarname" value="communication/libusb4java-*-osx-x86_64.jar"/>
             <param name="signing.filetype" value="*.dylib"/>
         </antcall>
+        <!-- Manually sign standalone libs -->
+        <!--use xargs to loop over and codesign all files-->
+        <echo message="Signing ${dist.dir}/libs/*.dylib using ${apple.packager.signid}"/>
+        <exec executable="bash" failonerror="true">
+            <arg value="-c"/>
+            <arg value="echo &quot;$(find ${dist.dir}/libs/*.dylib)&quot; |tr ':' '\n' |xargs codesign -s &quot;${apple.packager.signid}&quot; -v"/>
+        </exec>
+
     </target>
 
     <target name="codesign-libs">

--- a/build.xml
+++ b/build.xml
@@ -154,18 +154,8 @@
         <echo>Size: ${build.size} KB</echo>
     </target>
 
-    <!-- Download JavaFX if not already downloaded -->
+    <!-- Download JavaFX if needed -->
     <target name="check-javafx">
-        <first id="found">
-            <fileset dir="lib/" includes="**/*fx*" />
-        </first>
-        <condition property="javafx.needed" value="${toString:found}">
-            <equals arg1="${toString:found}" arg2=""/>
-        </condition>
-    </target>
-
-    <target name="download-javafx" depends="check-javafx" if="javafx.needed">
-        <property name="javafx.version" value="11.0.2" />
         <loadresource property="javafx.version-url">
             <propertyresource name="javafx.version"/>
             <filterchain>
@@ -176,6 +166,32 @@
             </filterchain>
         </loadresource>
 
+        <first id="found">
+            <dirset dir="lib/">
+                <include name="javafx*${javafx.version}"/>
+                <include name="javafx*${javafx.version-url}"/>
+            </dirset>
+        </first>
+        <condition property="javafx.needed" value="${toString:found}">
+            <equals arg1="${toString:found}" arg2=""/>
+        </condition>
+        <property name="javafx.found" value="${toString:found}"/>
+    </target>
+
+    <target name="skip-javafx" depends="check-javafx" unless="javafx.needed">
+        <echo>JavaFX ${javafx.version} found at ${javafx.found}.  Skipping.</echo>
+    </target>
+
+    <target name="download-javafx" depends="check-javafx,skip-javafx" if="javafx.needed">
+        <echo>JavaFX ${javafx.version} was not found, downloading...</echo>
+
+        <echo>Removing any old versions</echo>
+        <delete failonerror="false" includeemptydirs="true" verbose="true">
+            <fileset dir="lib/">
+                <include name="**/*javafx*sdk*/**"/>
+            </fileset>
+        </delete>
+
         <condition property="javafx.platform" value="windows">
             <os family="windows"/>
         </condition>
@@ -185,7 +201,7 @@
         <condition property="javafx.platform" value="linux">
             <os family="unix"/>
         </condition>
-        <get src="http://gluonhq.com/download/javafx-${javafx.version-url}-sdk-${javafx.platform}/" dest="fx.zip"/>
+        <get src="${javafx.mirror}/javafx-${javafx.version-url}-sdk-${javafx.platform}/" verbose="true" dest="fx.zip"/>
 
         <unzip src="fx.zip" dest="lib/" overwrite="true"/>
         <delete file="fx.zip" />

--- a/build.xml
+++ b/build.xml
@@ -156,6 +156,7 @@
 
     <!-- Download JavaFX if needed -->
     <target name="check-javafx">
+        <property file="ant/project.properties"/>
         <loadresource property="javafx.version-url">
             <propertyresource name="javafx.version"/>
             <filterchain>
@@ -179,13 +180,13 @@
     </target>
 
     <target name="skip-javafx" depends="check-javafx" unless="javafx.needed">
-        <echo>JavaFX ${javafx.version} found at ${javafx.found}.  Skipping.</echo>
+        <echo level="info">JavaFX ${javafx.version} found at ${javafx.found}.  Skipping.</echo>
     </target>
 
     <target name="download-javafx" depends="check-javafx,skip-javafx" if="javafx.needed">
-        <echo>JavaFX ${javafx.version} was not found, downloading...</echo>
+        <echo level="info">JavaFX ${javafx.version} was not found, downloading...</echo>
 
-        <echo>Removing any old versions</echo>
+        <echo level="info">Removing any old versions</echo>
         <delete failonerror="false" includeemptydirs="true" verbose="true">
             <fileset dir="lib/">
                 <include name="**/*javafx*sdk*/**"/>

--- a/build.xml
+++ b/build.xml
@@ -154,7 +154,44 @@
         <echo>Size: ${build.size} KB</echo>
     </target>
 
-    <target name="copy-native">
+    <!-- Download JavaFX if not already downloaded -->
+    <target name="check-javafx">
+        <first id="found">
+            <fileset dir="lib/" includes="**/*fx*" />
+        </first>
+        <condition property="javafx.needed" value="${toString:found}">
+            <equals arg1="${toString:found}" arg2=""/>
+        </condition>
+    </target>
+
+    <target name="download-javafx" depends="check-javafx" if="javafx.needed">
+        <property name="javafx.version" value="11.0.2" />
+        <loadresource property="javafx.version-url">
+            <propertyresource name="javafx.version"/>
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer/>
+                    <replacestring from="." to="-"/>
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
+
+        <condition property="javafx.platform" value="windows">
+            <os family="windows"/>
+        </condition>
+        <condition property="javafx.platform" value="mac">
+            <os family="mac"/>
+        </condition>
+        <condition property="javafx.platform" value="linux">
+            <os family="unix"/>
+        </condition>
+        <get src="http://gluonhq.com/download/javafx-${javafx.version-url}-sdk-${javafx.platform}/" dest="fx.zip"/>
+
+        <unzip src="fx.zip" dest="lib/" overwrite="true"/>
+        <delete file="fx.zip" />
+    </target>
+
+    <target name="copy-native" depends="download-javafx">
         <condition property="native.extension" value="*.dll">
             <os family="windows"/>
         </condition>

--- a/build.xml
+++ b/build.xml
@@ -248,6 +248,11 @@
         </copy>
         <copy file="${windows.jsonparser.in}" tofile="${windows.jsonparser.out}" ></copy>
 
+		<!-- Copy JavaFX native libs -->
+		<copy todir="${dist.dir}/libs">
+			<fileset dir="lib/javafx/bin" includes ="*.dll"/>
+		</copy>
+
         <exec executable="${nsisbin}" failonerror="true" >
             <arg value="${windows.launcher.out}"/>
         </exec>

--- a/src/com/apple/OSXAdapterWrapper.java
+++ b/src/com/apple/OSXAdapterWrapper.java
@@ -1,0 +1,77 @@
+/**
+ * @author Tres Finocchiaro
+ *
+ * Copyright (C) 2019 Tres Finocchiaro, QZ Industries, LLC
+ *
+ * LGPL 2.1 This is free software.  This software and source code are released under
+ * the "LGPL 2.1 License".  A copy of this license should be distributed with
+ * this software. http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+package com.apple;
+
+import com.github.zafarkhaja.semver.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qz.common.Constants;
+import qz.utils.MacUtilities;
+
+import java.awt.*;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * Java 9+ compatible shim around Apple's OSXAdapter
+ *
+ * @author Tres Finocchiaro
+ */
+public class OSXAdapterWrapper implements InvocationHandler {
+    private static final Logger log = LoggerFactory.getLogger(OSXAdapterWrapper.class);
+    public static final boolean legacyMode = Constants.JAVA_VERSION.lessThan(Version.valueOf("9.0.0"));
+
+    private Object target;
+    private Method handler;
+
+    public OSXAdapterWrapper(Object target, Method handler) {
+        this.target = target;
+        this.handler = handler;
+    }
+
+    public static void setQuitHandler(Object target, Method handler) {
+        if (!legacyMode) {
+            // Java 9+
+            wrap("java.awt.desktop.QuitHandler", "setQuitHandler", target, handler);
+        } else {
+            // Java 7, 8
+            OSXAdapter.setAboutHandler(target, handler);
+        }
+    }
+
+    public static void setAboutHandler(Object target, Method handler) {
+        if (!legacyMode) {
+            // Java 9+
+            wrap("java.awt.desktop.AboutHandler", "setAboutHandler", target, handler);
+        } else {
+            // Java 7, 8
+            OSXAdapter.setAboutHandler(target, handler);
+        }
+    }
+
+    public static void wrap(String className, String methodName, Object target, Method handler) {
+        try {
+            Class desktop = Desktop.getDesktop().getClass();
+            Class<?> handlerClass = Class.forName(className);
+            Method method = desktop.getDeclaredMethod(methodName, new Class<?>[] {handlerClass});
+            Object proxy = Proxy.newProxyInstance(MacUtilities.class.getClassLoader(), new Class<?>[] {handlerClass}, new OSXAdapterWrapper(target, handler));
+            method.invoke(Desktop.getDesktop(), new Object[] {proxy});
+        } catch (Exception e) {
+            log.warn("Failed to set {}", className, e.getMessage());
+        }
+    }
+
+    public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
+        handler.invoke(target);
+        return null;
+    }
+}

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -10,6 +10,7 @@
 
 package qz.printer.action;
 
+import com.github.zafarkhaja.semver.Version;
 import org.apache.commons.io.IOUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -17,9 +18,11 @@ import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qz.common.Constants;
+import qz.deploy.DeployUtilities;
 import qz.printer.PrintOptions;
 import qz.printer.PrintOutput;
 import qz.utils.PrintingUtilities;
+import qz.utils.SystemUtilities;
 
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.swing.*;
@@ -28,6 +31,7 @@ import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -46,6 +50,11 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
 
     public PrintHTML() {
         super();
+        //JavaFX native libs
+        if (SystemUtilities.isJar() && Constants.JAVA_VERSION.greaterThanOrEqualTo(Version.valueOf("11.0.0"))) {
+            System.setProperty("java.library.path", new File(DeployUtilities.detectJarPath()).getParent() + "/libs/");
+        }
+
         models = new ArrayList<>();
     }
 

--- a/src/qz/ui/BasicDialog.java
+++ b/src/qz/ui/BasicDialog.java
@@ -160,8 +160,8 @@ public class BasicDialog extends JDialog {
     public void setVisible(boolean b) {
         // fix window focus on macOS
         if (SystemUtilities.isMac() && !GraphicsEnvironment.isHeadless()) {
-            ShellUtilities.executeAppleScript("tell application \"System Events\" " +
-                                                      "set frontmost of every process whose unix id is " + MacUtilities.getProcessID() + " to true " +
+            ShellUtilities.executeAppleScript("tell application \"System Events\" \n" +
+                                                      "set frontmost of every process whose unix id is " + MacUtilities.getProcessID() + " to true \n" +
                                                       "end tell");
         }
         super.setVisible(b);

--- a/src/qz/utils/MacUtilities.java
+++ b/src/qz/utils/MacUtilities.java
@@ -10,7 +10,7 @@
 
 package qz.utils;
 
-import com.apple.OSXAdapter;
+import com.apple.OSXAdapterWrapper;
 import com.github.zafarkhaja.semver.Version;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
@@ -49,7 +49,7 @@ public class MacUtilities {
         MacUtilities.aboutDialog = aboutDialog;
 
         try {
-            OSXAdapter.setAboutHandler(MacUtilities.class, MacUtilities.class.getDeclaredMethod("showAboutDialog"));
+            OSXAdapterWrapper.setAboutHandler(MacUtilities.class, MacUtilities.class.getDeclaredMethod("showAboutDialog"));
         }
         catch(Exception e) {
             e.printStackTrace();
@@ -63,7 +63,7 @@ public class MacUtilities {
         MacUtilities.trayManager = trayManager;
 
         try {
-            OSXAdapter.setQuitHandler(MacUtilities.class, MacUtilities.class.getDeclaredMethod("showExitPrompt"));
+            OSXAdapterWrapper.setQuitHandler(MacUtilities.class, MacUtilities.class.getDeclaredMethod("showExitPrompt"));
         }
         catch(Exception e) {
             e.printStackTrace();

--- a/src/qz/utils/MacUtilities.java
+++ b/src/qz/utils/MacUtilities.java
@@ -11,8 +11,10 @@
 package qz.utils;
 
 import com.apple.OSXAdapter;
+import com.github.zafarkhaja.semver.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qz.common.Constants;
 import qz.common.TrayManager;
 import qz.ui.IconCache;
 
@@ -92,6 +94,13 @@ public class MacUtilities {
     }
 
     public static int getScaleFactor() {
+        // Java 9+ per JDK-8172962
+        if (Constants.JAVA_VERSION.greaterThanOrEqualTo(Version.valueOf("9.0.0"))) {
+            GraphicsDevice graphicsDevice = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+            GraphicsConfiguration graphicsConfig = graphicsDevice.getDefaultConfiguration();
+            return (int)graphicsConfig.getDefaultTransform().getScaleX();
+        }
+        // Java 7, 8
         try {
             // Use reflection to avoid compile errors on non-macOS environments
             Object screen = Class.forName("sun.awt.CGraphicsDevice").cast(GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice());

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -33,6 +33,7 @@ public class SystemUtilities {
 
     private static String uname;
     private static String linuxRelease;
+    private static String classProtocol;
 
 
     /**
@@ -246,5 +247,16 @@ public class SystemUtilities {
      */
     private static double getDpiScale() {
         return SystemUtilities.isMac() ? 1 : Toolkit.getDefaultToolkit().getScreenResolution() / 96.0;
+    }
+
+    /**
+     * Detects if running from IDE or jar
+     * @return true if running from a jar, false if running from IDE
+     */
+    public static boolean isJar() {
+        if (classProtocol == null) {
+            classProtocol = SystemUtilities.class.getResource("").getProtocol();
+        }
+        return "jar".equals(classProtocol);
     }
 }


### PR DESCRIPTION
### TODO
* [x] Bundle jars (done via 7085eda, 1789e29)
* [x] Bundle native libs (done via 7085eda, 1789e29)
   * [x] Sign native libs on macOS (done via 1789e29)
   * [x] Test/validate against Mojave hardening requirements #372/#388 (artifact passed Feb 1st)
* [x] Fix illegal exceptions/macOS integration (`EAWT/NoSuchMethodException`) (done via 179bd91, 3c23ec5)
* [x] Update [Compiling](https://github.com/qzind/tray/wiki/Compiling)/Dependencies in wiki (edit: javafx download was automated in 6dfc299, a443a31, no updates needed)
* [x] Add JDK11 target to Travis-CI (Done via 6dfc299)
* [x] Complete the below test matrix (3 platforms, 2 java versions, 3 use-cases).

## Test Matrix

|            | JDK8 Win | JDK11 Win | JDK8 Lin | JDK11 Lin | JDK8 Mac | JDK11 Mac |
|------------|----------|-----------|----------|-----------|----------|-----------|
| Install    | ✅         | ✅         | ✅        | ✅         | ✅        | ✅         | 
| CLI        | ✅         | ✅         | ✅        | ✅         | ✅        | ✅         | 
| IDE        | ✅         | ✅         | ✅        | ✅         | ✅        | ✅         | 

## To Test
* Checkout this branch
* Compile/run as usual.  Make sure print some HTML to invoke JavaFX engine.<br><br>
   ### Test Install
   * Windows: `ant nsis && out\qz-tray-2.0.8.exe`
   * macOS: `ant pkgbuild && sudo installer -pkg out/qz-tray-2.0.8.pkg -target /`
   * Linux: `ant makeself && sudo bash out/qz-tray-2.0.8.run -- -y` <br><br>
   ### Test CLI
   * `java -jar out/dist/qz-tray.jar`<br><br>
   ### Test IDE
   * From IntelliJ, configure the JDK and then run `src/ws/PrintSocketServer.java`<br><br>

### JavaFX Helpers
* Linux: `curl -L http://gluonhq.com/download/javafx-11-0-2-sdk-linux -o fx.zip && unzip fx.zip -d lib/; rm -rf fx.zip`
* macOS: `curl -L http://gluonhq.com/download/javafx-11-0-2-sdk-mac -o fx.zip && unzip fx.zip -d lib/; rm -rf fx.zip`

Closes #402 