### PR TITLE
Initial javafx dist refactor

### DIFF
--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -1,9 +1,9 @@
 <project name="javafx" default="download-javafx" basedir="..">
-    <target name="download-javafx" depends="get-current-platform,download-javafx-windows,download-javafx-mac,download-javafx-linux,copy-native-current,copy-native-target">
-        <property name="javafx.debug" value="true"/>
+    <target name="download-javafx" depends="get-current-platform,download-javafx-windows,download-javafx-mac,download-javafx-linux,copy-native-current,copy-native-target,show-javafx-debug">
     </target>
-
-    <target name="show-debug" if="javafx.debug">
+    <!-- Show detailed javafx download details, comment out to disable -->
+    <property name="show.javafx.debug" value="true"/>
+    <target name="show-javafx-debug" if="show.javafx.debug">
         <echo>Windows:</echo>
         <echo> current.platform.windows=${current.platform.windows}</echo>
         <echo> target.platform.windows=${target.platform.windows}</echo>
@@ -32,7 +32,12 @@
                 <os family="mac"/>
         </condition>
         <condition property="current.platform.linux" value="true">
-                <os family="unix"/>
+                <and>
+                    <os family="unix"/>
+                    <not>
+                        <os family="mac"/>
+                    </not>
+                </and>
         </condition>
     </target>
 

--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -1,0 +1,213 @@
+<project name="javafx" default="download-javafx" basedir="..">
+    <target name="download-javafx" depends="get-current-platform,download-javafx-windows,download-javafx-mac,download-javafx-linux,copy-native-current,copy-native-target">
+        <property name="javafx.debug" value="true"/>
+    </target>
+
+    <target name="show-debug" if="javafx.debug">
+        <echo>Windows:</echo>
+        <echo> current.platform.windows=${current.platform.windows}</echo>
+        <echo> target.platform.windows=${target.platform.windows}</echo>
+        <echo> javafx.windows.needed=${javafx.windows.needed}</echo>
+        <echo> javafx.windows.found=${javafx.windows.found}</echo>
+        <echo/>
+        <echo>Mac:</echo>
+        <echo> current.platform.mac=${current.platform.mac}</echo>
+        <echo> target.platform.mac=${target.platform.mac}</echo>
+        <echo> javafx.mac.needed=${javafx.mac.needed}</echo>
+        <echo> javafx.mac.found=${javafx.mac.found}</echo>
+        <echo/>
+        <echo>Linux:</echo>
+        <echo> current.platform.linux=${current.platform.linux}</echo>
+        <echo> target.platform.linux=${target.platform.linux}</echo>
+        <echo> javafx.linux.needed=${javafx.linux.needed}</echo>
+        <echo> javafx.linux.found=${javafx.linux.found}</echo>
+        <echo/>
+    </target>
+
+    <target name="get-current-platform">
+        <condition property="current.platform.windows" value="true">
+                <os family="windows"/>
+        </condition>
+        <condition property="current.platform.mac" value="true">
+                <os family="mac"/>
+        </condition>
+        <condition property="current.platform.linux" value="true">
+                <os family="unix"/>
+        </condition>
+    </target>
+
+    <!-- Gets the javafx version and version url -->
+    <target name="get-javafx-version">
+        <!-- required properties -->
+        <!--
+        <property file="ant/project.properties"/>
+        <property name="javafx.version" value="11.0.2"/>
+        <property name="javafx.mirror" value="https://gluonhq.com/download"/>
+        <property name="lib.dir" value="lib"/>
+        <property name="dist.dir" value="out/dist"/>
+        -->
+        <!-- end required properties -->
+
+        <loadresource property="javafx.version-url">
+            <propertyresource name="javafx.version"/>
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer/>
+                    <replacestring from="." to="-"/>
+                </tokenfilter>
+            </filterchain>
+        </loadresource>
+    </target>
+
+    <!-- Flags if javafx is needed for a particular platform-->
+    <target name="check-javafx-needed" depends="get-javafx-version">
+        <condition property="javafx.windows.needed" value="true">
+            <or>
+                <isset property="current.platform.windows"/>
+                <isset property="target.platform.windows"/>
+            </or>
+        </condition>
+        <condition property="javafx.mac.needed" value="true">
+            <or>
+                <isset property="current.platform.mac"/>
+                <isset property="target.platform.mac"/>
+            </or>
+        </condition>
+        <condition property="javafx.linux.needed" value="true">
+            <or>
+                <isset property="current.platform.linux"/>
+                <isset property="target.platform.linux"/>
+            </or>
+        </condition>
+    </target>
+
+    <!-- Downloads and extracts javafx for Windows -->
+    <target name="download-javafx-windows" if="javafx.windows.needed" unless="javafx.windows.found" depends="check-javafx-needed,check-javafx-found">
+        <antcall target="download-javafx-platform">
+            <param name="javafx.platform" value="windows"/>
+        </antcall>
+    </target>
+
+    <!-- Downloads and extracts javafx for macOS -->
+    <target name="download-javafx-mac" if="javafx.mac.needed" unless="javafx.mac.found" depends="check-javafx-needed,check-javafx-found">
+        <antcall target="download-javafx-platform">
+            <param name="javafx.platform" value="mac"/>
+        </antcall>
+    </target>
+
+    <!-- Downloads and extracts javafx for linux -->
+    <target name="download-javafx-linux" if="javafx.linux.needed" unless="javafx.linux.found" depends="check-javafx-needed,check-javafx-found">
+        <antcall target="download-javafx-platform">
+            <param name="javafx.platform" value="linux"/>
+        </antcall>
+    </target>
+
+    <!-- Downloads and extracts javafx for the specified platform -->
+    <target name="download-javafx-platform">
+        <get src="${javafx.mirror}/javafx-${javafx.version-url}-sdk-${javafx.platform}/" verbose="true" dest="javafx-${javafx.platform}.zip"/>
+        <unzip src="javafx-${javafx.platform}.zip" dest="${lib.dir}" overwrite="true"/>
+        <delete file="javafx-${javafx.platform}.zip"/>
+    </target>
+
+    <!-- Removes old javafx versions -->
+    <target name="cleanup-old-javafx" depends="get-javafx-version">
+        <delete>
+            <fileset dir="${lib.dir}">
+                <include name="**/javafx*/**"/>
+                <exclude name="**/javafx*${javafx.version}*/**"/>
+            </fileset>
+        </delete>
+    </target>
+
+    <!-- Copies native libraries for current platform -->
+    <target name="copy-native-current" depends="check-javafx-needed">
+        <condition property="javafx.current.extension" value="dll">
+            <isset property="current.platform.windows"/>
+        </condition>
+        <condition property="javafx.current.extension" value="dylib">
+            <isset property="current.platform.mac"/>
+        </condition>
+        <condition property="javafx.current.extension" value="so">
+            <isset property="current.platform.linux"/>
+        </condition>
+        <echo>javafx.current.extension=${javafx.current.extension}</echo>
+
+        <antcall target="copy-native-platform">
+            <param name="dest.dir" value="${dist.dir}"/>
+            <param name="prefix.pattern" value="javafx*/"/>
+            <param name="native.extension" value="${javafx.current.extension}"/>
+        </antcall>
+    </target>
+
+    <!-- Copies native libraries for target platform -->
+    <target name="copy-native-target">
+        <condition property="javafx.target.extension" value="dll">
+            <isset property="target.platform.windows"/>
+        </condition>
+        <condition property="javafx.target.extension" value="dylib">
+            <isset property="target.platform.mac"/>
+        </condition>
+        <condition property="javafx.target.extension" value="so">
+            <isset property="target.platform.linux"/>
+        </condition>
+        <echo>javafx.target.extension=${javafx.target.extension}</echo>
+
+        <antcall target="copy-native-platform">
+            <param name="dest.dir" value="${dist.dir}"/>
+            <param name="prefix.pattern" value="javafx*/"/>
+            <param name="native.extension" value="${javafx.target.extension}"/>
+        </antcall>
+    </target>
+
+    <!-- Cleanup dist directory for packaging -->
+    <target name="cleanup-javafx-dist" if="javafx.target.extension" >
+        <delete>
+            <fileset dir="${dist.dir}/libs">
+                <include name="**"/>
+                <exclude name="**/*.${javafx.target.extension}"/>
+            </fileset>
+        </delete>
+    </target>
+
+    <!-- Copies native libraries for specified platform -->
+    <target name="copy-native-platform">
+        <copy todir="${dest.dir}/libs" flatten="true">
+            <fileset dir="${lib.dir}">
+                <include name="${prefix.pattern}**/*.${native.extension}"/>
+            </fileset>
+        </copy>
+    </target>
+
+    <!-- Flags if javafx is already downloaded for a particular platform -->
+    <target name="check-javafx-found" depends="cleanup-old-javafx">
+        <first id="windows-found">
+            <fileset dir="${lib.dir}">
+                <include name="**/glass.dll"/>
+            </fileset>
+        </first>
+        <condition property="javafx.windows.found" value="${toString:windows-found}">
+            <not><equals arg1="${toString:windows-found}" arg2=""/></not>
+        </condition>
+        <property name="javafx.windows.files" value="${toString:windows-found}"/>
+
+        <first id="mac-found">
+            <fileset dir="${lib.dir}">
+                <include name="**/libglass.dylib"/>
+            </fileset>
+        </first>
+        <condition property="javafx.mac.found" value="${toString:mac-found}">
+            <not><equals arg1="${toString:mac-found}" arg2=""/></not>
+        </condition>
+        <property name="javafx.mac.files" value="${toString:mac-found}"/>
+
+        <first id="linux-found">
+            <fileset dir="${lib.dir}">
+                <include name="**/libglass.so"/>
+            </fileset>
+        </first>
+        <condition property="javafx.linux.found" value="${toString:linux-found}">
+            <not><equals arg1="${toString:linux-found}" arg2=""/></not>
+        </condition>
+        <property name="javafx.linux.files" value="${toString:linux-found}"/>
+    </target>
+</project>

--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -1,26 +1,28 @@
 <project name="javafx" default="download-javafx" basedir="..">
     <target name="download-javafx" depends="get-current-platform,download-javafx-windows,download-javafx-mac,download-javafx-linux,copy-native-current,copy-native-target,show-javafx-debug">
     </target>
-    <!-- Show detailed javafx download details, comment out to disable -->
+
+    <!-- Show detailed javafx download details, comment-out to disable -->
     <property name="show.javafx.debug" value="true"/>
+
     <target name="show-javafx-debug" if="show.javafx.debug">
         <echo>Windows:</echo>
         <echo> current.platform.windows=${current.platform.windows}</echo>
         <echo> target.platform.windows=${target.platform.windows}</echo>
         <echo> javafx.windows.needed=${javafx.windows.needed}</echo>
-        <echo> javafx.windows.found=${javafx.windows.found}</echo>
+        <echo> javafx.windows.found=${javafx.windows.found} (before download)</echo>
         <echo/>
         <echo>Mac:</echo>
         <echo> current.platform.mac=${current.platform.mac}</echo>
         <echo> target.platform.mac=${target.platform.mac}</echo>
         <echo> javafx.mac.needed=${javafx.mac.needed}</echo>
-        <echo> javafx.mac.found=${javafx.mac.found}</echo>
+        <echo> javafx.mac.found=${javafx.mac.found} (before download)</echo>
         <echo/>
         <echo>Linux:</echo>
         <echo> current.platform.linux=${current.platform.linux}</echo>
         <echo> target.platform.linux=${target.platform.linux}</echo>
         <echo> javafx.linux.needed=${javafx.linux.needed}</echo>
-        <echo> javafx.linux.found=${javafx.linux.found}</echo>
+        <echo> javafx.linux.found=${javafx.linux.found} (before download)</echo>
         <echo/>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="qz" default="distribute" basedir=".">
+    <property file="ant/project.properties"/>
+    <import file="ant/javafx.xml"/>
 
-    <target name="distribute" depends="init,clean,sign-jar,copy-native,override-authcert,include-assets">
+    <target name="distribute" depends="init,clean,sign-jar,download-javafx,override-authcert,include-assets">
         <echo message="Process complete" />
     </target>
 
     <target name="init">
         <property environment="env"/>
-        <property file="ant/project.properties"/>
 
         <!-- Your custom code signing properties here. Feel free to change. -->
         <!-- The project will default to qz.ks if it doesn't exist -->
@@ -20,19 +21,19 @@
 
         <condition property="codesign.windows" value="true">
             <and>
-                <os family="windows"/>
+                <isset property="target.platform.windows"/>
                 <isset property="signing.tsaurl"/>
             </and>
         </condition>
         <condition property="codesign.linux" value="true">
             <and>
-                <os family="unix"/>
+                <isset property="target.platform.linux"/>
                 <isset property="signing.tsaurl"/>
             </and>
         </condition>
         <condition property="codesign.mac" value="true">
             <and>
-                <os family="mac"/>
+                <isset property="target.platform.mac"/>
                 <isset property="signing.tsaurl"/>
             </and>
         </condition>
@@ -154,76 +155,6 @@
         <echo>Size: ${build.size} KB</echo>
     </target>
 
-    <!-- Download JavaFX if needed -->
-    <target name="check-javafx">
-        <property file="ant/project.properties"/>
-        <loadresource property="javafx.version-url">
-            <propertyresource name="javafx.version"/>
-            <filterchain>
-                <tokenfilter>
-                    <filetokenizer/>
-                    <replacestring from="." to="-"/>
-                </tokenfilter>
-            </filterchain>
-        </loadresource>
-
-        <first id="found">
-            <dirset dir="lib/">
-                <include name="javafx*${javafx.version}"/>
-                <include name="javafx*${javafx.version-url}"/>
-            </dirset>
-        </first>
-        <condition property="javafx.needed" value="${toString:found}">
-            <equals arg1="${toString:found}" arg2=""/>
-        </condition>
-        <property name="javafx.found" value="${toString:found}"/>
-    </target>
-
-    <target name="skip-javafx" depends="check-javafx" unless="javafx.needed">
-        <echo level="info">JavaFX ${javafx.version} found at ${javafx.found}.  Skipping.</echo>
-    </target>
-
-    <target name="download-javafx" depends="check-javafx,skip-javafx" if="javafx.needed">
-        <echo level="info">JavaFX ${javafx.version} was not found, downloading...</echo>
-
-        <echo level="info">Removing any old versions</echo>
-        <delete failonerror="false" includeemptydirs="true" verbose="true">
-            <fileset dir="lib/">
-                <include name="**/*javafx*sdk*/**"/>
-            </fileset>
-        </delete>
-
-        <condition property="javafx.platform" value="windows">
-            <os family="windows"/>
-        </condition>
-        <condition property="javafx.platform" value="mac">
-            <os family="mac"/>
-        </condition>
-        <condition property="javafx.platform" value="linux">
-            <os family="unix"/>
-        </condition>
-        <get src="${javafx.mirror}/javafx-${javafx.version-url}-sdk-${javafx.platform}/" verbose="true" dest="fx.zip"/>
-
-        <unzip src="fx.zip" dest="lib/" overwrite="true"/>
-        <delete file="fx.zip" />
-    </target>
-
-    <target name="copy-native" depends="download-javafx">
-        <condition property="native.extension" value="*.dll">
-            <os family="windows"/>
-        </condition>
-        <condition property="native.extension" value="*.dylib">
-            <os family="mac"/>
-        </condition>
-        <condition property="native.extension" value="*.so">
-            <os family="unix"/>
-        </condition>
-        <!-- Copy JavaFX native libs -->
-        <copy todir="${dist.dir}/libs" flatten="true">
-            <fileset dir="lib/" includes ="javafx*/**/${native.extension}"/>
-        </copy>
-    </target>
-
     <target name="internal-authcert" unless="authcert.use">
         <echo>Using internal cert for signing auth</echo>
         <property name="build.type" value=""/>
@@ -276,7 +207,7 @@
     #               Prepackage Steps - All Platforms               #
     ################################################################
     -->
-    <target name="prepackage">
+    <target name="prepackage" depends="cleanup-javafx-dist">
         <echo>Processing self-signing variables</echo>
         <property file="ant/ssl.properties"/>
 
@@ -295,9 +226,13 @@
     #                    Windows Installer                         #
     ################################################################
     -->
-    <target name="nsis" depends="build-exe,sign-exe-self,sign-exe-tsa"/>
+    <!-- Inform javafx.xml  -->
+    <target name="nsis-preflight">
+        <property name="target.platform.windows" value="true"/>
+    </target>
+    <target name="nsis" depends="nsis-preflight,build-exe,sign-exe-self,sign-exe-tsa"/>
 
-    <target name="build-exe" depends="distribute,prepackage,nsisbin-1,nsisbin-2,nsisbin-3">
+    <target name="build-exe" depends="distribute,prepackage,cleanup-javafx-dist,nsisbin-1,nsisbin-2,nsisbin-3">
         <echo>Creating installer using ${nsisbin}</echo>
 
         <property file="ant/windows/windows.properties"/>
@@ -316,7 +251,7 @@
         <copy file="${windows.keygen.in}" tofile="${windows.keygen.out}" >
             <filterchain><expandproperties/></filterchain>
         </copy>
-        <copy file="${windows.jsonparser.in}" tofile="${windows.jsonparser.out}" ></copy>
+        <copy file="${windows.jsonparser.in}" tofile="${windows.jsonparser.out}" />
 
         <exec executable="${nsisbin}" failonerror="true" >
             <arg value="${windows.launcher.out}"/>
@@ -380,7 +315,11 @@
     #                     Apple Installer                          #
     ################################################################
     -->
-    <target name="pkgbuild" depends="distribute,prepackage">
+    <!-- Inform javafx.xml  -->
+    <target name="pkgbuild-preflight">
+        <property name="target.platform.mac" value="true"/>
+    </target>
+    <target name="pkgbuild" depends="pkgbuild-preflight,distribute,prepackage">
         <echo>Creating installer using pkgbuild</echo>
 
         <property file="ant/apple/apple.properties"/>
@@ -443,7 +382,7 @@
         </copy>
         <chmod perm="u+x" file="${locator.out}"/>
 
-        <copy file="${jsonwriter.in}" tofile="${jsonwriter.out}" ></copy>
+        <copy file="${jsonwriter.in}" tofile="${jsonwriter.out}" />
         <chmod perm="u+x" file="${jsonwriter.out}"/>
 
         <exec executable="${apple.packager.out}" failonerror="true" />
@@ -454,7 +393,7 @@
         <delete file="${dist.dir}/${apple.plist.out}" />
     </target>
 
-    <target name="codesign" depends="init,copy-native,prepackage" if="codesign.mac">
+    <target name="codesign" depends="init,download-javafx,prepackage" if="codesign.mac">
         <property file="ant/apple/apple.properties"/>
         <exec executable="security">
             <arg value="add-certificates"/>
@@ -538,7 +477,11 @@
     #                     Linux Installer                          #
     ################################################################
     -->
-    <target name="makeself" depends="distribute,prepackage">
+    <!-- Inform javafx.xml  -->
+    <target name="makeself-preflight">
+        <property name="target.platform.linux" value="true"/>
+    </target>
+    <target name="makeself" depends="makeself-preflight,distribute,prepackage">
         <echo>Creating installer using makeself</echo>
 
         <property file="ant/linux/linux.properties"/>
@@ -581,7 +524,7 @@
         </copy>
         <chmod perm="u+x" file="${locator.out}"/>
 
-        <copy file="${jsonwriter.in}" tofile="${jsonwriter.out}" ></copy>
+        <copy file="${jsonwriter.in}" tofile="${jsonwriter.out}" />
         <chmod perm="u+x" file="${jsonwriter.out}"/>
 
         <exec executable="${linux.packager.out}" failonerror="true" />


### PR DESCRIPTION
Better handling of `current` platform and `target` platform so that (for example) Windows `.dll` files can be downloaded and packaged on a foreign OS (macOS, Linux), which is required for Travis-CI and the White-Label portal.

Closes #402