### PR TITLE
Fix AdoptOpenJDK detection on Windows

### DIFF
--- a/ant/windows/windows-keygen.js.in
+++ b/ant/windows/windows-keygen.js.in
@@ -129,8 +129,8 @@ function java() {
             try {
                 // AdoptOpenJDK adds java.exe to PATH
                 shell.Exec('java.exe'); // throws exception if not found
-                jreHome = "NOT_NEEDED, ON PATH";
-                regkey = "NOT_NEEDED, ON PATH";
+                jreHome = "NOT_NEEDED";
+                regkey = "NOT_NEEDED";
                 keyTool = "keytool.exe";
             } catch(ignore) {}
         }

--- a/ant/windows/windows-keygen.js.in
+++ b/ant/windows/windows-keygen.js.in
@@ -125,6 +125,17 @@ function java() {
             jreHome = getRegValue(regKey + getRegValue(regKey + "CurrentVersion") + "\\JavaHome");
         }
         var keyTool = jreHome + "\\bin\\keytool.exe";
+
+            if (!jreHome) {
+                try {
+                    // AdoptOpenJDK adds java.exe to PATH
+                    shell.Exec('java.exe'); // throws exception if not found
+                    jreHome = "NOT_NEEDED, ON PATH";
+                    regkey = "NOT_NEEDED, ON PATH";
+                    keyTool = "keytool.exe";
+                } catch(ignore) {}
+            }
+
         javaEnv = {
             regKey: regKey,
             jreHome: jreHome,

--- a/ant/windows/windows-keygen.js.in
+++ b/ant/windows/windows-keygen.js.in
@@ -125,17 +125,15 @@ function java() {
             jreHome = getRegValue(regKey + getRegValue(regKey + "CurrentVersion") + "\\JavaHome");
         }
         var keyTool = jreHome + "\\bin\\keytool.exe";
-
-            if (!jreHome) {
-                try {
-                    // AdoptOpenJDK adds java.exe to PATH
-                    shell.Exec('java.exe'); // throws exception if not found
-                    jreHome = "NOT_NEEDED, ON PATH";
-                    regkey = "NOT_NEEDED, ON PATH";
-                    keyTool = "keytool.exe";
-                } catch(ignore) {}
-            }
-
+        if (!jreHome) {
+            try {
+                // AdoptOpenJDK adds java.exe to PATH
+                shell.Exec('java.exe'); // throws exception if not found
+                jreHome = "NOT_NEEDED, ON PATH";
+                regkey = "NOT_NEEDED, ON PATH";
+                keyTool = "keytool.exe";
+            } catch(ignore) {}
+        }
         javaEnv = {
             regKey: regKey,
             jreHome: jreHome,


### PR DESCRIPTION
AdoptOpenJDK does not yet provide a registry key for `CurrentVersion` per https://github.com/AdoptOpenJDK/openjdk-installer/issues/64.

This PR allows Windows JVM detection to fallback to `%PATH%` environmental variable.

Note, MacOS and Linux JVM detection work as expected with AdoptOpenJDK.