### PR TITLE
fix for applescript focus

### DIFF
--- a/src/qz/ui/BasicDialog.java
+++ b/src/qz/ui/BasicDialog.java
@@ -1,6 +1,7 @@
 package qz.ui;
 
 import qz.common.Constants;
+import qz.utils.MacUtilities;
 import qz.utils.ShellUtilities;
 import qz.utils.SystemUtilities;
 
@@ -159,7 +160,9 @@ public class BasicDialog extends JDialog {
     public void setVisible(boolean b) {
         // fix window focus on macOS
         if (SystemUtilities.isMac() && !GraphicsEnvironment.isHeadless()) {
-            ShellUtilities.executeAppleScript("tell application \"" + Constants.ABOUT_TITLE + "\" to activate");
+            ShellUtilities.executeAppleScript("tell application \"System Events\" " +
+                                                      "set frontmost of every process whose unix id is " + MacUtilities.getProcessID() + " to true " +
+                                                      "end tell");
         }
         super.setVisible(b);
     }

--- a/src/qz/utils/MacUtilities.java
+++ b/src/qz/utils/MacUtilities.java
@@ -11,6 +11,8 @@
 package qz.utils;
 
 import com.apple.OSXAdapter;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qz.common.TrayManager;
@@ -104,6 +106,15 @@ public class MacUtilities {
             log.warn("Unable to determine screen scale factor.  Defaulting to 1.", e);
         }
         return 1;
+    }
+
+    public static int getProcessID() {
+        return CLibrary.INSTANCE.getpid();
+    }
+
+    private interface CLibrary extends Library {
+        CLibrary INSTANCE = (CLibrary) Native.loadLibrary("c", CLibrary.class);
+        int getpid ();
     }
 
 }


### PR DESCRIPTION
This fixes the 'bring to front' issue when opening an about window on macos. When launched from IDE or jar, tray would attempt to open a second process. The JNA code is kind of just tossed in there, any advice on where it should live/how it should be formatted is welcome.