### PR TITLE
Add stop-gap for shorter certs

### DIFF
--- a/ant/apple/apple-keygen.sh.in
+++ b/ant/apple/apple-keygen.sh.in
@@ -72,6 +72,14 @@ function replace_vars {
     cmd=$(echo "$cmd" | sed -e "s|\!sslcert|$trustedcertpath|g")
     cmd=$(echo "$cmd" | sed -e "s|\!sslkey|$trustedkeypath|g")
 
+    # Shorten cert life for macOS 10.15+ to 825 days per #491
+    curver=($(sw_vers -productVersion |tr '.' ' '))
+    curver="${curver[0]}.${curver[1]}"
+    compare="$(echo "$curver>10.14" | bc -l)"
+    if [ $compare -gt 0 ]; then
+        cmd=$(echo "$cmd" | sed -e "s|-validity ${ssl.validity}|-validity 825|g")
+    fi
+
     echo "$cmd"
     return 0
 }


### PR DESCRIPTION
Workaround for #491 for the 2.0 branch.

Note, this puts an 825 day expiration on any QZ Tray 2.0 install for macOS Catalina or higher meaning a reinstall will need to be done every two-years or so.

A permanent solution is available in #504, but will only be targeted against the 2.1 branch.