### PR TITLE
Move isMatch to FileWatcher to prevent file locks

### DIFF
--- a/src/qz/communication/FileIO.java
+++ b/src/qz/communication/FileIO.java
@@ -77,7 +77,7 @@ public class FileIO {
         }
     }
 
-    private boolean isMatch(String fileName) {
+    public boolean isMatch(String fileName) {
         boolean match = inclusions.isEmpty();
         for (String inclusion : inclusions) {
             if(FilenameUtils.wildcardMatch(fileName, inclusion, caseSensitivity)) {
@@ -134,8 +134,6 @@ public class FileIO {
     }
 
     public void fileChanged(String fileName, String type, String fileData) {
-        if (!isMatch(fileName)) return;
-
         StreamEvent evt = new StreamEvent(StreamEvent.Stream.FILE, StreamEvent.Type.ACTION)
                 .withData("file", getOriginalPath().resolve(fileName))
                 .withData("eventType", type);

--- a/src/qz/utils/FileWatcher.java
+++ b/src/qz/utils/FileWatcher.java
@@ -72,6 +72,8 @@ public class FileWatcher {
     private synchronized static void fileChanged(Path path, String fileName, String type) {
         Path filePath = path.resolve(fileName);
         for(FileIO fio : fileIOs) {
+            if (!fio.isMatch(fileName)) continue;
+
             String fileData = null;
             if (fio.getAbsolutePath().equals(path.normalize().toAbsolutePath())) {
                 if (!type.equals("ENTRY_DELETE") && fio.returnsContents() && !Files.isDirectory(filePath)) {


### PR DESCRIPTION
Fixes a bug identified in #562 