### PR TITLE
Firefox preemptive certificate install

### DIFF
--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -18,11 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import qz.auth.Certificate;
 import qz.auth.RequestState;
-import qz.installer.Installer;
 import qz.installer.certificate.firefox.FirefoxCertificateInstaller;
-import qz.installer.certificate.firefox.locator.AppAlias;
-import qz.installer.certificate.firefox.locator.AppInfo;
-import qz.installer.certificate.firefox.locator.AppLocator;
 import qz.installer.shortcut.ShortcutCreator;
 import qz.ui.*;
 import qz.ui.component.IconCache;
@@ -37,7 +33,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -156,48 +151,15 @@ public class TrayManager {
             confirmDialog = new ConfirmDialog(null, "Please Confirm", iconCache);
             componentList.add(confirmDialog);
 
-            // Detect missing Firefox certs on Windows
-            if(SystemUtilities.isWindows()) {
-                new Thread(() -> {
-                    while(true) {
-                        try {
-                            Thread.sleep(5000);
-                            ArrayList<AppInfo> appList = AppLocator.getInstance().locate(AppAlias.FIREFOX);
-                            ArrayList<AppInfo> missingPolicy = new ArrayList();
-                            for(AppInfo appInfo : appList) {
-                                log.info("Checking {}...", appInfo.getName());
-                                // WARNING: If the JSON policy is expanded in the future, this check may wrongly fail!
-                                if (FirefoxCertificateInstaller.honorsPolicy(appInfo) && !FirefoxCertificateInstaller.hasPolicy(appInfo)) {
-                                    log.warn("Firefox policy for {} ({}) is missing!", appInfo.getName(), appInfo.getPath());
-                                    missingPolicy.add(appInfo);
-                                }
-                            }
-
-                            ArrayList<Path> processPaths = null;
-                            for(AppInfo appInfo : missingPolicy) {
-                                // Install alt policy
-                                FirefoxCertificateInstaller.installAltPolicy(appInfo);
-
-                                // Issue restart warning FIXME: Fix redundancies with FirefoxCertificateInstaller
-                                if (appInfo.getVersion().greaterThanOrEqualTo(FirefoxCertificateInstaller.FIREFOX_RESTART_VERSION)) {
-                                    if (processPaths == null) {
-                                        processPaths = AppLocator.getRunningPaths(appList);
-                                    }
-                                    if (processPaths.contains(appInfo.getExePath())) {
-                                        try {
-                                            Installer.getInstance().spawn(appInfo.getExePath().toString(), "-private", "about:restartrequired");
-                                        }
-                                        catch(Exception ignore) {}
-                                    }
-                                } else {
-                                    log.warn("{} must be restarted for changes to take effect", appInfo.getName());
-                                }
-
-                            }
-                        } catch(InterruptedException ignore) {}
-                    }
-                }).start();
-            }
+            // Detect missing Firefox certs
+            new Thread(() -> {
+                while(true) {
+                    try {
+                        Thread.sleep(30000);
+                        FirefoxCertificateInstaller.fixMissingPolicies();
+                    } catch(InterruptedException ignore) {}
+                }
+            }).start();
 
             // Detect theme changes
             new Thread(() -> {

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -151,16 +151,6 @@ public class TrayManager {
             confirmDialog = new ConfirmDialog(null, "Please Confirm", iconCache);
             componentList.add(confirmDialog);
 
-            // Detect missing Firefox certs
-            new Thread(() -> {
-                while(true) {
-                    try {
-                        Thread.sleep(30000);
-                        FirefoxCertificateInstaller.fixMissingPolicies();
-                    } catch(InterruptedException ignore) {}
-                }
-            }).start();
-
             // Detect theme changes
             new Thread(() -> {
                 boolean darkDesktopMode = SystemUtilities.isDarkDesktop();

--- a/src/qz/installer/certificate/firefox/ConflictingPolicyException.java
+++ b/src/qz/installer/certificate/firefox/ConflictingPolicyException.java
@@ -1,0 +1,7 @@
+package qz.installer.certificate.firefox;
+
+class ConflictingPolicyException extends Exception {
+    ConflictingPolicyException(String message) {
+        super(message);
+    }
+}

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -65,7 +65,7 @@ public class FirefoxCertificateInstaller {
         for(AppAlias.Alias alias : AppAlias.FIREFOX.getAliases()) {
             try {
                 if(alias.isEnterpriseReady() && !hasEnterprisePolicy(alias, false)) {
-                    log.info("Installing Firefox auto-config script for {}", alias);
+                    log.info("Installing Firefox enterprise certificate policy for {}", alias);
                     if (!installEnterprisePolicy(alias, false)) {
                         log.warn("Unable to install {} enterprise cert support. We'll fallback on the distribution policy instead", alias.getName());
                         enterpriseFailed.add(alias);

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -226,7 +226,7 @@ public class FirefoxCertificateInstaller {
         if(SystemUtilities.isWindows()) {
             String key = String.format("Software\\Policies\\%s\\%s\\Certificates", alias.getVendor(), alias.getName(true));;
             WindowsUtilities.addRegValue(userOnly ? WinReg.HKEY_CURRENT_USER : WinReg.HKEY_LOCAL_MACHINE, key, "Comment", POLICY_AUDIT_MESSAGE);
-            return WindowsUtilities.addRegValue(WinReg.HKEY_CURRENT_USER, key, "ImportEnterpriseRoots", 1);
+            return WindowsUtilities.addRegValue(userOnly ? WinReg.HKEY_CURRENT_USER : WinReg.HKEY_LOCAL_MACHINE, key, "ImportEnterpriseRoots", 1);
         } else if(SystemUtilities.isMac()) {
             String policyLocation = "/Library/Preferences/";
             if(userOnly) {

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -70,10 +70,9 @@ public class FirefoxCertificateInstaller {
                     success = installEnterprisePolicy(alias, false);
                 }
             } catch(ConflictingPolicyException e) {
-                log.warn("Conflict found installing {} enterprise cert support.", e);
+                log.warn("Conflict found installing {} enterprise cert support.  We'll fallback on the distribution policy instead", alias.getName(), e);
             }
             if(!success) {
-                log.warn("Unable to install {} enterprise cert support. We'll fallback on the distribution policy instead", alias.getName());
                 enterpriseFailed.add(alias);
             }
         }

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -240,8 +240,8 @@ public class FirefoxCertificateInstaller {
     }
 
     public static boolean issueRestartWarning(ArrayList<Path> runningPaths, AppInfo appInfo) {
-        if (appInfo.getVersion().greaterThanOrEqualTo(FirefoxCertificateInstaller.FIREFOX_RESTART_VERSION)) {
-            if (runningPaths.contains(appInfo.getExePath())) {
+        if (runningPaths.contains(appInfo.getExePath())) {
+            if (appInfo.getVersion().greaterThanOrEqualTo(FirefoxCertificateInstaller.FIREFOX_RESTART_VERSION)) {
                 try {
                     Installer.getInstance().spawn(appInfo.getExePath().toString(), "-private", "about:restartrequired");
                     return true;

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -91,7 +91,7 @@ public class FirefoxCertificateInstaller {
                     success = installDistributionPolicy(appInfo, cert);
                 }
             } else {
-                log.info("Installing Firefox auto-config script for", appInfo);
+                log.info("Installing Firefox auto-config script for {}", appInfo);
                 try {
                     String certData = Base64.getEncoder().encodeToString(cert.getEncoded());
                     success = LegacyFirefoxCertificateInstaller.installAutoConfigScript(appInfo, certData, hostNames);

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -63,16 +63,17 @@ public class FirefoxCertificateInstaller {
         // Blindly install Firefox enterprise policies to the system (macOS, Windows)
         ArrayList<AppAlias.Alias> enterpriseFailed = new ArrayList<>();
         for(AppAlias.Alias alias : AppAlias.FIREFOX.getAliases()) {
+            boolean success = false;
             try {
                 if(alias.isEnterpriseReady() && !hasEnterprisePolicy(alias, false)) {
                     log.info("Installing Firefox enterprise certificate policy for {}", alias);
-                    if (!installEnterprisePolicy(alias, false)) {
-                        log.warn("Unable to install {} enterprise cert support. We'll fallback on the distribution policy instead", alias.getName());
-                        enterpriseFailed.add(alias);
-                    }
+                    success = installEnterprisePolicy(alias, false);
                 }
             } catch(ConflictingPolicyException e) {
-                log.warn("Conflict found installing {} enterprise cert support.  We'll fallback on the distribution policy instead", alias.getName(), e);
+                log.warn("Conflict found installing {} enterprise cert support.", e);
+            }
+            if(!success) {
+                log.warn("Unable to install {} enterprise cert support. We'll fallback on the distribution policy instead", alias.getName());
                 enterpriseFailed.add(alias);
             }
         }

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -247,9 +247,9 @@ public class FirefoxCertificateInstaller {
                     return true;
                 }
                 catch(Exception ignore) {}
+            } else {
+                log.warn("{} must be restarted manually for changes to take effect", appInfo);
             }
-        } else {
-            log.warn("{} must be restarted manually for changes to take effect", appInfo);
         }
         return false;
     }

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -161,9 +161,9 @@ public class FirefoxCertificateInstaller {
             }
             String policesEnabled = ShellUtilities.executeRaw(new String[] { "defaults", "read", policyLocation + alias.getBundleId(), "EnterprisePoliciesEnabled"}, true);
             String foundPolicy = ShellUtilities.executeRaw(new String[] {"defaults", "read", policyLocation + alias.getBundleId(), "Certificates"}, true);
-            if(policesEnabled != null && foundPolicy != null) {
+            if(!policesEnabled.isEmpty() && !foundPolicy.isEmpty()) {
                 // Policies exist, decide how to proceed
-                if(policesEnabled.equals("1") && foundPolicy.contains("ImportEnterpriseRoots = 1;")) {
+                if(policesEnabled.trim().equals("1") && foundPolicy.contains("ImportEnterpriseRoots = 1;")) {
                     return true;
                 }
                 throw new ConflictingPolicyException(String.format("%s enterprise policy conflict at %s: %s", alias.getName(), policyLocation + alias.getBundleId(), foundPolicy));

--- a/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/FirefoxCertificateInstaller.java
@@ -65,6 +65,7 @@ public class FirefoxCertificateInstaller {
         for(AppAlias.Alias alias : AppAlias.FIREFOX.getAliases()) {
             try {
                 if(alias.isEnterpriseReady() && !hasEnterprisePolicy(alias, false)) {
+                    log.info("Installing Firefox auto-config script for {}", alias);
                     if (!installEnterprisePolicy(alias, false)) {
                         log.warn("Unable to install {} enterprise cert support. We'll fallback on the distribution policy instead", alias.getName());
                         enterpriseFailed.add(alias);

--- a/src/qz/installer/certificate/firefox/LegacyFirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/LegacyFirefoxCertificateInstaller.java
@@ -37,13 +37,13 @@ public class LegacyFirefoxCertificateInstaller {
     private static final String PREFS_DIR = "defaults/pref";
     private static final String MAC_PREFIX = "Contents/Resources";
 
-    public static boolean installAutoConfigScript(AppInfo app, String certData, String ... hostNames) {
+    public static boolean installAutoConfigScript(AppInfo appInfo, String certData, String ... hostNames) {
         try {
-            writePrefsFile(app);
-            writeParsedConfig(app, certData, false, hostNames);
+            writePrefsFile(appInfo);
+            writeParsedConfig(appInfo, certData, false, hostNames);
             return true;
         } catch(Exception e) {
-            log.warn("Error installing auto-config support for {}", app.getName(), e);
+            log.warn("Error installing auto-config support for {}", appInfo, e);
         }
         return false;
     }
@@ -53,7 +53,7 @@ public class LegacyFirefoxCertificateInstaller {
             writeParsedConfig(appInfo, "", true);
             return true;
         } catch(Exception e) {
-            log.warn("Error uninstalling auto-config support for {}", appInfo.getName(), e);
+            log.warn("Error uninstalling auto-config support for {}", appInfo, e);
         }
         return false;
     }

--- a/src/qz/installer/certificate/firefox/LegacyFirefoxCertificateInstaller.java
+++ b/src/qz/installer/certificate/firefox/LegacyFirefoxCertificateInstaller.java
@@ -37,21 +37,25 @@ public class LegacyFirefoxCertificateInstaller {
     private static final String PREFS_DIR = "defaults/pref";
     private static final String MAC_PREFIX = "Contents/Resources";
 
-    public static void installAutoConfigScript(AppInfo app, String certData, String ... hostNames) {
+    public static boolean installAutoConfigScript(AppInfo app, String certData, String ... hostNames) {
         try {
             writePrefsFile(app);
             writeParsedConfig(app, certData, false, hostNames);
+            return true;
         } catch(Exception e) {
             log.warn("Error installing auto-config support for {}", app.getName(), e);
         }
+        return false;
     }
 
-    public static void uninstallAutoConfigScript(AppInfo appInfo) {
+    public static boolean uninstallAutoConfigScript(AppInfo appInfo) {
         try {
             writeParsedConfig(appInfo, "", true);
+            return true;
         } catch(Exception e) {
             log.warn("Error uninstalling auto-config support for {}", appInfo.getName(), e);
         }
+        return false;
     }
 
     public static File tryWrite(AppInfo appInfo, boolean mkdirs, String ... paths) throws IOException {

--- a/src/qz/installer/certificate/firefox/locator/AppAlias.java
+++ b/src/qz/installer/certificate/firefox/locator/AppAlias.java
@@ -6,7 +6,7 @@ public enum AppAlias {
     // Tor Browser intentionally excluded; Tor's proxy blocks localhost connections
     FIREFOX(
             // Alias([Vendor], Name)
-            new Alias("Firefox", null, "org.mozilla.firefox"), // macOS, Linux
+            new Alias(null, "Firefox", "org.mozilla.firefox"), // macOS, Linux
             new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox"), // Windows
             new Alias("Mozilla", "SeaMonkey", "org.mozilla.seamonkey"),
             new Alias("Waterfox", "Waterfox", "net.waterfox.waterfoxcurrent"),

--- a/src/qz/installer/certificate/firefox/locator/AppAlias.java
+++ b/src/qz/installer/certificate/firefox/locator/AppAlias.java
@@ -6,12 +6,12 @@ public enum AppAlias {
     // Tor Browser intentionally excluded; Tor's proxy blocks localhost connections
     FIREFOX(
             // Alias([Vendor], Name)
-            new Alias("Firefox"), // macOS, Linux
-            new Alias("Mozilla", "Mozilla Firefox"), // Windows
-            new Alias("Mozilla", "SeaMonkey"),
-            new Alias("Mozilla", "Waterfox"),
-            new Alias("Mozilla", "Pale Moon"),
-            new Alias("Mozilla", "IceCat")
+            new Alias("Firefox", null, "org.mozilla.firefox"), // macOS, Linux
+            new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox"), // Windows
+            new Alias("Mozilla", "SeaMonkey", "org.mozilla.seamonkey"),
+            new Alias("Waterfox", "Waterfox", "net.waterfox.waterfoxcurrent"),
+            new Alias("Mozilla", "Pale Moon", "org.mozilla.palemoon"),
+            new Alias("Mozilla", "IceCat", "org.gnu.icecat")
     );
     Alias[] aliases;
     AppAlias(Alias... aliases) {
@@ -22,10 +22,11 @@ public enum AppAlias {
         return aliases;
     }
 
-    public boolean matches(AppInfo appInfo) {
+    public boolean setBundleId(AppInfo appInfo) {
         if (appInfo.getName() != null && !appInfo.isBlacklisted()) {
             for (Alias alias : aliases) {
                 if (appInfo.getName().toLowerCase(Locale.ENGLISH).matches(alias.name.toLowerCase(Locale.ENGLISH))) {
+                    appInfo.setBundleId(alias.bundleId);
                     return true;
                 }
             }
@@ -36,14 +37,14 @@ public enum AppAlias {
     public static class Alias {
         public String vendor;
         public String name;
+        public String bundleId;
         public String posix;
-        public Alias(String name) {
+
+        public Alias(String vendor, String name, String bundleId) {
             this.name = name;
             this.posix = name.replaceAll(" ", "").toLowerCase(Locale.ENGLISH);
-        }
-        public Alias(String vendor, String name) {
-            this(name);
             this.vendor = vendor;
+            this.bundleId = bundleId;
         }
     }
 }

--- a/src/qz/installer/certificate/firefox/locator/AppInfo.java
+++ b/src/qz/installer/certificate/firefox/locator/AppInfo.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
  */
 public class AppInfo {
     String name;
+    String vendor;
+    String bundleId; // macOS only
     Path path;
     Path exePath;
     Version version;
@@ -16,15 +18,17 @@ public class AppInfo {
 
     public AppInfo() {}
 
-    public AppInfo(String name, Path exePath, String version) {
+    public AppInfo(String name, String vendor, Path exePath, String version) {
         this.name = name;
+        this.vendor = vendor;
         this.path = exePath.getParent();
         this.exePath = exePath;
         this.version = parseVersion(version);
     }
 
-    public AppInfo(String name, Path exePath) {
+    public AppInfo(String name, String vendor, Path exePath) {
         this.name = name;
+        this.vendor = vendor;
         this.path = exePath.getParent();
         this.exePath = exePath;
     }
@@ -33,8 +37,34 @@ public class AppInfo {
         return name;
     }
 
+    /**
+     * Remove vendor prefix
+     */
+    public String getVendorlessName() {
+        if(name.startsWith(vendor)) {
+           return name.substring(name.indexOf(vendor)).trim();
+        }
+        return name;
+    }
+
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getVendor() {
+        return vendor;
+    }
+
+    public void setVendor(String vendor) {
+        this.vendor = vendor;
+    }
+
+    public String getBundleId() {
+        return bundleId;
+    }
+
+    public void setBundleId(String bundleId) {
+        this.bundleId = bundleId;
     }
 
     public Path getExePath() {

--- a/src/qz/installer/certificate/firefox/locator/AppInfo.java
+++ b/src/qz/installer/certificate/firefox/locator/AppInfo.java
@@ -3,76 +3,47 @@ package qz.installer.certificate.firefox.locator;
 import com.github.zafarkhaja.semver.Version;
 
 import java.nio.file.Path;
+import qz.installer.certificate.firefox.locator.AppAlias.Alias;
 
 /**
  * Container class for installed app information
  */
 public class AppInfo {
-    String name;
-    String vendor;
-    String bundleId; // macOS only
-    Path path;
-    Path exePath;
-    Version version;
-    boolean isBlacklisted = false;
+    private AppAlias.Alias alias;
+    private Path path;
+    private Path exePath;
+    private Version version;
 
-    public AppInfo() {}
-
-    public AppInfo(String name, String vendor, Path exePath, String version) {
-        this.name = name;
-        this.vendor = vendor;
+    public AppInfo(Alias alias, Path exePath, String version) {
+        this.alias = alias;
         this.path = exePath.getParent();
         this.exePath = exePath;
         this.version = parseVersion(version);
     }
 
-    public AppInfo(String name, String vendor, Path exePath) {
-        this.name = name;
-        this.vendor = vendor;
+    public AppInfo(Alias alias, Path path, Path exePath, String version) {
+        this.alias = alias;
+        this.path = path;
+        this.exePath = exePath;
+        this.version = parseVersion(version);
+    }
+
+    public AppInfo(Alias alias, Path exePath) {
+        this.alias = alias;
         this.path = exePath.getParent();
         this.exePath = exePath;
     }
 
-    public String getName() {
-        return name;
+    public Alias getAlias() {
+        return alias;
     }
 
-    /**
-     * Remove vendor prefix if exists
-     */
     public String getName(boolean stripVendor) {
-        if(stripVendor && name.startsWith(vendor)) {
-           return name.substring(vendor.length()).trim();
-        }
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getVendor() {
-        return vendor;
-    }
-
-    public void setVendor(String vendor) {
-        this.vendor = vendor;
-    }
-
-    public String getBundleId() {
-        return bundleId;
-    }
-
-    public void setBundleId(String bundleId) {
-        this.bundleId = bundleId;
+        return alias.getName(stripVendor);
     }
 
     public Path getExePath() {
         return exePath;
-    }
-
-    public void setExePath(Path exePath) {
-        this.exePath = exePath;
     }
 
     public Path getPath() {
@@ -95,32 +66,27 @@ public class AppInfo {
         this.version = version;
     }
 
-    public boolean isBlacklisted() {
-        return isBlacklisted;
-    }
-
-    public void setBlacklisted(boolean blacklisted) {
-        isBlacklisted = blacklisted;
-    }
-
     private static Version parseVersion(String version) {
         try {
             // Ensure < 3 octets (e.g. "56.0") doesn't failing
             while(version.split("\\.").length < 3) {
                 version = version + ".0";
             }
-            if (version != null) {
-                return Version.valueOf(version);
-            }
+            return Version.valueOf(version);
         } catch(Exception ignore) {}
         return null;
     }
 
     @Override
     public boolean equals(Object o) {
-        if(o instanceof AppLocator && o != null && path != null) {
+        if(o instanceof AppInfo && o != null && path != null) {
             return path.equals(((AppInfo)o).getPath());
         }
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return alias + " " + path;
     }
 }

--- a/src/qz/installer/certificate/firefox/locator/AppInfo.java
+++ b/src/qz/installer/certificate/firefox/locator/AppInfo.java
@@ -38,11 +38,11 @@ public class AppInfo {
     }
 
     /**
-     * Remove vendor prefix
+     * Remove vendor prefix if exists
      */
-    public String getVendorlessName() {
-        if(name.startsWith(vendor)) {
-           return name.substring(name.indexOf(vendor)).trim();
+    public String getName(boolean stripVendor) {
+        if(stripVendor && name.startsWith(vendor)) {
+           return name.substring(vendor.length()).trim();
         }
         return name;
     }

--- a/src/qz/installer/certificate/firefox/locator/AppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/AppLocator.java
@@ -43,13 +43,24 @@ public abstract class AppLocator {
     }
 
     public static ArrayList<Path> getRunningPaths(ArrayList<AppInfo> appList) {
-        ArrayList<String> appNames = new ArrayList<>();
-        for (AppInfo app : appList) {
-            String exeName = app.getExePath().getFileName().toString();
-            if (!appNames.contains(exeName)) appNames.add(exeName);
+        return getRunningPaths(appList, null);
+    }
+
+    /**
+     * Gets the path to the running executables matching on <code>AppInfo.getExePath</code>
+     * This is resource intensive; if a non-null <code>cache</code> is provided, it will return that instead
+     */
+    public static ArrayList<Path> getRunningPaths(ArrayList<AppInfo> appList, ArrayList<Path> cache) {
+        if(cache == null) {
+            ArrayList<String> appNames = new ArrayList<>();
+            for(AppInfo app : appList) {
+                String exeName = app.getExePath().getFileName().toString();
+                if (!appNames.contains(exeName)) appNames.add(exeName);
+            }
+            cache = INSTANCE.getPidPaths(INSTANCE.getPids(appNames));
         }
 
-        return INSTANCE.getPidPaths(INSTANCE.getPids(appNames));
+        return cache;
     }
 
     public static AppLocator getInstance() {

--- a/src/qz/installer/certificate/firefox/locator/LinuxAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/LinuxAppLocator.java
@@ -67,7 +67,7 @@ public class LinuxAppLocator extends AppLocator {
                         } else {
                             log.info("Assuming {} {} is installed: {}", alias.vendor, alias.name, file);
                         }
-                        AppInfo appInfo = new AppInfo(alias.name, file.toPath());
+                        AppInfo appInfo = new AppInfo(alias.name, alias.vendor, file.toPath());
                         appList.add(appInfo);
 
                         // Call "--version" on executable to obtain version information

--- a/src/qz/installer/certificate/firefox/locator/LinuxAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/LinuxAppLocator.java
@@ -25,10 +25,10 @@ public class LinuxAppLocator extends AppLocator {
         for(AppAlias.Alias alias : appAlias.aliases) {
 
             // Add non-standard app search locations (e.g. Fedora)
-            for (String dirname : appendPaths(alias.posix, "/usr/lib/$/bin", "/usr/lib64/$/bin")) {
-                Path path = Paths.get(dirname, alias.posix);
+            for (String dirname : appendPaths(alias.getPosix(), "/usr/lib/$/bin", "/usr/lib64/$/bin")) {
+                Path path = Paths.get(dirname, alias.getPosix());
                 if (Files.isRegularFile(path) && Files.isExecutable(path)) {
-                    log.info("Found {} {}: {}, investigating...", alias.vendor, alias.name, path);
+                    log.info("Found {} {}: {}, investigating...", alias.getVendor(), alias.getName(true), path);
                     try {
                         File file = path.toFile().getCanonicalFile(); // fix symlinks
                         String contentType = Files.probeContentType(file.toPath());
@@ -42,7 +42,7 @@ public class LinuxAppLocator extends AppLocator {
                             BufferedReader reader = new BufferedReader(new FileReader(file));
                             String line;
                             while((line = reader.readLine()) != null) {
-                                if(line.startsWith("exec") && line.contains(alias.posix)) {
+                                if(line.startsWith("exec") && line.contains(alias.getPosix())) {
                                     String[] parts = line.split(" ");
                                     // Get the app name after "exec"
                                     if (parts.length > 1) {
@@ -65,9 +65,9 @@ public class LinuxAppLocator extends AppLocator {
                                 }
                             }
                         } else {
-                            log.info("Assuming {} {} is installed: {}", alias.vendor, alias.name, file);
+                            log.info("Assuming {} {} is installed: {}", alias.getVendor(), alias.getName(true), file);
                         }
-                        AppInfo appInfo = new AppInfo(alias.name, alias.vendor, file.toPath());
+                        AppInfo appInfo = new AppInfo(alias, file.toPath());
                         appList.add(appInfo);
 
                         // Call "--version" on executable to obtain version information
@@ -92,7 +92,7 @@ public class LinuxAppLocator extends AppLocator {
                         }
                         break;
                     } catch(Exception e) {
-                        log.warn("Something went wrong getting app info for {} {}", alias.vendor, alias.name, e);
+                        log.warn("Something went wrong getting app info for {} {}", alias.getVendor(), alias.getName(true), e);
                     }
                 }
             }

--- a/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.regex.Pattern;
+import java.util.Iterator;
 
 public class MacAppLocator extends AppLocator{
     protected static final Logger log = LoggerFactory.getLogger(MacAppLocator.class);
@@ -94,10 +94,12 @@ public class MacAppLocator extends AppLocator{
         }
 
         // Remove blacklisted paths
-        for(AppInfo appInfo : appList) {
+        Iterator<AppInfo> appInfoIterator = appList.iterator();
+        while(appInfoIterator.hasNext()) {
+            AppInfo appInfo = appInfoIterator.next();
             for(String listEntry : BLACKLISTED_PATHS) {
-                if (appInfo.getPath() != null && appInfo.getPath().toString().matches(Pattern.quote(listEntry))) {
-                    appList.remove(appInfo);
+                if (appInfo.getPath() != null && appInfo.getPath().toString().contains(listEntry)) {
+                    appInfoIterator.remove();
                 }
             }
         }

--- a/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
@@ -15,12 +15,10 @@ import qz.utils.ShellUtilities;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.regex.Pattern;
 
 public class MacAppLocator extends AppLocator{
@@ -95,7 +93,7 @@ public class MacAppLocator extends AppLocator{
                     }
                 }
             }
-            if (appAlias.matches(appInfo)) {
+            if (appAlias.setBundleId(appInfo)) {
                 appList.add(appInfo);
             }
         }

--- a/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/MacAppLocator.java
@@ -19,12 +19,13 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.regex.Pattern;
 
 public class MacAppLocator extends AppLocator{
     protected static final Logger log = LoggerFactory.getLogger(MacAppLocator.class);
 
-    private static String[] BLACKLIST = new String[]{ "/Volumes/", "/.Trash/", "/Applications (Parallels)/" };
+    private static String[] BLACKLISTED_PATHS = new String[]{"/Volumes/", "/.Trash/", "/Applications (Parallels)/" };
 
     /**
      * Helper class for finding key/value siblings from the DDM
@@ -44,20 +45,9 @@ public class MacAppLocator extends AppLocator{
 
         private boolean isKey(Node node) {
             if (node.getNodeName().equals("key") && node.getTextContent().equals(key)) {
-                this.wants = true;
                 return true;
             }
             return false;
-        }
-
-        private void set(Node node, AppInfo info) {
-            switch(this) {
-                case NAME: info.setName(node.getTextContent()); break;
-                case PATH: info.setPath(Paths.get(node.getTextContent())); break;
-                case VERSION: info.setVersion(node.getTextContent()); break;
-                default: throw new UnsupportedOperationException(this.name() + " not supported");
-            }
-            wants = false;
         }
     }
 
@@ -79,34 +69,37 @@ public class MacAppLocator extends AppLocator{
         NodeList nodeList = doc.getElementsByTagName("dict");
         for (int i = 0; i < nodeList.getLength(); i++) {
             NodeList dict = nodeList.item(i).getChildNodes();
-            AppInfo appInfo = new AppInfo();
+            HashMap<SiblingNode, String> foundApp = new HashMap<>();
             for (int j = 0; j < dict.getLength(); j++) {
                 Node node = dict.item(j);
                 if (node.getNodeType() == Node.ELEMENT_NODE) {
                     for (SiblingNode sibling : SiblingNode.values()) {
                         if (sibling.wants) {
-                            sibling.set(node, appInfo);
+                            foundApp.put(sibling, node.getTextContent());
+                            sibling.wants = false;
                             break;
                         } else if(sibling.isKey(node)) {
+                            sibling.wants = true;
                             break;
                         }
                     }
                 }
             }
-            if (appAlias.setBundleId(appInfo)) {
-                appList.add(appInfo);
+            AppAlias.Alias alias;
+            if((alias = AppAlias.findAlias(appAlias, foundApp.get(SiblingNode.NAME), true)) != null) {
+                appList.add(new AppInfo(alias, Paths.get(foundApp.get(SiblingNode.PATH)),
+                        getExePath(foundApp.get(SiblingNode.PATH)), foundApp.get(SiblingNode.VERSION)
+                ));
             }
         }
 
+        // Remove blacklisted paths
         for(AppInfo appInfo : appList) {
-            // Mark blacklisted locations
-            for(String listEntry : BLACKLIST) {
+            for(String listEntry : BLACKLISTED_PATHS) {
                 if (appInfo.getPath() != null && appInfo.getPath().toString().matches(Pattern.quote(listEntry))) {
-                    appInfo.setBlacklisted(true);
+                    appList.remove(appInfo);
                 }
             }
-            // Calculate exePath
-            appInfo.setExePath(getExePath(appInfo));
         }
         return appList;
     }
@@ -125,19 +118,20 @@ public class MacAppLocator extends AppLocator{
     /**
      * Calculate executable path by parsing Contents/Info.plist
      */
-    private static Path getExePath(AppInfo appInfo) {
-        Path plist = appInfo.getPath().resolve("Contents/Info.plist");
+    private static Path getExePath(String appPath) {
+        Path path = Paths.get(appPath);
+        Path plist = path.resolve("Contents/Info.plist");
         Document doc;
         try {
             if(!plist.toFile().exists()) {
-                log.warn("Could not locate plist file for {}: {}",  appInfo.getName(), plist);
+                log.warn("Could not locate plist file for {}: {}",  appPath, plist);
                 return null;
             }
             // Convert potentially binary plist files to XML
             Process p = Runtime.getRuntime().exec(new String[] {"plutil", "-convert", "xml1", plist.toAbsolutePath().toString(), "-o", "-"}, ShellUtilities.envp);
             doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(p.getInputStream());
         } catch(IOException | ParserConfigurationException | SAXException e) {
-            log.warn("Could not parse plist file for {}: {}", appInfo.getName(), plist, e);
+            log.warn("Could not parse plist file for {}: {}", appPath, appPath, e);
             return null;
         }
         doc.normalizeDocument();
@@ -151,7 +145,7 @@ public class MacAppLocator extends AppLocator{
                 if ("key".equals(node.getNodeName()) && node.getTextContent().equals("CFBundleExecutable")) {
                     upNext = true;
                 } else if (upNext && "string".equals(node.getNodeName())) {
-                    return appInfo.getPath().resolve("Contents/MacOS/" + node.getTextContent());
+                    return path.resolve("Contents/MacOS/" + node.getTextContent());
                 }
             }
         }

--- a/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
@@ -47,7 +47,7 @@ public class WindowsAppLocator extends AppLocator{
                 for (String suffix : suffixes) {
                     for (String prefix : prefixes) {
                         String key = String.format(REG_TEMPLATE, prefix, alias.vendor, alias.name, suffix);
-                        AppInfo appInfo = getAppInfo(alias.name, key, suffix);
+                        AppInfo appInfo = getAppInfo(alias.name, alias.vendor, key, suffix);
                         if (appInfo != null && !appList.contains(appInfo)) {
                             appList.add(appInfo);
                         }
@@ -107,7 +107,7 @@ public class WindowsAppLocator extends AppLocator{
     /**
      * Use a proprietary Firefox-only technique for getting "PathToExe" registry value
      */
-    private static AppInfo getAppInfo(String name, String key, String suffix) {
+    private static AppInfo getAppInfo(String name, String vendor, String key, String suffix) {
         String version = WindowsUtilities.getRegString(HKEY_LOCAL_MACHINE, key, "CurrentVersion");
         if (version != null) {
             version = version.split(" ")[0]; // chop off (x86 ...)
@@ -122,7 +122,7 @@ public class WindowsAppLocator extends AppLocator{
             if (exePath != null) {
                 // SemVer: Replace spaces in suffixes with dashes
                 version = version.replaceAll(" ", "-");
-                return new AppInfo(name, exePath, version);
+                return new AppInfo(name, vendor, exePath, version);
             }
         }
         return null;

--- a/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
@@ -13,6 +13,7 @@ package qz.installer.certificate.firefox.locator;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qz.installer.certificate.firefox.locator.AppAlias.Alias;
 import qz.utils.ShellUtilities;
 import qz.utils.SystemUtilities;
 import qz.utils.WindowsUtilities;
@@ -40,14 +41,14 @@ public class WindowsAppLocator extends AppLocator{
     @Override
     public ArrayList<AppInfo> locate(AppAlias appAlias) {
         ArrayList<AppInfo> appList = new ArrayList<>();
-        for (AppAlias.Alias alias : appAlias.aliases) {
-            if (alias.vendor != null) {
+        for (Alias alias : appAlias.aliases) {
+            if (alias.getVendor() != null) {
                 String[] suffixes = new String[]{ "", " ESR"};
                 String[] prefixes = new String[]{ "", "WOW6432Node\\"};
                 for (String suffix : suffixes) {
                     for (String prefix : prefixes) {
-                        String key = String.format(REG_TEMPLATE, prefix, alias.vendor, alias.name, suffix);
-                        AppInfo appInfo = getAppInfo(alias.name, alias.vendor, key, suffix);
+                        String key = String.format(REG_TEMPLATE, prefix, alias.getVendor(), alias.getName(), suffix);
+                        AppInfo appInfo = getAppInfo(alias, key, suffix);
                         if (appInfo != null && !appList.contains(appInfo)) {
                             appList.add(appInfo);
                         }
@@ -107,7 +108,7 @@ public class WindowsAppLocator extends AppLocator{
     /**
      * Use a proprietary Firefox-only technique for getting "PathToExe" registry value
      */
-    private static AppInfo getAppInfo(String name, String vendor, String key, String suffix) {
+    private static AppInfo getAppInfo(Alias alias, String key, String suffix) {
         String version = WindowsUtilities.getRegString(HKEY_LOCAL_MACHINE, key, "CurrentVersion");
         if (version != null) {
             version = version.split(" ")[0]; // chop off (x86 ...)
@@ -122,7 +123,7 @@ public class WindowsAppLocator extends AppLocator{
             if (exePath != null) {
                 // SemVer: Replace spaces in suffixes with dashes
                 version = version.replaceAll(" ", "-");
-                return new AppInfo(name, vendor, exePath, version);
+                return new AppInfo(alias, exePath, version);
             }
         }
         return null;

--- a/src/qz/utils/JsonWriter.java
+++ b/src/qz/utils/JsonWriter.java
@@ -58,13 +58,7 @@ public class JsonWriter {
 
     public static boolean contains(File path, String data) {
         try {
-            if (!path.exists()) {
-                log.warn("Warning, {} does not exist, skipping.", path);
-                return false;
-            }
-
-            if (data == null && data.isEmpty()) {
-                log.warn("Data is null, nothing to validate against");
+            if (!path.exists() || (data == null && data.isEmpty())) {
                 return false;
             }
 

--- a/src/qz/utils/JsonWriter.java
+++ b/src/qz/utils/JsonWriter.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 
 /**
@@ -53,6 +54,28 @@ public class JsonWriter {
         FileUtils.write(f, config.toString(2));
 
         return true;
+    }
+
+    public static boolean contains(File path, String data) {
+        try {
+            if (!path.exists()) {
+                log.warn("Warning, {} does not exist, skipping.", path);
+                return false;
+            }
+
+            if (data == null && data.isEmpty()) {
+                log.warn("Data is null, nothing to validate against");
+                return false;
+            }
+
+            String jsonData = FileUtils.readFileToString(path, Charsets.UTF_8);
+            JSONObject before = new JSONObject(jsonData);
+            JSONObject after = new JSONObject(jsonData);
+            merge(after, new JSONObject(data), true);
+            return before.toString().equals(after.toString());
+        } catch(JSONException | IOException ignore) {
+            return false;
+        }
     }
 
     /**

--- a/src/qz/utils/ShellUtilities.java
+++ b/src/qz/utils/ShellUtilities.java
@@ -146,14 +146,21 @@ public class ShellUtilities {
         return "";
     }
 
+    public static String executeRaw(String ... commandArray) {
+        return executeRaw(commandArray, false);
+    }
+
     /**
      * Executes a synchronous shell command and return the raw character result.
      *
      * @param commandArray array of shell commands to execute
      * @return The entire raw standard output of command
      */
-    public static String executeRaw(String... commandArray) {
-        log.debug("Executing: {}", Arrays.toString(commandArray));
+    public static String executeRaw(String[] commandArray, boolean silent) {
+        if(!silent) {
+            log.debug("Executing: {}", Arrays.toString(commandArray));
+        }
+
         InputStreamReader in = null;
         try {
             Process p = Runtime.getRuntime().exec(commandArray, envp);
@@ -170,7 +177,9 @@ public class ShellUtilities {
             return out.toString();
         }
         catch(IOException ex) {
-            log.error("IOException executing: {} envp: {}", Arrays.toString(commandArray), Arrays.toString(envp), ex);
+            if(!silent) {
+                log.error("IOException executing: {} envp: {}", Arrays.toString(commandArray), Arrays.toString(envp), ex);
+            }
         }
         finally {
             if (in != null) {

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -79,6 +79,10 @@ public class SystemUtilities {
         return df.format(d);
     }
 
+    public static String timeStamp() {
+        return toISO(new Date());
+    }
+
     public static Version getOSVersion() {
         if (osVersion == null) {
             String version = System.getProperty("os.version");

--- a/test/qz/installer/browser/AppFinderTests.java
+++ b/test/qz/installer/browser/AppFinderTests.java
@@ -22,25 +22,19 @@ public class AppFinderTests {
     private static void runTest(AppAlias app) {
         Date begin = new Date();
         ArrayList<AppInfo> appList = AppLocator.getInstance().locate(app);
-        ArrayList<Path> processPaths = AppLocator.getRunningPaths(appList);
+        ArrayList<Path> runningPaths = AppLocator.getRunningPaths(appList);
 
         StringBuilder output = new StringBuilder("Found apps:\n");
         for (AppInfo appInfo : appList) {
             output.append(String.format("      name: '%s', path: '%s', exePath: '%s', version: '%s'\n",
-                                        appInfo.getName(),
+                                        appInfo.getAlias().getName(),
                                         appInfo.getPath(),
                                         appInfo.getExePath(),
                                         appInfo.getVersion()
             ));
 
-            if(processPaths.contains(appInfo.getExePath())) {
-                if (appInfo.getVersion().greaterThanOrEqualTo(FirefoxCertificateInstaller.FIREFOX_RESTART_VERSION)) {
-                    try {
-                        Installer.getInstance().spawn(appInfo.getExePath().toString(), "-private", "about:restartrequired");
-                        continue;
-                    } catch(Exception ignore) {}
-                }
-                log.warn("{} must be restarted for changes to take effect", appInfo.getName());
+            if(runningPaths.contains(appInfo.getExePath())) {
+                FirefoxCertificateInstaller.issueRestartWarning(runningPaths, appInfo);
             }
         }
 


### PR DESCRIPTION
Adds a preemptive system-wide policy (Group Policy area on Windows, `/Library/Preferences` on macOS) for Firefox to trust QZ Tray certificates.

Closes #697 