### PR TITLE
Initial support for --help option

### DIFF
--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -44,23 +44,6 @@ public abstract class Installer {
     // Silence prompts within our control
     public static boolean IS_SILENT =  "1".equals(System.getenv(PROPS_FILE + "_silent"));
 
-
-    public enum InstallType {
-        PREINSTALL(""),
-        INSTALL("install --dest /my/install/location [--silent]"),
-        CERTGEN("certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host \"list;of;hosts\""),
-        UNINSTALL(""),
-        SPAWN("spawn [params]");
-        public String usage;
-        InstallType(String usage) {
-            this.usage = usage;
-        }
-        @Override
-        public String toString() {
-            return name().toLowerCase(Locale.ENGLISH);
-        }
-    }
-
     public enum PrivilegeLevel {
         USER,
         SYSTEM

--- a/src/qz/utils/ArgParser.java
+++ b/src/qz/utils/ArgParser.java
@@ -44,6 +44,8 @@ public class ArgParser {
     }
 
     protected static final Logger log = LoggerFactory.getLogger(ArgParser.class);
+    private static final String USAGE_COMMAND = String.format("java -jar %s.jar", PROPS_FILE);
+
     private List<String> args;
     private ExitStatus exitStatus;
 
@@ -164,7 +166,7 @@ public class ArgParser {
                     throw new UnsupportedOperationException("Installation type " + argValue + " is not yet supported");
             }
         } catch(MissingArgException e) {
-            log.error("Valid usage:\n   java -jar {}.jar {}", PROPS_FILE, argValue.getUsage());
+            log.error("Valid usage:\n   {} {}", USAGE_COMMAND, argValue.getUsage());
             return USAGE_ERROR;
         } catch(Exception e) {
             log.error("Installation step {} failed", argValue, e);
@@ -199,7 +201,8 @@ public class ArgParser {
 
             // Handle help request
             if(hasFlag(HELP)) {
-                System.out.println("Usage: java -jar qz-tray.jar (command)");
+
+                System.out.println(String.format("Usage: %s (command)", USAGE_COMMAND));
                 int lpad = 30;
                 for(ArgType argType : ArgValue.ArgType.values()) {
                     System.out.println(String.format("%s%s", System.lineSeparator(), argType));
@@ -210,7 +213,7 @@ public class ArgParser {
                         }
                         System.out.println(text);
                         if(argValue.getUsage() != null) {
-                            System.out.println(StringUtils.rightPad("", lpad) + String.format("Usage: %s", argValue.getUsage()));
+                            System.out.println(StringUtils.rightPad("", lpad) + String.format("  %s %s", USAGE_COMMAND, argValue.getUsage()));
                         }
                     }
                 }

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -1,0 +1,85 @@
+package qz.utils;
+
+import qz.common.Constants;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static qz.utils.ArgValue.ArgType.*;
+
+public enum ArgValue {
+    // Informational
+    HELP(INFORMATION, "--help", "-h", "Display help information and exit.", null),
+    VERSION(INFORMATION, "--version", "-v", "Display version information and exit.", null),
+    BUNDLEID(INFORMATION, "--bundleid", "-i", "Display Apple bundle identifier and exit.", null),
+    LIBINFO(INFORMATION, "--libinfo", "-l", "Display detailed library version information and exit.", null),
+
+    // Actions
+    ALLOW(ACTION,"--allow", "--whitelist", "-a", String.format("Add the specified certificate to %s.dat.", Constants.ALLOW_FILE), "--allow cert.pem"),
+    BLOCK(ACTION,"--block", "--blacklist", "-b", String.format("Add the specified certificate to %s.dat.", Constants.BLOCK_FILE), "--block cert.pem"),
+
+    // Options
+    AUTOSTART(OPTION,"--honorautostart", "-A", "Read and honor any autostart preferences before launching.", null),
+
+    // Installer stubs
+    PREINSTALL(INSTALLER, "preinstall", "Perform critical pre-installation steps: Stop instances, special considerations.", null),
+    INSTALL(INSTALLER, "install", "Copy to the specified destination and preforms platform-specific registration.", "install --dest /my/install/location [--silent]"),
+    CERTGEN(INSTALLER, "certgen", "Performs certificate generation and registration for proper HTTPS support.", "certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host \"list;of;hosts\"]"),
+    UNINSTALL(INSTALLER, "uninstall", "Perform all uninstall tasks: Stop instances, delete files, unregister settings.", null),
+    SPAWN(INSTALLER, "spawn", "Spawn an instance of the specified program as the logged-in user, avoiding the root user at all costs.", "spawn [program params ...]");
+
+    private ArgType argType;
+    private String[] matches;
+    private String description;
+    private String usage;
+
+    ArgValue(ArgType argType, String[] matches, String description, String usage) {
+        this.argType = argType;
+        this.matches = matches;
+        this.description = description;
+        this.usage = usage;
+    }
+    ArgValue(ArgType argType, String match1, String match2, String match3, String description, String usage) {
+        this(argType, new String[] { match1, match2, match3 }, description, usage);
+    }
+    ArgValue(ArgType argType, String match1, String match2, String description, String usage) {
+        this(argType, new String[] { match1, match2 }, description, usage);
+    }
+    ArgValue(ArgType argType, String match, String description, String usage) {
+        this(argType, new String[] { match }, description, usage);
+    }
+
+    public String[] getMatches() {
+        return matches;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUsage() {
+        return usage;
+    }
+
+    public ArgType getType() {
+        return argType;
+    }
+
+    public enum ArgType {
+        INFORMATION,
+        ACTION,
+        OPTION,
+        INSTALLER
+    }
+
+    public static ArgValue[] filter(ArgType ... argTypes) {
+        ArrayList<ArgType> match = new ArrayList<>(Arrays.asList(argTypes));
+        ArrayList<ArgValue> found = new ArrayList<>();
+        for(ArgValue argValue : values()) {
+            if(match.contains(argValue.getType())) {
+                found.add(argValue);
+            }
+        }
+        return found.toArray(new ArgValue[found.size()]);
+    }
+}

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -83,4 +83,53 @@ public enum ArgValue {
         }
         return found.toArray(new ArgValue[found.size()]);
     }
+
+    /**
+     * Child/parent for options
+     */
+    public enum ArgValueOption {
+        // install
+        DEST(ArgValue.INSTALL, "--dest", "-d", "Installs to the specified destination.  If omitted, a sane default will be used."),
+        SILENT(ArgValue.INSTALL, "--silent", "-s", "Suppress all prompts to the user, taking sane defaults."),
+
+        // certgen
+        HOST(ArgValue.CERTGEN, "--host", "--hosts", "Semicolon-delimited hostnames and/or IP addresses to generate the HTTPS certificate for."),
+        CERT(ArgValue.CERTGEN, "--cert", "-c", "Path to a stand-alone HTTPS certificate"),
+        KEY(ArgValue.CERTGEN, "--key", "-k", "Path to a stand-alone HTTPS private key"),
+        PFX(ArgValue.CERTGEN, "--pfx", "--pkcs12", "Path to a paired HTTPS private key and certificate in PKCS#12 format."),
+        PASS(ArgValue.CERTGEN, "--pass", "-p", "Password for decoding private key.");
+
+        ArgValue parent;
+        String[] matches;
+        String description;
+
+        ArgValueOption(ArgValue parent, String match1, String match2, String description) {
+            this.parent = parent;
+            this.matches = new String[]{ match1, match2 };
+            this.description = description;
+        }
+
+        public static ArgValueOption[] filter(ArgValue ... parents) {
+            ArrayList<ArgValue> match = new ArrayList<>(Arrays.asList(parents));
+            ArrayList<ArgValueOption> found = new ArrayList<>();
+            for(ArgValueOption argValueOption : values()) {
+                if(match.contains(argValueOption.getParent())) {
+                    found.add(argValueOption);
+                }
+            }
+            return found.toArray(new ArgValueOption[found.size()]);
+        }
+
+        public ArgValue getParent() {
+            return parent;
+        }
+
+        public String[] getMatches() {
+            return matches;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
 }

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -20,13 +20,14 @@ public enum ArgValue {
 
     // Options
     AUTOSTART(OPTION,"--honorautostart", "-A", "Read and honor any autostart preferences before launching.", null),
+    HEADLESS(OPTION, "--headless", "Force startup \"headless\" without graphical interface or interactive components.", null),
 
     // Installer stubs
-    PREINSTALL(INSTALLER, "preinstall", "Perform critical pre-installation steps: Stop instances, special considerations.", null),
+    PREINSTALL(INSTALLER, "preinstall", "Perform critical pre-installation steps: Stop instances, all other special considerations.", null),
     INSTALL(INSTALLER, "install", "Copy to the specified destination and preforms platform-specific registration.", "install --dest /my/install/location [--silent]"),
     CERTGEN(INSTALLER, "certgen", "Performs certificate generation and registration for proper HTTPS support.", "certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host \"list;of;hosts\"]"),
     UNINSTALL(INSTALLER, "uninstall", "Perform all uninstall tasks: Stop instances, delete files, unregister settings.", null),
-    SPAWN(INSTALLER, "spawn", "Spawn an instance of the specified program as the logged-in user, avoiding the root user at all costs.", "spawn [program params ...]");
+    SPAWN(INSTALLER, "spawn", "Spawn an instance of the specified program as the logged-in user, avoiding starting as the root user if possible.", "spawn [program params ...]");
 
     private ArgType argType;
     private String[] matches;

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -9,47 +9,50 @@ import static qz.utils.ArgValue.ArgType.*;
 
 public enum ArgValue {
     // Informational
-    HELP(INFORMATION, "--help", "-h", "Display help information and exit.", null),
-    VERSION(INFORMATION, "--version", "-v", "Display version information and exit.", null),
-    BUNDLEID(INFORMATION, "--bundleid", "-i", "Display Apple bundle identifier and exit.", null),
-    LIBINFO(INFORMATION, "--libinfo", "-l", "Display detailed library version information and exit.", null),
+    HELP(INFORMATION, "Display help information and exit.", null,
+         "--help", "-h", "/?"),
+    VERSION(INFORMATION, "Display version information and exit.", null,
+            "--version", "-v"),
+    BUNDLEID(INFORMATION, "Display Apple bundle identifier and exit.", null,
+             "--bundleid", "-i"),
+    LIBINFO(INFORMATION, "Display detailed library version information and exit.", null,
+            "--libinfo", "-l"),
 
     // Actions
-    ALLOW(ACTION,"--allow", "--whitelist", "-a", String.format("Add the specified certificate to %s.dat.", Constants.ALLOW_FILE), "--allow cert.pem"),
-    BLOCK(ACTION,"--block", "--blacklist", "-b", String.format("Add the specified certificate to %s.dat.", Constants.BLOCK_FILE), "--block cert.pem"),
+    ALLOW(ACTION,String.format("Add the specified certificate to %s.dat.", Constants.ALLOW_FILE), "--allow cert.pem",
+          "--allow", "--whitelist", "-a"),
+    BLOCK(ACTION, String.format("Add the specified certificate to %s.dat.", Constants.BLOCK_FILE), "--block cert.pem",
+          "--block", "--blacklist", "-b"),
 
     // Options
-    AUTOSTART(OPTION,"--honorautostart", "-A", "Read and honor any autostart preferences before launching.", null),
-    HEADLESS(OPTION, "--headless", "Force startup \"headless\" without graphical interface or interactive components.", null),
+    AUTOSTART(OPTION,"Read and honor any autostart preferences before launching.", null,
+              "--honorautostart", "-A"),
+    HEADLESS(OPTION, "Force startup \"headless\" without graphical interface or interactive components.", null,
+             "--headless"),
 
     // Installer stubs
-    PREINSTALL(INSTALLER, "preinstall", "Perform critical pre-installation steps: Stop instances, all other special considerations.", null),
-    INSTALL(INSTALLER, "install", "Copy to the specified destination and preforms platform-specific registration.", "install --dest /my/install/location [--silent]"),
-    CERTGEN(INSTALLER, "certgen", "Performs certificate generation and registration for proper HTTPS support.", "certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host \"list;of;hosts\"]"),
-    UNINSTALL(INSTALLER, "uninstall", "Perform all uninstall tasks: Stop instances, delete files, unregister settings.", null),
-    SPAWN(INSTALLER, "spawn", "Spawn an instance of the specified program as the logged-in user, avoiding starting as the root user if possible.", "spawn [program params ...]");
+    PREINSTALL(INSTALLER, "Perform critical pre-installation steps: Stop instances, all other special considerations.", null,
+               "preinstall"),
+    INSTALL(INSTALLER, "Copy to the specified destination and preforms platform-specific registration.", "install --dest /my/install/location [--silent]",
+            "install"),
+    CERTGEN(INSTALLER, "Performs certificate generation and registration for proper HTTPS support.", "certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host \"list;of;hosts\"]",
+            "certgen"),
+    UNINSTALL(INSTALLER, "Perform all uninstall tasks: Stop instances, delete files, unregister settings.", null,
+              "uninstall"),
+    SPAWN(INSTALLER, "Spawn an instance of the specified program as the logged-in user, avoiding starting as the root user if possible.", "spawn [program params ...]",
+          "spawn");
 
     private ArgType argType;
-    private String[] matches;
     private String description;
     private String usage;
+    private String[] matches;
 
-    ArgValue(ArgType argType, String[] matches, String description, String usage) {
+    ArgValue(ArgType argType, String description, String usage, String ... matches) {
         this.argType = argType;
-        this.matches = matches;
         this.description = description;
         this.usage = usage;
+        this.matches = matches;
     }
-    ArgValue(ArgType argType, String match1, String match2, String match3, String description, String usage) {
-        this(argType, new String[] { match1, match2, match3 }, description, usage);
-    }
-    ArgValue(ArgType argType, String match1, String match2, String description, String usage) {
-        this(argType, new String[] { match1, match2 }, description, usage);
-    }
-    ArgValue(ArgType argType, String match, String description, String usage) {
-        this(argType, new String[] { match }, description, usage);
-    }
-
     public String[] getMatches() {
         return matches;
     }
@@ -89,24 +92,31 @@ public enum ArgValue {
      */
     public enum ArgValueOption {
         // install
-        DEST(ArgValue.INSTALL, "--dest", "-d", "Installs to the specified destination.  If omitted, a sane default will be used."),
-        SILENT(ArgValue.INSTALL, "--silent", "-s", "Suppress all prompts to the user, taking sane defaults."),
+        DEST(ArgValue.INSTALL, "Installs to the specified destination.  If omitted, a sane default will be used.",
+             "--dest", "-d"),
+        SILENT(ArgValue.INSTALL, "Suppress all prompts to the user, taking sane defaults.",
+               "--silent", "-s"),
 
         // certgen
-        HOST(ArgValue.CERTGEN, "--host", "--hosts", "Semicolon-delimited hostnames and/or IP addresses to generate the HTTPS certificate for."),
-        CERT(ArgValue.CERTGEN, "--cert", "-c", "Path to a stand-alone HTTPS certificate"),
-        KEY(ArgValue.CERTGEN, "--key", "-k", "Path to a stand-alone HTTPS private key"),
-        PFX(ArgValue.CERTGEN, "--pfx", "--pkcs12", "Path to a paired HTTPS private key and certificate in PKCS#12 format."),
-        PASS(ArgValue.CERTGEN, "--pass", "-p", "Password for decoding private key.");
+        HOST(ArgValue.CERTGEN, "Semicolon-delimited hostnames and/or IP addresses to generate the HTTPS certificate for.",
+             "--host", "--hosts"),
+        CERT(ArgValue.CERTGEN, "Path to a stand-alone HTTPS certificate",
+             "--cert", "-c"),
+        KEY(ArgValue.CERTGEN, "Path to a stand-alone HTTPS private key",
+            "--key", "-k"),
+        PFX(ArgValue.CERTGEN, "Path to a paired HTTPS private key and certificate in PKCS#12 format.",
+            "--pfx", "--pkcs12"),
+        PASS(ArgValue.CERTGEN, "Password for decoding private key.",
+             "--pass", "-p");
 
         ArgValue parent;
-        String[] matches;
         String description;
+        String[] matches;
 
-        ArgValueOption(ArgValue parent, String match1, String match2, String description) {
+        ArgValueOption(ArgValue parent, String description, String ... matches) {
             this.parent = parent;
-            this.matches = new String[]{ match1, match2 };
             this.description = description;
+            this.matches = matches;
         }
 
         public static ArgValueOption[] filter(ArgValue ... parents) {

--- a/src/qz/ws/PrintSocketServer.java
+++ b/src/qz/ws/PrintSocketServer.java
@@ -32,6 +32,7 @@ import qz.common.TrayManager;
 import qz.installer.Installer;
 import qz.installer.certificate.*;
 import qz.utils.ArgParser;
+import qz.utils.ArgValue;
 import qz.utils.FileUtilities;
 import qz.utils.SystemUtilities;
 
@@ -68,7 +69,7 @@ public class PrintSocketServer {
         if(parser.intercept()) {
             System.exit(parser.getExitCode());
         }
-        forceHeadless = parser.hasFlag("--headless");
+        forceHeadless = parser.hasFlag(ArgValue.HEADLESS);
         log.info(Constants.ABOUT_TITLE + " version: {}", Constants.VERSION);
         log.info(Constants.ABOUT_TITLE + " vendor: {}", Constants.ABOUT_COMPANY);
         log.info("Java version: {}", Constants.JAVA_VERSION.toString());

--- a/src/qz/ws/PrintSocketServer.java
+++ b/src/qz/ws/PrintSocketServer.java
@@ -68,7 +68,7 @@ public class PrintSocketServer {
         if(parser.intercept()) {
             System.exit(parser.getExitCode());
         }
-        forceHeadless = parser.hasFlag("-h", "--headless");
+        forceHeadless = parser.hasFlag("--headless");
         log.info(Constants.ABOUT_TITLE + " version: {}", Constants.VERSION);
         log.info(Constants.ABOUT_TITLE + " vendor: {}", Constants.ABOUT_COMPANY);
         log.info("Java version: {}", Constants.JAVA_VERSION.toString());


### PR DESCRIPTION
Preview:

```
Usage: java -jar qz-tray.jar (command)

INFORMATION
  --help, -h                  Display help information and exit.
  --version, -v               Display version information and exit.
  --bundleid, -i              Display Apple bundle identifier and exit.
  --libinfo, -l               Display detailed library version information and exit.

ACTION
  --allow, --whitelist, -a    Add the specified certificate to allowed.dat.
                                java -jar qz-tray.jar --allow cert.pem
  --block, --blacklist, -b    Add the specified certificate to blocked.dat.
                                java -jar qz-tray.jar --block cert.pem

OPTION
  --honorautostart, -A        Read and honor any autostart preferences before launching.
  --headless                  Force startup "headless" without graphical interface or interactive components.

INSTALLER
  preinstall                  Perform critical pre-installation steps: Stop instances, all other special considerations.
  install                     Copy to the specified destination and preforms platform-specific registration.
                                java -jar qz-tray.jar install --dest /my/install/location [--silent]
  certgen                     Performs certificate generation and registration for proper HTTPS support.
                                java -jar qz-tray.jar certgen [--key key.pem --cert cert.pem] [--pfx cert.pfx --pass 12345] [--host "list;of;hosts"]
  uninstall                   Perform all uninstall tasks: Stop instances, delete files, unregister settings.
  spawn                       Spawn an instance of the specified program as the logged-in user, avoiding starting as the root user if possible.
                                java -jar qz-tray.jar spawn [program params ...]

For help on a specific command:
  Usage: java -jar qz-tray.jar --help (command)
    --help install
    --help certgen

Process finished with exit code 2
```