### PR TITLE
FileIO Filtering

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1985,7 +1985,7 @@ var qz = (function() {
              */
             startListening: function(path, params) {
                 if (params && typeof params.include !== 'undefined' && !Array.isArray(params.include)) {
-                     params.include = [params.include];
+                    params.include = [params.include];
                 }
                 if (params && typeof params.exclude !== 'undefined' && !Array.isArray(params.exclude)) {
                     params.exclude = [params.exclude];

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1975,7 +1975,7 @@ var qz = (function() {
              *   @param {boolean} [params.listener.reverse] Controls whether data should be returned from the bottom of the file.  Default value is true for line mode and false for byte mode.
              *   @param {string|Array<string>} [params.include] File patterns to match.  Blank values will be ignored.
              *   @param {string|Array<string>} [params.exclude] File patterns to exclude.  Blank values will be ignored.  Takes priority over <code>params.include</code>.
-             *   @param {boolean) [params.ignoreCase=true] Whether <code>params.include</code> or <code>params.exclude</code> are case-sensitive.
+             *   @param {boolean} [params.ignoreCase=true] Whether <code>params.include</code> or <code>params.exclude</code> are case-sensitive.
              * @returns {Promise<null|Error>}
              * @since 2.1.0
              *

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1973,6 +1973,9 @@ var qz = (function() {
              *   @param {number} [params.listener.bytes=-1] Number of bytes to return or -1 for all
              *   @param {number} [params.listener.lines=-1] Number of lines to return or -1 for all
              *   @param {boolean} [params.listener.reverse] Controls whether data should be returned from the bottom of the file.  Default value is true for line mode and false for byte mode.
+             *   @param {string|Array<string>} [params.include] File patterns to match.  Blank values will be ignored.
+             *   @param {string|Array<string>} [params.exclude] File patterns to exclude.  Blank values will be ignored.  Takes priority over <code>params.include</code>.
+             *   @param {boolean) [params.ignoreCase=true] Whether <code>params.include</code> or <code>params.exclude</code> are case-sensitive.
              * @returns {Promise<null|Error>}
              * @since 2.1.0
              *
@@ -1981,6 +1984,12 @@ var qz = (function() {
              * @memberof qz.file
              */
             startListening: function(path, params) {
+                if (params && typeof params.include !== 'undefined' && !Array.isArray(params.include)) {
+                     params.include = [params.include];
+                }
+                if (params && typeof params.exclude !== 'undefined' && !Array.isArray(params.exclude)) {
+                    params.exclude = [params.exclude];
+                }
                 var param = _qz.tools.extend({ path: path }, params);
                 return _qz.websocket.dataPromise('file.startListening', param);
             },

--- a/sample.html
+++ b/sample.html
@@ -2196,7 +2196,6 @@
             }
         }
 
-
         for (var i = 1; i < 4; i++) {
             var inc = $("#inclusionsList").children().eq(i).val();
             var enc = $("#exclusionsList").children().eq(i).val();

--- a/sample.html
+++ b/sample.html
@@ -1014,110 +1014,97 @@
                 <div class="row" style="margin-top: 1em;">
                     <div class="col-md-12">
                         <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <h4 class="panel-title">Options</h4>
+                            </div>
                             <div class="panel-body">
-                                <fieldset> 
-                                    <legend>Options</legend>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="form-group">
-                                                <label for="fileLocation">
-                                                    File / Directory Path
-                                                </label>
-                                                <input type="text" id="fileLocation" class="form-control" />
-                                            </div>
-                                            <div class="form-group">
-                                                <label for="fileData">Data To Write</label>
-                                                <textarea id="fileData" rows="11" style="resize:vertical" class="form-control"></textarea>
-                                            </div>
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group">
+                                            <label for="fileLocation">
+                                                File / Directory Path
+                                            </label>
+                                            <input type="text" id="fileLocation" class="form-control" />
                                         </div>
-                                        <div class="col-md-6">
-                                            <div class="form-group form-inline">
-                                                <label for="fileShared">
-                                                    Shared
-                                                </label>
-                                                <input type="checkbox" id="fileShared" class="pull-right" />
-                                            </div>
-                                            <div class="form-group form-inline">
-                                                <label for="fileSandbox" data-toggle="tooltip">
-                                                    Sandbox
-                                                </label>
-                                                <input checked type="checkbox" id="fileSandbox" class="pull-right" />
-                                            </div>
-                                            <div class="form-group form-inline">
-                                                <label for="fileAppend">
-                                                    Append Data
-                                                </label>
-                                                <input type="checkbox" id="fileAppend" class="pull-right" />
-                                            </div>
+                                        <div class="form-group">
+                                            <label for="fileData">Data To Write</label>
+                                            <textarea id="fileData" rows="5" style="resize:vertical" class="form-control"></textarea>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="includePattern" class="tip" data-toggle="tooltip" title="Wildcards supported, see documentation">
+                                                Include File Pattern
+                                            </label>
+                                            <input type="text" id="includePattern" class="form-control pull-right" />
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="excludePattern">Exclude File Pattern</label>
+                                            <input type="text" id="excludePattern" class="form-control pull-right" />
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-group form-inline">
+                                            <label for="fileShared">
+                                                Shared
+                                            </label>
+                                            <input type="checkbox" id="fileShared" class="pull-right" />
+                                        </div>
+                                        <div class="form-group form-inline">
+                                            <label for="fileSandbox" data-toggle="tooltip">
+                                                Sandbox
+                                            </label>
+                                            <input checked type="checkbox" id="fileSandbox" class="pull-right" />
+                                        </div>
+                                        <div class="form-group form-inline">
+                                            <label for="fileAppend">
+                                                Append Data
+                                            </label>
+                                            <input type="checkbox" id="fileAppend" class="pull-right" />
+                                        </div>
 
+                                        <div class="form-group form-inline">
+                                            <label for="fileListenerData">
+                                                Listener Data
+                                            </label>
+                                            <input type="checkbox" id="fileListenerData" class="pull-right" onclick="checkGroupActive('fileListenerData', 'fileTriggersGroup')" />
+                                        </div>
+                                        <div class="inline" id="fileTriggersGroup">
                                             <div class="form-group form-inline">
-                                                <label for="fileListenerData">
-                                                    Listener Data
+                                                <label>
+                                                    Read direction
                                                 </label>
-                                                <input type="checkbox" id="fileListenerData" class="pull-right" onclick="checkGroupActive('fileListenerData', 'fileTriggersGroup')" />
+                                                <div>
+                                                    <label>
+                                                        <input type="radio" name="fileDir" id="fileDirEnd" value="end" />
+                                                        End
+                                                    </label>
+                                                    <label>
+                                                        <input type="radio" name="fileDir" id="fileDirStart" value="begin" />
+                                                        Start
+                                                    </label>
+                                                </div>
                                             </div>
-                                            <div class="inline" id="fileTriggersGroup">
-                                                <div class="form-group form-inline">
+                                            <div class="form-group form-inline">
+                                                <label>
+                                                    Truncate
+                                                </label>
+                                                <div>
                                                     <label>
-                                                        Read direction
+                                                        <input type="radio" name="fileTruncate" id="fileTruncateLines" value="lines" />
+                                                        Lines
                                                     </label>
-                                                    <div>
-                                                        <label>
-                                                            <input type="radio" name="fileDir" id="fileDirEnd" value="end" />
-                                                            End
-                                                        </label>
-                                                        <label>
-                                                            <input type="radio" name="fileDir" id="fileDirStart" value="begin" />
-                                                            Start
-                                                        </label>
-                                                    </div>
-                                                </div>
-                                                <div class="form-group form-inline">
                                                     <label>
-                                                        Truncate
+                                                        <input type="radio" name="fileTruncate" id="fileTruncateBytes" value="bytes" />
+                                                        Bytes
                                                     </label>
-                                                    <div>
-                                                        <label>
-                                                            <input type="radio" name="fileTruncate" id="fileTruncateLines" value="lines" />
-                                                            Lines
-                                                        </label>
-                                                        <label>
-                                                            <input type="radio" name="fileTruncate" id="fileTruncateBytes" value="bytes" />
-                                                            Bytes
-                                                        </label>
-                                                    </div>
                                                 </div>
-                                                <div class="form-group">
-                                                    <label for="fileLength">Truncate length</label>
-                                                    <input type="number" id="fileLength" class="form-control pull-right" />
-                                                </div>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="fileLength">Truncate length</label>
+                                                <input type="number" id="fileLength" class="form-control pull-right" />
                                             </div>
                                         </div>
                                     </div>
-                                </fieldset> 
-                                <hr/>
-                                
-                                <fieldset>    
-                                    <legend>Filter Rules</legend>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="form-group" id="inclusionsList">
-                                                <label for="fileLength">Inlude</label>
-                                                <input type="text" class="form-control pull-right" />
-                                                <input type="text" class="form-control pull-right" />
-                                                <input type="text" class="form-control pull-right" />
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <div class="form-group" id="exclusionsList">
-                                                <label for="fileLength">Exclude</label>
-                                                <input type="text" class="form-control pull-right" />
-                                                <input type="text" class="form-control pull-right" />
-                                                <input type="text" class="form-control pull-right" />
-                                            </div>
-                                        </div>
-                                    </div>
-                                </fieldset>
+                                </div>
                                 <hr />
                                 <div class="row">
                                     <div class="col-md-12">
@@ -2196,12 +2183,10 @@
             }
         }
 
-        for (var i = 1; i < 4; i++) {
-            var inc = $("#inclusionsList").children().eq(i).val();
-            var enc = $("#exclusionsList").children().eq(i).val();
-            if (inc && inc.trim()) params.include.push(inc);
-            if (enc && enc.trim()) params.exclude.push(enc);
-        }
+        var inc = $("#includePattern").val();
+        var enc = $("#excludePattern").val();
+        if (inc && inc.trim()) params.include.push(inc);
+        if (enc && enc.trim()) params.exclude.push(enc);
 
         qz.file.startListening($("#fileLocation").val(), params).then(function() {
             displayMessage("Started listening for <strong><code>" + ($("#fileLocation").val() || "./") + "</code></strong> events");

--- a/sample.html
+++ b/sample.html
@@ -1031,13 +1031,15 @@
                                             <textarea id="fileData" rows="5" style="resize:vertical" class="form-control"></textarea>
                                         </div>
                                         <div class="form-group">
-                                            <label for="includePattern" class="tip" data-toggle="tooltip" title="Wildcards supported, see documentation">
+                                            <label for="includePattern" class="tip" data-toggle="tooltip" title="File pattern to match when listening for file events (e.g. *.txt)">
                                                 Include File Pattern
                                             </label>
                                             <input type="text" id="includePattern" class="form-control pull-right" />
                                         </div>
                                         <div class="form-group">
-                                            <label for="excludePattern">Exclude File Pattern</label>
+                                            <label for="excludePattern" class="tip" data-toggle="tooltip" title="File pattern to ignore when listening for file events (e.g. *.tmp) ">
+                                                Exclude File Pattern
+                                            </label>
                                             <input type="text" id="excludePattern" class="form-control pull-right" />
                                         </div>
                                     </div>
@@ -2166,8 +2168,8 @@
         var params = {
             sandbox: $("#fileSandbox").prop("checked"),
             shared: $("#fileShared").prop("checked"),
-            include: [],
-            exclude: [],
+            include: $("#includePattern").val() == "" ? [] : $("#includePattern").val(),
+            exclude: $("#excludePattern").val() == "" ? [] : $("#excludePattern").val(),
             ignoreCase: true,
             listener: {}
         };
@@ -2182,11 +2184,6 @@
                 params.listener.bytes = len;
             }
         }
-
-        var inc = $("#includePattern").val();
-        var enc = $("#excludePattern").val();
-        if (inc && inc.trim()) params.include.push(inc);
-        if (enc && enc.trim()) params.exclude.push(enc);
 
         qz.file.startListening($("#fileLocation").val(), params).then(function() {
             displayMessage("Started listening for <strong><code>" + ($("#fileLocation").val() || "./") + "</code></strong> events");

--- a/sample.html
+++ b/sample.html
@@ -1014,87 +1014,110 @@
                 <div class="row" style="margin-top: 1em;">
                     <div class="col-md-12">
                         <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h4 class="panel-title">Options</h4>
-                            </div>
                             <div class="panel-body">
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <div class="form-group">
-                                            <label for="fileLocation">
-                                                File / Directory Path
-                                            </label>
-                                            <input type="text" id="fileLocation" class="form-control" />
-                                        </div>
-                                        <div class="form-group">
-                                            <label for="fileData">Data To Write</label>
-                                            <textarea id="fileData" rows="5" style="resize:vertical" class="form-control"></textarea>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-6">
-                                        <div class="form-group form-inline">
-                                            <label for="fileShared">
-                                                Shared
-                                            </label>
-                                            <input type="checkbox" id="fileShared" class="pull-right" />
-                                        </div>
-                                        <div class="form-group form-inline">
-                                            <label for="fileSandbox" data-toggle="tooltip">
-                                                Sandbox
-                                            </label>
-                                            <input checked type="checkbox" id="fileSandbox" class="pull-right" />
-                                        </div>
-                                        <div class="form-group form-inline">
-                                            <label for="fileAppend">
-                                                Append Data
-                                            </label>
-                                            <input type="checkbox" id="fileAppend" class="pull-right" />
-                                        </div>
-
-                                        <div class="form-group form-inline">
-                                            <label for="fileListenerData">
-                                                Listener Data
-                                            </label>
-                                            <input type="checkbox" id="fileListenerData" class="pull-right" onclick="checkGroupActive('fileListenerData', 'fileTriggersGroup')" />
-                                        </div>
-                                        <div class="inline" id="fileTriggersGroup">
-                                            <div class="form-group form-inline">
-                                                <label>
-                                                    Read direction
+                                <fieldset> 
+                                    <legend>Options</legend>
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="form-group">
+                                                <label for="fileLocation">
+                                                    File / Directory Path
                                                 </label>
-                                                <div>
-                                                    <label>
-                                                        <input type="radio" name="fileDir" id="fileDirEnd" value="end" />
-                                                        End
-                                                    </label>
-                                                    <label>
-                                                        <input type="radio" name="fileDir" id="fileDirStart" value="begin" />
-                                                        Start
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="form-group form-inline">
-                                                <label>
-                                                    Truncate
-                                                </label>
-                                                <div>
-                                                    <label>
-                                                        <input type="radio" name="fileTruncate" id="fileTruncateLines" value="lines" />
-                                                        Lines
-                                                    </label>
-                                                    <label>
-                                                        <input type="radio" name="fileTruncate" id="fileTruncateBytes" value="bytes" />
-                                                        Bytes
-                                                    </label>
-                                                </div>
+                                                <input type="text" id="fileLocation" class="form-control" />
                                             </div>
                                             <div class="form-group">
-                                                <label for="fileLength">Truncate length</label>
-                                                <input type="number" id="fileLength" class="form-control pull-right" />
+                                                <label for="fileData">Data To Write</label>
+                                                <textarea id="fileData" rows="11" style="resize:vertical" class="form-control"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="form-group form-inline">
+                                                <label for="fileShared">
+                                                    Shared
+                                                </label>
+                                                <input type="checkbox" id="fileShared" class="pull-right" />
+                                            </div>
+                                            <div class="form-group form-inline">
+                                                <label for="fileSandbox" data-toggle="tooltip">
+                                                    Sandbox
+                                                </label>
+                                                <input checked type="checkbox" id="fileSandbox" class="pull-right" />
+                                            </div>
+                                            <div class="form-group form-inline">
+                                                <label for="fileAppend">
+                                                    Append Data
+                                                </label>
+                                                <input type="checkbox" id="fileAppend" class="pull-right" />
+                                            </div>
+
+                                            <div class="form-group form-inline">
+                                                <label for="fileListenerData">
+                                                    Listener Data
+                                                </label>
+                                                <input type="checkbox" id="fileListenerData" class="pull-right" onclick="checkGroupActive('fileListenerData', 'fileTriggersGroup')" />
+                                            </div>
+                                            <div class="inline" id="fileTriggersGroup">
+                                                <div class="form-group form-inline">
+                                                    <label>
+                                                        Read direction
+                                                    </label>
+                                                    <div>
+                                                        <label>
+                                                            <input type="radio" name="fileDir" id="fileDirEnd" value="end" />
+                                                            End
+                                                        </label>
+                                                        <label>
+                                                            <input type="radio" name="fileDir" id="fileDirStart" value="begin" />
+                                                            Start
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="form-group form-inline">
+                                                    <label>
+                                                        Truncate
+                                                    </label>
+                                                    <div>
+                                                        <label>
+                                                            <input type="radio" name="fileTruncate" id="fileTruncateLines" value="lines" />
+                                                            Lines
+                                                        </label>
+                                                        <label>
+                                                            <input type="radio" name="fileTruncate" id="fileTruncateBytes" value="bytes" />
+                                                            Bytes
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label for="fileLength">Truncate length</label>
+                                                    <input type="number" id="fileLength" class="form-control pull-right" />
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
+                                </fieldset> 
+                                <hr/>
+                                
+                                <fieldset>    
+                                    <legend>Filter Rules</legend>
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="form-group" id="inclusionsList">
+                                                <label for="fileLength">Inlude</label>
+                                                <input type="text" class="form-control pull-right" />
+                                                <input type="text" class="form-control pull-right" />
+                                                <input type="text" class="form-control pull-right" />
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <div class="form-group" id="exclusionsList">
+                                                <label for="fileLength">Exclude</label>
+                                                <input type="text" class="form-control pull-right" />
+                                                <input type="text" class="form-control pull-right" />
+                                                <input type="text" class="form-control pull-right" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </fieldset>
                                 <hr />
                                 <div class="row">
                                     <div class="col-md-12">
@@ -2156,6 +2179,9 @@
         var params = {
             sandbox: $("#fileSandbox").prop("checked"),
             shared: $("#fileShared").prop("checked"),
+            include: [],
+            exclude: [],
+            ignoreCase: true,
             listener: {}
         };
 
@@ -2168,6 +2194,14 @@
             } else {
                 params.listener.bytes = len;
             }
+        }
+
+
+        for (var i = 1; i < 4; i++) {
+            var inc = $("#inclusionsList").children().eq(i).val();
+            var enc = $("#exclusionsList").children().eq(i).val();
+            if (inc && inc.trim()) params.include.push(inc);
+            if (enc && enc.trim()) params.exclude.push(enc);
         }
 
         qz.file.startListening($("#fileLocation").val(), params).then(function() {

--- a/src/qz/communication/FileIO.java
+++ b/src/qz/communication/FileIO.java
@@ -78,18 +78,22 @@ public class FileIO {
     }
 
     private boolean isMatch(String fileName) {
-        boolean match = false;
-        if (inclusions.size() == 0) match = true;
-        for (int i = 0; i < inclusions.size(); i++) {
-            if (match) break;
-            match = FilenameUtils.wildcardMatch(fileName, inclusions.get(i), caseSensitivity);
+        boolean match = inclusions.isEmpty();
+        for (String inclusion : inclusions) {
+            if(FilenameUtils.wildcardMatch(fileName, inclusion, caseSensitivity)) {
+                match = true;
+                break;
+            }
         }
 
-        for (int i = 0; i < exclusions.size(); i++) {
-            if (!match) break;
-            match = !FilenameUtils.wildcardMatch(fileName, exclusions.get(i), caseSensitivity);
+        if(match) {
+            for(String exclusion : exclusions) {
+                if (FilenameUtils.wildcardMatch(fileName, exclusion, caseSensitivity)) {
+                    match = false;
+                    break;
+                }
+            }
         }
-
         return match;
     }
 


### PR DESCRIPTION
Closes #555 

Some things to note,

- If `include` is empty or missing, it will include everything.
- `include`/`exclude` are both lists of strings. Wildcard behaviour is documented [here](https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,%20java.lang.String,%20org.apache.commons.io.IOCase)).
- The exclusion list overrides the inclusion list.