### PR TITLE
Add environmental variable QZ_OPTS

### DIFF
--- a/ant/project.properties
+++ b/ant/project.properties
@@ -8,7 +8,7 @@ project.filename=qz-tray
 project.datadir=qz
 
 launch.opts=-Xms512m -Djna.nosys=true
-launch.overrides=QZ_JAVA_OPTS
+launch.overrides=QZ_OPTS
 
 src.dir=${basedir}/src
 out.dir=${basedir}/out

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -26,3 +26,6 @@ javac.target=1.8
 javafx.version=15.ea+3_monocle
 javafx.mirror=https://download2.gluonhq.com/openjfx/15
 java.download=https://adoptopenjdk.net/?variant=openjdk11
+
+# Workaround to delay expansion of $${foo} (e.g. shell scripts)
+dollar=$

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -8,6 +8,7 @@ project.filename=qz-tray
 project.datadir=qz
 
 launch.opts=-Xms512m -Djna.nosys=true
+launch.overrides=QZ_JAVA_OPTS
 
 src.dir=${basedir}/src
 out.dir=${basedir}/out

--- a/ant/unix/unix-launcher.sh.in
+++ b/ant/unix/unix-launcher.sh.in
@@ -22,7 +22,7 @@ RED="\\x1B[1;31m";GREEN="\\x1B[1;32m";YELLOW="\\x1B[1;33m";PLAIN="\\x1B[0m"
 SUCCESS="   [${GREEN}success${PLAIN}]"
 FAILURE="   [${RED}failure${PLAIN}]"
 WARNING="   [${YELLOW}warning${PLAIN}]"
-OBSERVE="   [${YELLOW}note${PLAIN}]"
+MESSAGE="   [${YELLOW}message${PLAIN}]"
 
 echo "Looking for Java..."
 
@@ -41,14 +41,14 @@ fi
 
 # Check for user overridable launch options
 if [ -n "${dollar}${launch.overrides}" ]; then
-  echo -e "$OBSERVE Picked up additional launch options: ${dollar}${launch.overrides}"
+  echo -e "$MESSAGE Picked up additional launch options: ${dollar}${launch.overrides}"
   LAUNCH_OPTS="$LAUNCH_OPTS ${dollar}${launch.overrides}"
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     DEFAULTS_READ=$(defaults read ${apple.bundleid} ${launch.overrides} 2>/dev/null) || true
     if [ -n "$DEFAULTS_READ" ]; then
-          echo -e "$OBSERVE Picked up additional launch options: $DEFAULTS_READ"
+          echo -e "$MESSAGE Picked up additional launch options: $DEFAULTS_READ"
           LAUNCH_OPTS="$LAUNCH_OPTS $DEFAULTS_READ"
     fi
     ICON_PATH="$DIR/Contents/Resources/apple-icon.icns"

--- a/ant/unix/unix-launcher.sh.in
+++ b/ant/unix/unix-launcher.sh.in
@@ -40,9 +40,9 @@ if [ -d ./jre ]; then
 fi
 
 # Check for user overridable launch options
-if [ -z "$${launch.overrides}" ]; then
-  echo -e "$OBSERVE Picked up additional launch options: $${launch.overrides}"
-  LAUNCH_OPTS="$LAUNCH_OPTS $${launch.overrides}"
+if [ -z "${dollar}${launch.overrides}" ]; then
+  echo -e "$OBSERVE Picked up additional launch options: ${dollar}${launch.overrides}"
+  LAUNCH_OPTS="$LAUNCH_OPTS ${dollar}${launch.overrides}"
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/ant/unix/unix-launcher.sh.in
+++ b/ant/unix/unix-launcher.sh.in
@@ -40,7 +40,7 @@ if [ -d ./jre ]; then
 fi
 
 # Check for user overridable launch options
-if [ -z "${dollar}${launch.overrides}" ]; then
+if [ -n "${dollar}${launch.overrides}" ]; then
   echo -e "$OBSERVE Picked up additional launch options: ${dollar}${launch.overrides}"
   LAUNCH_OPTS="$LAUNCH_OPTS ${dollar}${launch.overrides}"
 fi

--- a/ant/unix/unix-launcher.sh.in
+++ b/ant/unix/unix-launcher.sh.in
@@ -22,6 +22,7 @@ RED="\\x1B[1;31m";GREEN="\\x1B[1;32m";YELLOW="\\x1B[1;33m";PLAIN="\\x1B[0m"
 SUCCESS="   [${GREEN}success${PLAIN}]"
 FAILURE="   [${RED}failure${PLAIN}]"
 WARNING="   [${YELLOW}warning${PLAIN}]"
+OBSERVE="   [${YELLOW}note${PLAIN}]"
 
 echo "Looking for Java..."
 
@@ -36,6 +37,12 @@ if [ -d ./jre ]; then
     echo -e "$SUCCESS A bundled runtime was found.  Using..."
     PATH="$(pwd)/jre/bin:$PATH"
     export PATH
+fi
+
+# Check for user overridable launch options
+if [ -z "$${launch.overrides}" ]; then
+  echo -e "$OBSERVE Picked up additional launch options: $${launch.overrides}"
+  LAUNCH_OPTS="$LAUNCH_OPTS $${launch.overrides}"
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/ant/unix/unix-launcher.sh.in
+++ b/ant/unix/unix-launcher.sh.in
@@ -46,9 +46,14 @@ if [ -n "${dollar}${launch.overrides}" ]; then
 fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
+    DEFAULTS_READ=$(defaults read ${apple.bundleid} ${launch.overrides} 2>/dev/null) || true
+    if [ -n "$DEFAULTS_READ" ]; then
+          echo -e "$OBSERVE Picked up additional launch options: $DEFAULTS_READ"
+          LAUNCH_OPTS="$LAUNCH_OPTS $DEFAULTS_READ"
+    fi
     ICON_PATH="$DIR/Contents/Resources/apple-icon.icns"
     MAC_PRIMARY="/usr/libexec/java_home"
-    MAC_FALLACK="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin"
+    MAC_FALLBACK="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin"
     echo "Trying $MAC_PRIMARY..."
     if "$MAC_PRIMARY" -v $JAVA_MIN+ &>/dev/null; then
         echo -e "$SUCCESS Using \"$MAC_PRIMARY -v $JAVA_MIN+ --exec\" to launch $ABOUT_TITLE"
@@ -57,9 +62,9 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         }
     elif [ -d "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin" ]; then
         echo -e "$WARNING No luck using $MAC_PRIMARY"
-        echo "Trying $MAC_FALLACK..."
+        echo "Trying $MAC_FALLBACK..."
         java() {
-            "$MAC_FALLACK/java" "$@"
+            "$MAC_FALLBACK/java" "$@"
         }
     fi
 else

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -41,14 +41,14 @@ Section
     ; Sets the $java variable
     Call FindJava
 
-	Var /GLOBAL opts
-	StrCpy $opts "${launch.opts}"
+    Var /GLOBAL opts
+    StrCpy $opts "${launch.opts}"
 
-	; Check for user overridable launch options
-	ClearErrors
-	ReadEnvStr $R0 ${launch.overrides}
-	IfErrors +2 0
-	StrCpy $opts "$opts $R0"
+    ; Check for user overridable launch options
+    ClearErrors
+    ReadEnvStr $R0 ${launch.overrides}
+    IfErrors +2 0
+    StrCpy $opts "$opts $R0"
 
     Exec '"$javaw" $opts -jar "${JAR}" $params'
     ${If} ${RunningX64}

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -41,7 +41,16 @@ Section
     ; Sets the $java variable
     Call FindJava
 
-    Exec '"$javaw" ${launch.opts} -jar "${JAR}" $params'
+	Var /GLOBAL opts
+	StrCpy $opts "${launch.opts}"
+
+	; Check for user overridable launch options
+	ReadEnvStr $0 ${launch.overrides}
+	IfErrors +2 0
+	StrCpy $opts "$opts $0"
+	Pop $0
+
+    Exec '"$javaw" $opts -jar "${JAR}" $params'
     ${If} ${RunningX64}
         ${EnableX64FSRedirection}
     ${EndIf}

--- a/ant/windows/windows-launcher.nsi.in
+++ b/ant/windows/windows-launcher.nsi.in
@@ -45,10 +45,10 @@ Section
 	StrCpy $opts "${launch.opts}"
 
 	; Check for user overridable launch options
-	ReadEnvStr $0 ${launch.overrides}
+	ClearErrors
+	ReadEnvStr $R0 ${launch.overrides}
 	IfErrors +2 0
-	StrCpy $opts "$opts $0"
-	Pop $0
+	StrCpy $opts "$opts $R0"
 
     Exec '"$javaw" $opts -jar "${JAR}" $params'
     ${If} ${RunningX64}


### PR DESCRIPTION
Currently to change the behavior of Java, the undocumented `_JAVA_OPTIONS` environmental variable is is required, which affects all Java applications installed system-wide.

This attempts to remedy that by allowing overriding java's command line launch behavior such as `-Xms`, `-Xmx` etc through a dedicated environmental variable `QZ_OPTS`.

This will affect QZ Tray normal startup only.  Commands such as [`install`, `certgen`](https://github.com/qzind/tray/pulls/707), etc are not affected.

Documentation: https://github.com/qzind/tray/wiki/Command-Line