### PR TITLE
Whitelist qz protocol handler for Google Chrome

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
+    <entry_points version="2.0" />
     <list size="4">
       <item index="0" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose" />
       <item index="1" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect" />
@@ -8,5 +9,5 @@
       <item index="3" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <entry_points version="2.0" />
     <list size="4">
       <item index="0" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose" />
       <item index="1" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect" />
@@ -9,5 +8,5 @@
       <item index="3" class="java.lang.String" itemvalue="org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage" />
     </list>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/src/qz/installer/LinuxInstaller.java
+++ b/src/qz/installer/LinuxInstaller.java
@@ -5,16 +5,11 @@ import org.slf4j.LoggerFactory;
 import qz.utils.FileUtilities;
 import qz.utils.ShellUtilities;
 import qz.utils.SystemUtilities;
-
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static qz.common.Constants.*;
@@ -106,15 +101,12 @@ public class LinuxInstaller extends Installer {
         // Chrome protocol handler
         for (String policyDir : CHROME_POLICY_DIRS) {
             log.info("Installing chrome protocol handler {}/{}...", policyDir, PROPS_FILE + ".json");
-            Path parent = Paths.get(policyDir);
-            if(!parent.toFile().exists()) {
-                try {
-                    Files.createDirectories(parent, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x")));
-                } catch(IOException e) {
-                    log.warn("Unable to create Chrome policy directory: {} ({}:launch will fail)", policyDir, DATA_DIR);
-                    continue;
-                }
+            try {
+                FileUtilities.setPermissionsParentally(Files.createDirectories(Paths.get(policyDir)), false);
+            } catch(IOException e) {
+                log.warn("An error occurred creating {}", policyDir);
             }
+
             Path policy = Paths.get(policyDir, PROPS_FILE + ".json");
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(policy.toFile()))){
                 writer.write(CHROME_POLICY);

--- a/src/qz/installer/MacInstaller.java
+++ b/src/qz/installer/MacInstaller.java
@@ -58,7 +58,14 @@ public class MacInstaller extends Installer {
         return destination;
     }
 
-    public Installer addSystemSettings() { return this; }
+    public Installer addSystemSettings() {
+        // Chrome protocol handler
+        String plist = "/Library/Preferences/com.google.Chrome.plist";
+        if(ShellUtilities.execute(new String[] { "/usr/bin/defaults", "write", plist }, new String[] { "qz://*" }).isEmpty()) {
+            ShellUtilities.execute("/usr/bin/defaults", "write", plist, "URLWhitelist", "-array-add", "qz://*");
+        }
+        return this;
+    }
     public Installer removeSystemSettings() {
         // Remove startup entry
         File dest = new File(String.format("/Library/LaunchAgents/%s.plist", PACKAGE_NAME));

--- a/src/qz/installer/WindowsInstaller.java
+++ b/src/qz/installer/WindowsInstaller.java
@@ -36,11 +36,11 @@ import java.util.List;
 public class WindowsInstaller extends Installer {
     protected static final Logger log = LoggerFactory.getLogger(WindowsInstaller.class);
     private String destination = getDefaultDestination();
-    private String destinationExe;
+    private String destinationExe = getDefaultDestination() + File.separator + PROPS_FILE + ".exe";
 
     public void setDestination(String destination) {
         this.destination = destination;
-        this.destinationExe = destination + File.separator + PROPS_FILE+ ".exe";
+        this.destinationExe = destination + File.separator + PROPS_FILE + ".exe";
     }
 
     /**
@@ -133,6 +133,9 @@ public class WindowsInstaller extends Installer {
         WindowsUtilities.addRegValue(HKEY_LOCAL_MACHINE, uninstallKey, "URLInfoAbout", ABOUT_SUPPORT_URL);
         WindowsUtilities.addRegValue(HKEY_LOCAL_MACHINE, uninstallKey, "DisplayVersion", VERSION.toString());
         WindowsUtilities.addRegValue(HKEY_LOCAL_MACHINE, uninstallKey, "EstimatedSize", FileUtils.sizeOfDirectoryAsBigInteger(new File(destination)).intValue() / 1024);
+
+        // Chrome Protocol Handler
+        WindowsUtilities.addNumberedRegValue(HKEY_LOCAL_MACHINE, "SOFTWARE\\Policies\\Google\\Chrome\\URLWhitelist", String.format("%s://*", DATA_DIR));
 
         // Firewall rules
         String ports = StringUtils.join(PrintSocketServer.SECURE_PORTS, ",") + "," + StringUtils.join(PrintSocketServer.INSECURE_PORTS, ",");

--- a/src/qz/installer/WindowsInstaller.java
+++ b/src/qz/installer/WindowsInstaller.java
@@ -89,6 +89,8 @@ public class WindowsInstaller extends Installer {
         WindowsUtilities.deleteRegKey(HKEY_LOCAL_MACHINE, "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\" + ABOUT_TITLE);
         WindowsUtilities.deleteRegKey(HKEY_LOCAL_MACHINE, "Software\\" + ABOUT_TITLE);
         WindowsUtilities.deleteRegKey(HKEY_LOCAL_MACHINE, DATA_DIR);
+        // Chrome protocol handler
+        WindowsUtilities.deleteRegData(HKEY_LOCAL_MACHINE, "SOFTWARE\\Policies\\Google\\Chrome\\URLWhitelist", String.format("%s://*", DATA_DIR));
 
         // Cleanup launchers
         for(WindowsSpecialFolders folder : new WindowsSpecialFolders[] { START_MENU, COMMON_START_MENU, DESKTOP, PUBLIC_DESKTOP }) {
@@ -134,7 +136,7 @@ public class WindowsInstaller extends Installer {
         WindowsUtilities.addRegValue(HKEY_LOCAL_MACHINE, uninstallKey, "DisplayVersion", VERSION.toString());
         WindowsUtilities.addRegValue(HKEY_LOCAL_MACHINE, uninstallKey, "EstimatedSize", FileUtils.sizeOfDirectoryAsBigInteger(new File(destination)).intValue() / 1024);
 
-        // Chrome Protocol Handler
+        // Chrome protocol handler
         WindowsUtilities.addNumberedRegValue(HKEY_LOCAL_MACHINE, "SOFTWARE\\Policies\\Google\\Chrome\\URLWhitelist", String.format("%s://*", DATA_DIR));
 
         // Firewall rules

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -666,6 +666,21 @@ public class FileUtilities {
         return null;
     }
 
+    public static void setPermissionsParentally(Path toTraverse, boolean worldWrite) {
+        Path stepper = toTraverse.toAbsolutePath();
+        // Assume we shouldn't go higher than 2nd-level (e.g. "/etc", "C:\Program Files\", etc)
+        while(stepper.getParent() != null && !stepper.getRoot().equals(stepper.getParent())) {
+            File file = stepper.toFile();
+            file.setReadable(true, false);
+            file.setExecutable(true, false);
+            file.setWritable(true, !worldWrite);
+            if (SystemUtilities.isWindows() && worldWrite) {
+                WindowsUtilities.setWritable(stepper);
+            }
+            stepper = stepper.getParent();
+        }
+    }
+
     public static void setPermissionsRecursively(Path toRecurse, boolean worldWrite) {
         try (Stream<Path> paths = Files.walk(toRecurse)) {
             paths.forEach((path)->{

--- a/src/qz/utils/WindowsUtilities.java
+++ b/src/qz/utils/WindowsUtilities.java
@@ -78,6 +78,26 @@ public class WindowsUtilities {
         return null;
     }
 
+    /**
+     * Deletes all matching data values directly beneath the specified key
+     */
+    public static boolean deleteRegData(HKEY root, String key, String data) {
+        boolean success = true;
+        if (Advapi32Util.registryKeyExists(root, key)) {
+            for(Map.Entry<String, Object> entry : Advapi32Util.registryGetValues(root, key).entrySet()) {
+                if(entry.getValue().equals(data)) {
+                    try {
+                        Advapi32Util.registryDeleteValue(root, key, entry.getKey());
+                    } catch(Exception e) {
+                        log.warn("Couldn't delete value {}\\\\{}\\\\{}", getHkeyName(root), key, entry.getKey());
+                        success = false;
+                    }
+                }
+            }
+        }
+        return success;
+    }
+
     // gracefully swallow InvocationTargetException
     public static boolean deleteRegKey(HKEY root, String key) {
         try {
@@ -86,7 +106,7 @@ public class WindowsUtilities {
                 return true;
             }
         } catch(Exception e) {
-            log.warn("Couldn't delete value {}\\\\{}\\\\{}", getHkeyName(root), key);
+            log.warn("Couldn't delete value {}\\\\{}", getHkeyName(root), key);
         }
         return false;
     }


### PR DESCRIPTION
Per #526, adds `qz:launch` support to Chrome, Chromium by whitelisting the `qz:` URL on Windows, Mac and Linux.