### PR TITLE
Certificate Adjustments

### DIFF
--- a/src/qz/auth/RequestState.java
+++ b/src/qz/auth/RequestState.java
@@ -86,7 +86,7 @@ public class RequestState {
     }
 
     public boolean hasSavedCert() {
-        return certUsed.isTrusted() && certUsed.isSaved();
+        return isVerified() && certUsed.isSaved();
     }
 
     public boolean hasBlockedCert() {
@@ -97,7 +97,7 @@ public class RequestState {
         return certUsed.getCommonName();
     }
 
-    public boolean isTrusted() {
+    public boolean isVerified() {
         return certUsed.isTrusted() && status == Validity.TRUSTED;
     }
 

--- a/src/qz/ui/GatewayDialog.java
+++ b/src/qz/ui/GatewayDialog.java
@@ -85,7 +85,7 @@ public class GatewayDialog extends JDialog implements Themeable {
         bottomPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 10, 5));
         persistentCheckBox = new JCheckBox("Remember this decision", false);
         persistentCheckBox.setMnemonic(KeyEvent.VK_R);
-        persistentCheckBox.addActionListener(e -> allowButton.setEnabled(!persistentCheckBox.isSelected() || request.isTrusted()));
+        persistentCheckBox.addActionListener(e -> allowButton.setEnabled(!persistentCheckBox.isSelected() || request.isVerified()));
         persistentCheckBox.setAlignmentX(RIGHT_ALIGNMENT);
 
         bottomPanel.add(certInfoLabel);
@@ -149,7 +149,7 @@ public class GatewayDialog extends JDialog implements Themeable {
 
             IconCache.Icon trustIcon;
             Color detailColor = Constants.TRUSTED_COLOR;
-            if (request.isTrusted()) {
+            if (request.isVerified()) {
                 //cert and signature are good
                 trustIcon = IconCache.Icon.TRUST_VERIFIED_ICON;
             } else if (request.getCertUsed().isValid()) {

--- a/src/qz/ui/component/RequestTable.java
+++ b/src/qz/ui/component/RequestTable.java
@@ -119,7 +119,7 @@ public class RequestTable extends DisplayTable implements Themeable {
                     }
                     break;
                 case SIGNATURE:
-                    if (request.isTrusted()) {
+                    if (request.isVerified()) {
                         style = STATUS_TRUSTED;
                     } else if (request.getStatus() != RequestState.Validity.EXPIRED) {
                         style = STATUS_WARNING;
@@ -140,7 +140,7 @@ public class RequestTable extends DisplayTable implements Themeable {
                     }
                     break;
                 case VALIDITY:
-                    style = request.isTrusted()? STATUS_TRUSTED:STATUS_WARNING;
+                    style = request.isVerified()? STATUS_TRUSTED:STATUS_WARNING;
                     break;
             }
 

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -94,7 +94,7 @@ public class FileUtilities {
 
     public static Path getAbsolutePath(JSONObject params, RequestState request, boolean allowRootDir) throws JSONException, IOException {
         FileParams fp = new FileParams(params);
-        String commonName = request.isTrusted()? escapeFileName(request.getCertName()):"UNTRUSTED";
+        String commonName = request.isVerified()? escapeFileName(request.getCertName()):"UNTRUSTED";
 
         Path path = createAbsolutePath(fp, commonName);
         initializeRootFolder(fp, commonName);


### PR DESCRIPTION
Fix some problems that came up with the recent improvements to requests/certs:

- OffsetDateTime MIN/MAX values are actually outside the valid Instant range
- Allowed/Blocked sites couldn't be removed via the manager dialog due to date formatting mismatch
- Checking cert trusted without checking request trusted (renamed to "verified" to help in the future)
