### PR TITLE
Add rendering hints for PDF

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -285,6 +285,11 @@
                                         </div>
 
                                         <div class="form-group form-inline">
+                                            <label for="pxlDither">Dithering</label>
+                                            <input type="checkbox" id="pxlDither" class="pull-right" />
+                                        </div>
+
+                                        <div class="form-group form-inline">
                                             <label for="pxlDuplex"> Duplex</label>
                                             <input type="checkbox" id="pxlDuplex" class="pull-right" />
                                         </div>
@@ -1539,6 +1544,7 @@
         $("#pxlColorType").val("color");
         $("#pxlCopies").val(1);
         $("#pxlDensity").val('');
+        $("#pxlDither").prop('checked', false);
         $("#pxlDuplex").prop('checked', false);
         $("#pxlInterpolation").val("");
         $("#pxlJobName").val("");
@@ -1951,6 +1957,7 @@
                             colorType: $("#pxlColorType").val(),
                             copies: copies,
                             density: $("#pxlDensity").val(),
+                            dithering: $("#pxlDither").prop('checked'),
                             duplex: $("#pxlDuplex").prop('checked'),
                             interpolation: $("#pxlInterpolation").val(),
                             jobName: jobName,

--- a/src/qz/printer/PDFWrapper.java
+++ b/src/qz/printer/PDFWrapper.java
@@ -24,7 +24,7 @@ public class PDFWrapper implements Printable {
 
     private PDFPrintable printable;
 
-    public PDFWrapper(PDDocument document, Scaling scaling, boolean showPageBorder, float dpi, boolean center, PrintOptions.Orientation orientation) {
+    public PDFWrapper(PDDocument document, Scaling scaling, boolean showPageBorder, float dpi, boolean center, PrintOptions.Orientation orientation, RenderingHints hints) {
         this.document = document;
         this.scaling = scaling;
         if (orientation != null) {
@@ -32,6 +32,7 @@ public class PDFWrapper implements Printable {
         }
 
         printable = new PDFPrintable(document, scaling, showPageBorder, dpi, center);
+        printable.setRenderingHints(hints);
     }
 
 

--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -110,6 +110,16 @@ public class PrintOptions {
                 catch(JSONException e) { warn("double", "density", configOpts.opt("density")); }
             }
         }
+        if (!configOpts.isNull("dithering")) {
+            try {
+                if (configOpts.getBoolean("dithering")) {
+                    psOptions.dithering = RenderingHints.VALUE_DITHER_ENABLE;
+                } else {
+                    psOptions.dithering = RenderingHints.VALUE_DITHER_DISABLE;
+                }
+            }
+            catch(JSONException e) { warn("boolean", "dithering", configOpts.opt("dithering")); }
+        }
         if (!configOpts.isNull("duplex")) {
             try { psOptions.duplex = configOpts.getBoolean("duplex"); }
             catch(JSONException e) { warn("boolean", "duplex", configOpts.opt("duplex")); }
@@ -318,6 +328,7 @@ public class PrintOptions {
         private ColorType colorType = ColorType.COLOR;                              //Color / black&white
         private int copies = 1;                                                     //Job copies
         private double density = 0;                                                 //Pixel density (DPI or DPMM)
+        private Object dithering = RenderingHints.VALUE_DITHER_DEFAULT;             //Image dithering
         private boolean duplex = false;                                             //Double/single sided
         private Object interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;  //Image interpolation
         private String jobName = null;                                              //Job name
@@ -343,6 +354,10 @@ public class PrintOptions {
 
         public double getDensity() {
             return density;
+        }
+
+        public Object getDithering() {
+            return dithering;
         }
 
         public boolean isDuplex() {

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -206,7 +206,8 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
             }
             log.trace("Requested page {} for printing", pageIndex);
 
-            Graphics2D graphics2D = super.withRenderHints((Graphics2D)graphics, dithering, interpolation);
+            Graphics2D graphics2D = (Graphics2D)graphics;
+            graphics2D.setRenderingHints(buildRenderingHints(dithering, interpolation));
             graphics2D.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
             graphics2D.scale(pageFormat.getImageableWidth() / pageFormat.getWidth(), pageFormat.getImageableHeight() / pageFormat.getHeight());
             legacyLabel.paint(graphics2D);

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -206,7 +206,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor, Printable {
             }
             log.trace("Requested page {} for printing", pageIndex);
 
-            Graphics2D graphics2D = super.withRenderHints((Graphics2D)graphics, interpolation);
+            Graphics2D graphics2D = super.withRenderHints((Graphics2D)graphics, dithering, interpolation);
             graphics2D.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
             graphics2D.scale(pageFormat.getImageableWidth() / pageFormat.getWidth(), pageFormat.getImageableHeight() / pageFormat.getHeight());
             legacyLabel.paint(graphics2D);

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -172,7 +172,8 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
             log.debug("Scaling image up by x{}", upScale);
 
             BufferedImage scaled = new BufferedImage((int)(imgToPrint.getWidth() * upScale), (int)(imgToPrint.getHeight() * upScale), BufferedImage.TYPE_INT_ARGB);
-            Graphics2D g2d = withRenderHints(scaled.createGraphics(), dithering, interpolation);
+            Graphics2D g2d = scaled.createGraphics();
+            g2d.setRenderingHints(buildRenderingHints(dithering, interpolation));
             g2d.drawImage(imgToPrint, 0, 0, (int)(imgToPrint.getWidth() * upScale), (int)(imgToPrint.getHeight() * upScale), null);
             g2d.dispose();
 
@@ -195,7 +196,8 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         log.trace("Image size: {},{}", imgW, imgH);
 
         // Now we perform our rendering
-        Graphics2D graphics2D = withRenderHints((Graphics2D)graphics, dithering, interpolation);
+        Graphics2D graphics2D = (Graphics2D)graphics;
+        graphics2D.setRenderingHints(buildRenderingHints(dithering, interpolation));
         log.trace("{}", graphics2D.getRenderingHints());
 
         log.debug("Memory: {}m/{}m", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576, Runtime.getRuntime().maxMemory() / 1048576);
@@ -229,7 +231,8 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()[0].getDefaultConfiguration();
         BufferedImage result = gc.createCompatibleImage(eWidth, eHeight, Transparency.TRANSLUCENT);
 
-        Graphics2D g2d = withRenderHints(result.createGraphics(), dithering, interpolation);
+        Graphics2D g2d = result.createGraphics();
+        g2d.setRenderingHints(buildRenderingHints(dithering, interpolation));
         g2d.translate((eWidth - sWidth) / 2, (eHeight - sHeight) / 2);
         g2d.rotate(rads, sWidth / 2, sHeight / 2);
 
@@ -243,18 +246,6 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         g2d.dispose();
 
         return result;
-    }
-
-    protected Graphics2D withRenderHints(Graphics2D g2d, Object dithering, Object interpolation) {
-        g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_DITHERING, dithering);
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
-        g2d.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        g2d.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-
-        return g2d;
     }
 
     @Override

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -53,6 +53,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
 
     protected double dpiScale = 1;
     protected boolean scaleImage = false;
+    protected Object dithering = RenderingHints.VALUE_DITHER_DEFAULT;
     protected Object interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;
     protected double imageRotation = 0;
     protected boolean manualReverse = false;
@@ -115,6 +116,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         PrintRequestAttributeSet attributes = applyDefaultSettings(pxlOpts, page);
 
         scaleImage = pxlOpts.isScaleContent();
+        dithering = pxlOpts.getDithering();
         interpolation = pxlOpts.getInterpolation();
         imageRotation = pxlOpts.getRotation();
 
@@ -170,7 +172,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
             log.debug("Scaling image up by x{}", upScale);
 
             BufferedImage scaled = new BufferedImage((int)(imgToPrint.getWidth() * upScale), (int)(imgToPrint.getHeight() * upScale), BufferedImage.TYPE_INT_ARGB);
-            Graphics2D g2d = withRenderHints(scaled.createGraphics(), interpolation);
+            Graphics2D g2d = withRenderHints(scaled.createGraphics(), dithering, interpolation);
             g2d.drawImage(imgToPrint, 0, 0, (int)(imgToPrint.getWidth() * upScale), (int)(imgToPrint.getHeight() * upScale), null);
             g2d.dispose();
 
@@ -193,7 +195,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         log.trace("Image size: {},{}", imgW, imgH);
 
         // Now we perform our rendering
-        Graphics2D graphics2D = withRenderHints((Graphics2D)graphics, interpolation);
+        Graphics2D graphics2D = withRenderHints((Graphics2D)graphics, dithering, interpolation);
         log.trace("{}", graphics2D.getRenderingHints());
 
         log.debug("Memory: {}m/{}m", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576, Runtime.getRuntime().maxMemory() / 1048576);
@@ -227,7 +229,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()[0].getDefaultConfiguration();
         BufferedImage result = gc.createCompatibleImage(eWidth, eHeight, Transparency.TRANSLUCENT);
 
-        Graphics2D g2d = withRenderHints(result.createGraphics(), interpolation);
+        Graphics2D g2d = withRenderHints(result.createGraphics(), dithering, interpolation);
         g2d.translate((eWidth - sWidth) / 2, (eHeight - sHeight) / 2);
         g2d.rotate(rads, sWidth / 2, sHeight / 2);
 
@@ -243,8 +245,9 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         return result;
     }
 
-    protected Graphics2D withRenderHints(Graphics2D g2d, Object interpolation) {
+    protected Graphics2D withRenderHints(Graphics2D g2d, Object dithering, Object interpolation) {
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+        g2d.setRenderingHint(RenderingHints.KEY_DITHERING, dithering);
         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
         g2d.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
@@ -261,6 +264,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         dpiScale = 1.0;
         scaleImage = false;
         imageRotation = 0;
+        dithering = RenderingHints.VALUE_DITHER_DEFAULT;
         interpolation = RenderingHints.VALUE_INTERPOLATION_BICUBIC;
         manualReverse = false;
     }

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -24,6 +24,7 @@ import qz.utils.PrintingUtilities;
 import qz.utils.SystemUtilities;
 
 import javax.print.attribute.PrintRequestAttributeSet;
+import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.print.PageFormat;
 import java.awt.print.Paper;
@@ -113,6 +114,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
         }
 
         Scaling scale = (pxlOpts.isScaleContent()? Scaling.SCALE_TO_FIT:Scaling.ACTUAL_SIZE);
+        RenderingHints hints = new RenderingHints(buildRenderingHints(pxlOpts.getDithering(), pxlOpts.getInterpolation()));
 
         BookBundle bundle = new BookBundle();
 
@@ -144,7 +146,7 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                 }
             }
 
-            bundle.append(new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false, pxlOpts.getOrientation()), page, doc.getNumberOfPages());
+            bundle.append(new PDFWrapper(doc, scale, false, (float)(pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()), false, pxlOpts.getOrientation(), hints), page, doc.getNumberOfPages());
         }
 
         job.setJobName(pxlOpts.getJobName(Constants.PDF_PRINT));

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -161,8 +161,15 @@ public abstract class PrintPixel {
         rhMap.put(RenderingHints.KEY_INTERPOLATION, interpolation);
         rhMap.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
         rhMap.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        rhMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         rhMap.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+        if (RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR.equals(interpolation)) {
+            rhMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+            rhMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
+        } else {
+            rhMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            rhMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        }
+
 
         return rhMap;
     }

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -12,6 +12,7 @@ import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.ResolutionSyntax;
 import javax.print.attribute.standard.*;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
@@ -20,7 +21,9 @@ import java.awt.print.Paper;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public abstract class PrintPixel {
 
@@ -149,6 +152,19 @@ public abstract class PrintPixel {
         }
 
         return imgToPrint;
+    }
+
+    protected Map<RenderingHints.Key, Object> buildRenderingHints(Object dithering, Object interpolation) {
+        Map<RenderingHints.Key, Object> rhMap = new HashMap<>();
+        rhMap.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+        rhMap.put(RenderingHints.KEY_DITHERING, dithering);
+        rhMap.put(RenderingHints.KEY_INTERPOLATION, interpolation);
+        rhMap.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+        rhMap.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        rhMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        rhMap.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
+        return rhMap;
     }
 
 }


### PR DESCRIPTION
Dependent on  https://issues.apache.org/jira/browse/PDFBOX-4435 (merged 1/26/19, released 2/28/19)

To quote Tillman from PDFBOX:

> @tresf, please test whether [the latest PDFBOX] solves the bad quality problems. What you should do is to pass these renderingHints to `PDFPrintable`:

```java
RenderingHints r = new RenderingHints(null);
r.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR); // maybe, maybe not
r.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY); // don't know
r.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF); // important
```

Closes #405
