### PR TITLE
Add whitelisted certificate directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
     <property file="ant/project.properties"/>
     <import file="ant/javafx.xml"/>
 
-    <target name="distribute" depends="init,clean,sign-jar,download-javafx,override-authcert,include-assets">
+    <target name="distribute" depends="init,clean,sign-jar,download-javafx,override-authcert,include-assets,whitelist-certs">
         <echo message="Process complete" />
     </target>
 
@@ -166,6 +166,15 @@
         <!-- See also: Constants.OVERRIDE_CERT -->
         <copy file="${authcert.use}" tofile="${dist.dir}/override.crt" overwrite="true"></copy>
         <property name="build.type" value="-community"/>
+    </target>
+
+    <!-- install certs to "whitelist" directory for whitelabel builds -->
+    <target name="whitelist-certs" depends="include-assets" if="whitelist.use">
+        <echo>Copying certificate(s) to dist/whitelist: ${whitelist.use}</echo>
+        <!-- See also: Constants.WHITELIST_CERT_DIR -->
+
+        <mkdir dir="${dist.dir}/whitelist"/>
+        <copy file="${whitelist.use}" todir="${dist.dir}/whitelist" overwrite="true"/>
     </target>
 
     <target name="include-assets" depends="init,get-version" unless="dist.minimal">

--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
     public static final String BLOCKED = "Blocked";
 
     public static final String OVERRIDE_CERT = "override.crt";
+    public static final String WHITELIST_CERT_DIR = "whitelist";
 
     public static final long VALID_SIGNING_PERIOD = 15 * 60 * 1000; //millis
     public static final int EXPIRY_WARN = 30;   // days

--- a/src/qz/installer/LinuxInstaller.java
+++ b/src/qz/installer/LinuxInstaller.java
@@ -66,10 +66,6 @@ public class LinuxInstaller extends Installer {
         }
     }
 
-    public Installer addUserSettings() {
-        return this;
-    }
-
     public Installer removeLegacyStartup() {
         log.info("Removing legacy autostart entries for all users matching {} or {}", ABOUT_TITLE, PROPS_FILE);
         // assume users are in /home

--- a/src/qz/installer/MacInstaller.java
+++ b/src/qz/installer/MacInstaller.java
@@ -58,8 +58,6 @@ public class MacInstaller extends Installer {
         return destination;
     }
 
-    public Installer addUserSettings() { return this; }
-
     public Installer addSystemSettings() { return this; }
     public Installer removeSystemSettings() {
         // Remove startup entry

--- a/src/qz/installer/WindowsInstaller.java
+++ b/src/qz/installer/WindowsInstaller.java
@@ -142,6 +142,7 @@ public class WindowsInstaller extends Installer {
         return this;
     }
 
+    @Override
     public Installer addUserSettings() {
         // Whitelist loopback for IE/Edge
         if(ShellUtilities.execute("CheckNetIsolation.exe", "LoopbackExempt", "-a", "-n=Microsoft.MicrosoftEdge_8wekyb3d8bbwe")) {
@@ -169,7 +170,7 @@ public class WindowsInstaller extends Installer {
         } catch(Exception e) {
             log.warn("An error occurred configuring the \"Local Intranet Zone\"; connections to \"localhost\" may fail", e);
         }
-        return this;
+        return super.addUserSettings();
     }
 
     public static String getDefaultDestination() {


### PR DESCRIPTION
Adds the ability to scan and whitelist certificates that are provided along with a Desktop install.

**Ant**:
The file will be automatically placed in the correct location using the `whitelist.use` parameter.

```bash
ant nsis -Dwhitelist.use=path/to/digital-certficate.txt
```

**Manually**:
The file should be located in `<install>/whitelist/`, i.e:

* Mac : `/Applications/QZ Tray.app/whitelist/`
* Linux : `/opt/qz-tray/whitelist/`
* Windows: `C:\Program Files\QZ Tray\whitelist\`

The white-label portal will be enhanced to pre-whitelist a certificate so that users of the white-label version won't need to click  "☑️ Remember this decision".

Closes #557 