### PR TITLE
HTML snapshot fixes

### DIFF
--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -594,9 +594,8 @@ public class TrayManager {
         }
     }
 
-    public boolean isMonocleAllowed() {
-        boolean useMonocle = prefs.getBoolean(monocleKey, true);
-        return useMonocle && Constants.JAVA_VERSION.greaterThanOrEqualTo(Version.valueOf("11.0.0"));
+    public boolean isMonoclePreferred() {
+       return prefs.getBoolean(monocleKey, true);
     }
 
 }

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -9,10 +9,8 @@ import javafx.beans.value.ObservableValue;
 import javafx.concurrent.Worker;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Scene;
-import javafx.scene.SnapshotResult;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import javafx.util.Callback;
 import org.joor.Reflect;
 import org.joor.ReflectException;
 import org.slf4j.Logger;
@@ -116,23 +114,7 @@ public class WebApp extends Application {
                                     log.debug("Attempting image capture");
 
                                     try {
-                                        webView.snapshot(new Callback<SnapshotResult,Void>() {
-                                            @Override
-                                            public Void call(SnapshotResult snapshotResult) {
-                                                try {
-                                                    capture.set(SwingFXUtils.fromFXImage(snapshotResult.getImage(), null));
-                                                }
-                                                catch(Exception e) {
-                                                    log.error("Caught during callback");
-                                                    thrown.set(e);
-                                                }
-                                                finally {
-                                                    unlatch();
-                                                }
-
-                                                return null;
-                                            }
-                                        }, null, null);
+                                        capture.set(SwingFXUtils.fromFXImage(webView.snapshot(null, null), null));
 
                                         //stop timer after snapshot
                                         stop();
@@ -140,6 +122,8 @@ public class WebApp extends Application {
                                     catch(Exception e) {
                                         log.error("Caught during snapshot");
                                         thrown.set(e);
+                                    }
+                                    finally {
                                         unlatch();
                                     }
                                 }

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -115,19 +115,33 @@ public class WebApp extends Application {
                                 if (++frames == 2) {
                                     log.debug("Attempting image capture");
 
+                                    try {
+                                        webView.snapshot(new Callback<SnapshotResult,Void>() {
+                                            @Override
+                                            public Void call(SnapshotResult snapshotResult) {
+                                                try {
+                                                    capture.set(SwingFXUtils.fromFXImage(snapshotResult.getImage(), null));
+                                                }
+                                                catch(Exception e) {
+                                                    log.error("Caught during callback");
+                                                    thrown.set(e);
+                                                }
+                                                finally {
+                                                    unlatch();
+                                                }
 
-                                    webView.snapshot(new Callback<SnapshotResult,Void>() {
-                                        @Override
-                                        public Void call(SnapshotResult snapshotResult) {
-                                            capture.set(SwingFXUtils.fromFXImage(snapshotResult.getImage(), null));
-                                            unlatch();
+                                                return null;
+                                            }
+                                        }, null, null);
 
-                                            return null;
-                                        }
-                                    }, null, null);
-
-                                    //stop timer after snapshot
-                                    stop();
+                                        //stop timer after snapshot
+                                        stop();
+                                    }
+                                    catch(Exception e) {
+                                        log.error("Caught during snapshot");
+                                        thrown.set(e);
+                                        unlatch();
+                                    }
                                 }
                             }
                         }.start();

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -165,21 +165,26 @@ public class WebApp extends Application {
         if (instance == null) {
             startupLatch = new CountDownLatch(1);
 
-            // JavaFX native libs
-            if (SystemUtilities.isJar() && Constants.JAVA_VERSION.greaterThanOrEqualTo(Version.valueOf("11.0.0"))) {
-                System.setProperty("java.library.path", new File(DeployUtilities.detectJarPath()).getParent() + "/libs/");
-            }
+            // JDK11+ depends bundled javafx
+            if(Constants.JAVA_VERSION.greaterThanOrEqualTo(Version.valueOf("11.0.0"))) {
+                // JavaFX native libs
+                if (SystemUtilities.isJar()) {
+                    System.setProperty("java.library.path", new File(DeployUtilities.detectJarPath()).getParent() + "/libs/");
+                }
 
-            if (PrintSocketServer.getTrayManager().isMonocleAllowed()) {
-                log.trace("Initializing monocle platform");
+                // Monocle default for unit tests
+                boolean monocleDefault = true;
+                if (monocleDefault || PrintSocketServer.getTrayManager() != null && PrintSocketServer.getTrayManager().isMonoclePreferred()) {
+                    log.trace("Initializing monocle platform");
 
-                System.setProperty("javafx.platform", "monocle"); // Standard JDKs
-                System.setProperty("glass.platform", "Monocle"); // Headless JDKs
-                System.setProperty("monocle.platform", "Headless");
+                    System.setProperty("javafx.platform", "monocle"); // Standard JDKs
+                    System.setProperty("glass.platform", "Monocle"); // Headless JDKs
+                    System.setProperty("monocle.platform", "Headless");
 
-                //software rendering required headless environments
-                if (PrintSocketServer.isHeadless()) {
-                    System.setProperty("prism.order", "sw");
+                    //software rendering required headless environments
+                    if (PrintSocketServer.isHeadless()) {
+                        System.setProperty("prism.order", "sw");
+                    }
                 }
             }
 
@@ -196,6 +201,14 @@ public class WebApp extends Application {
 
                 if (!startupLatch.await(60, TimeUnit.SECONDS)) {
                     throw new IOException("JavaFX did not start");
+                } else {
+                    log.trace("Running a test snapshot to size the stage...");
+                    try {
+                        capture(new WebAppModel("<h1>startup</h1>", true, 0, 0, true, 2));
+                    }
+                    catch (Throwable t) {
+                        throw new IOException(t);
+                    }
                 }
             }
             catch(InterruptedException ignore) {}

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -173,8 +173,12 @@ public class WebApp extends Application {
                 }
 
                 // Monocle default for unit tests
-                boolean monocleDefault = true;
-                if (monocleDefault || PrintSocketServer.getTrayManager() != null && PrintSocketServer.getTrayManager().isMonoclePreferred()) {
+                boolean monoclePreferred = true;
+                if(PrintSocketServer.getTrayManager() != null) {
+                    // User preference, if available
+                    monoclePreferred = PrintSocketServer.getTrayManager().isMonoclePreferred();
+                }
+                if (monoclePreferred) {
                     log.trace("Initializing monocle platform");
 
                     System.setProperty("javafx.platform", "monocle"); // Standard JDKs

--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -173,12 +173,12 @@ public class WebApp extends Application {
                 }
 
                 // Monocle default for unit tests
-                boolean monoclePreferred = true;
+                boolean useMonocle = true;
                 if(PrintSocketServer.getTrayManager() != null) {
-                    // User preference, if available
-                    monoclePreferred = PrintSocketServer.getTrayManager().isMonoclePreferred();
+                    // Honor user override
+                    useMonocle = PrintSocketServer.getTrayManager().isMonoclePreferred();
                 }
-                if (monoclePreferred) {
+                if (useMonocle) {
                     log.trace("Initializing monocle platform");
 
                     System.setProperty("javafx.platform", "monocle"); // Standard JDKs


### PR DESCRIPTION
- Brings back the previous 2.0 behavior of 1x fallback when `WebView.snapshot(...)` throws NPE, closes #627 
- Calls `WebView.snapshot()` once on `initialize()` to prevent sizing issues on first capture, closes #547 