### PR TITLE
Add CFBundleIdentifier to Info.plist

### DIFF
--- a/ant/apple/apple-bundle.plist.in
+++ b/ant/apple/apple-bundle.plist.in
@@ -3,6 +3,7 @@
 <plist version="1.0"><dict>
     <key>CFBundleDevelopmentRegion</key><string>English</string>
     <key>CFBundleIconFile</key><string>${project.filename}</string>
+    <key>CFBundleIdentifier</key><string>${apple.bundleid}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>CFBundleGetInfoString</key><string>${project.name} ${build.version}</string>
     <key>CFBundleSignature</key><string>${project.name}</string>

--- a/build.xml
+++ b/build.xml
@@ -139,20 +139,17 @@
         <java jar="${dist.dir}/${project.filename}.jar" fork="true" outputproperty="build.version">
             <arg value="--version"/>
         </java>
-
         <!-- Fallback to a bogus version number if the above command failed -->
         <property name="build.version" value="0.0.0" />
-        <echo>Version ${build.version}</echo>
-        <!-- Calculate installation size -->
-        <length property="build.bytes" mode="all">
-            <fileset dir="${dist.dir}" includes="**/*"/>
-        </length>
-        <script language="javascript">
-            <![CDATA[
-            project.setNewProperty("build.size", Math.round(project.getProperty("build.bytes") / 1024));
-            ]]>
-        </script>
-        <echo>Size: ${build.size} KB</echo>
+
+        <java jar="${dist.dir}/${project.filename}.jar" fork="true" outputproperty="apple.bundleid">
+            <arg value="--bundleid"/>
+        </java>
+        <!-- Fallback to a safe bundle id if the above command failed -->
+        <property name="apple.bundleid" value="io.qz.fallback.${project.filename}" />
+
+        <echo>Version   : ${build.version}</echo>
+        <echo>Bundle Id : ${apple.bundleid}</echo>
     </target>
 
     <target name="internal-authcert" unless="authcert.use">

--- a/src/qz/installer/shortcut/MacShortcutCreator.java
+++ b/src/qz/installer/shortcut/MacShortcutCreator.java
@@ -17,6 +17,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 import qz.common.Constants;
 import qz.installer.MacInstaller;
+import qz.utils.MacUtilities;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -40,11 +41,7 @@ class MacShortcutCreator extends ShortcutCreator {
     @Override
     public boolean canAutoStart() {
         // plist is stored as io.qz.plist
-        String parent = "/Library/LaunchAgents";
-        String[] parts = Constants.ABOUT_URL.split("/");
-        parts = parts[parts.length - 1].split("\\.");
-        String plist = parts[1] + "." + parts[0] + "." + Constants.PROPS_FILE + ".plist";
-        Path plistPath = Paths.get(parent, plist);
+        Path plistPath = Paths.get("/Library/LaunchAgents", MacUtilities.getBundleId() +  ".plist");
 
         if (Files.exists(plistPath)) {
             try {

--- a/src/qz/utils/ArgParser.java
+++ b/src/qz/utils/ArgParser.java
@@ -191,6 +191,12 @@ public class ArgParser {
                 exitStatus = SUCCESS;
                 return true;
             }
+            // Handle macOS CFBundleIdentifier request
+            if (hasFlag("-i", "--bundleid")) {
+                System.out.println(MacUtilities.getBundleId());
+                exitStatus = SUCCESS;
+                return true;
+            }
             // Handle cert installation
             String certFile;
             if ((certFile = valueOf("-a", "--whitelist")) != null) {

--- a/src/qz/utils/MacUtilities.java
+++ b/src/qz/utils/MacUtilities.java
@@ -33,6 +33,7 @@ public class MacUtilities {
     private static final Logger log = LoggerFactory.getLogger(IconCache.class);
     private static Dialog aboutDialog;
     private static TrayManager trayManager;
+    private static String bundleId;
 
     public static void showAboutDialog() {
         if (aboutDialog != null) { aboutDialog.setVisible(true); }
@@ -54,6 +55,24 @@ public class MacUtilities {
         catch(Exception e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Calculates CFBundleIdentifier for macOS
+     * @return
+     */
+    public static String getBundleId() {
+        if(bundleId == null) {
+            String[] parts = Constants.ABOUT_URL.split("/");
+            if(Constants.ABOUT_URL.endsWith("/")) {
+                // Handle trailing backslash
+                parts = parts[parts.length - 2].split("\\.");
+            } else {
+                parts = parts[parts.length - 1].split("\\.");
+            }
+            bundleId = parts[1] + "." + parts[0] + "." + Constants.PROPS_FILE;
+        }
+        return bundleId;
     }
 
     /**


### PR DESCRIPTION
* Adds [CFBundleIdentifier](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier) to Info.plist
* Removes Nashorn engine warning (moved from ant to Java via #504 but never removed)

Related: https://github.com/mozilla/policy-templates/issues/532

Closes #561 