### PR TITLE
Add stub window for trayless OS

### DIFF
--- a/src/qz/ui/tray/DialogTrayIcon.java
+++ b/src/qz/ui/tray/DialogTrayIcon.java
@@ -1,0 +1,71 @@
+package qz.ui.tray;
+
+import qz.common.Constants;
+import qz.utils.SystemUtilities;
+import qz.utils.UbuntuUtilities;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class DialogTrayIcon extends JFrame {
+    private Dimension iconSize;
+    private JLabel popupLabel;
+
+    public DialogTrayIcon(Image trayImage) {
+        super(Constants.ABOUT_TITLE);
+        iconSize = new Dimension(40, 40);
+        popupLabel = new JLabel();
+        setImage(trayImage);
+        setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                setExtendedState(JFrame.ICONIFIED);
+            }
+        });
+    }
+
+    public void setImage(Image trayImage) {
+        popupLabel.setIcon(new ImageIcon(trayImage));
+    }
+
+    public void setToolTip(String tooltip) {
+        popupLabel.setToolTipText(tooltip);
+    }
+
+    /**
+     * Return the "tray" icon size
+     */
+    @Override
+    public Dimension getSize() {
+        return iconSize;
+    }
+
+    public void setJPopupMenu(final JPopupMenu popup) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+        if (SystemUtilities.isUbuntu()) {
+            panel.setBackground(UbuntuUtilities.getTrayColor());
+        }
+        popupLabel.addMouseListener(new MouseListener() {
+            @Override
+            public void mousePressed(MouseEvent mouseEvent) {
+                popup.show(popupLabel, mouseEvent.getX(), mouseEvent.getY());
+            }
+            @Override
+            public void mouseReleased(MouseEvent mouseEvent) {}
+            @Override
+            public void mouseEntered(MouseEvent mouseEvent) {}
+            @Override
+            public void mouseExited(MouseEvent mouseEvent) {}
+            @Override
+            public void mouseClicked(MouseEvent mouseEvent) {}
+
+        });
+        panel.add(popupLabel);
+        setContentPane(panel);
+        pack();
+    }
+
+    public void displayMessage(String caption, String text, TrayIcon.MessageType level) { /* noop */ }
+}

--- a/src/qz/ui/tray/TrayType.java
+++ b/src/qz/ui/tray/TrayType.java
@@ -1,0 +1,90 @@
+package qz.ui.tray;
+
+import org.jdesktop.swinghelper.tray.JXTrayIcon;
+
+import javax.swing.*;
+import java.awt.*;
+
+class Const {  public static final Image BLANK = new ImageIcon(new byte[1]).getImage(); }
+
+public enum TrayType {
+    JX,
+    CLASSIC,
+    MODERN,
+    DIALOG;
+
+    private JXTrayIcon tray = null;
+    private DialogTrayIcon dialog = null;
+
+    public JXTrayIcon tray() { return tray; }
+    public DialogTrayIcon dialog() { return dialog; }
+
+    public TrayType init() {
+        switch (this) {
+            case JX:
+                tray = new JXTrayIcon(Const.BLANK);
+            case CLASSIC:
+                tray = new ClassicTrayIcon(Const.BLANK);
+            case MODERN:
+                tray = new ModernTrayIcon(Const.BLANK);
+            default:
+                dialog = new DialogTrayIcon(Const.BLANK);
+        }
+        return this;
+    }
+
+    public boolean isTray() { return tray != null; }
+
+    public boolean isDialog() { return dialog != null; }
+
+    public void setImage(Image image) {
+        if (isTray()) {
+            tray.setImage(image);
+        } else {
+            dialog.setImage(image);
+        }
+    }
+
+    public Dimension getSize() {
+        return isTray() ? tray.getSize() : dialog.getSize();
+    }
+
+    public void setToolTip(String tooltip) {
+        if (isTray()) {
+            tray.setToolTip(tooltip);
+        } else {
+            dialog.setToolTip(tooltip);
+        }
+    }
+
+    public void setJPopupMenu(JPopupMenu popup) {
+        if (isTray()) {
+            tray.setJPopupMenu(popup);
+        } else {
+            dialog.setJPopupMenu(popup);
+        }
+    }
+
+    public void displayMessage(String caption, String text, TrayIcon.MessageType level) {
+        if (isTray()) {
+            tray.displayMessage(caption, text, level);
+        } else {
+            dialog.displayMessage(caption, text, level);
+        }
+    }
+
+    public void createDialog() {
+        if (isDialog()) {
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    dialog.setResizable(false);
+                    dialog.setLocationRelativeTo(null);
+                    dialog.setState(Frame.ICONIFIED);
+                    dialog.setVisible(true);
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a small window for accessing the UI on OSs that no longer provide a system tray.

![image](https://user-images.githubusercontent.com/6345473/52243714-81def480-28a8-11e9-8db2-e42ba0b2978d.png)

Todo:
- Make it draggable
- Set taskbar icon
- Optionally auto-show the menu on activate

Closes #60.