### PR TITLE
Added Fallback value for CUPS_DPI when output is empty or invalid

### DIFF
--- a/src/qz/utils/ShellUtilities.java
+++ b/src/qz/utils/ShellUtilities.java
@@ -240,6 +240,10 @@ public class ShellUtilities {
                     }
                 }
             }
+            if (!densityMap.containsKey(entry.getKey())) {
+                densityMap.put(entry.getKey(), null);
+                log.warn("Error parsing default density from CUPS, either no response or invalid response {}: {}", entry.getKey(), out);
+            }
         }
         return densityMap;
     }

--- a/src/qz/utils/ShellUtilities.java
+++ b/src/qz/utils/ShellUtilities.java
@@ -233,10 +233,7 @@ public class ShellUtilities {
                             densityMap.put(entry.getKey(), new PrinterResolution(density, density, type));
                             log.debug("Parsed default density from CUPS {}: {}{}", entry.getKey(), density,
                                       type == PrinterResolution.DPI? "dpi":"dpcm");
-                        } catch(NumberFormatException e) {
-                            densityMap.put(entry.getKey(), null);
-                            log.warn("Error parsing default density from CUPS {}: {}", entry.getKey(), part);
-                        }
+                        } catch(NumberFormatException ignore) {}
                     }
                 }
             }


### PR DESCRIPTION
I Added a fallback value for CUPS_DPI when output is empty or invalid. This prevents qz from polling raw printers over and over.

This caused us al lot of trouble because we had 190 printers from which about half are raw label printers.