### PR TITLE
Re-add missing dpiscale setter

### DIFF
--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -69,6 +69,8 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
 
     @Override
     public void parseData(JSONArray printData, PrintOptions options) throws JSONException, UnsupportedOperationException {
+        dpiScale = (options.getPixelOptions().getDensity() * options.getPixelOptions().getUnits().as1Inch()) / 72.0;
+
         for(int i = 0; i < printData.length(); i++) {
             JSONObject data = printData.getJSONObject(i);
 


### PR DESCRIPTION
Fix to scaling interpolation for #704

Looks like a mistake/lost line from a rebase? As the history timeline around [this commit](https://github.com/qzind/tray/commit/25a19840d5237bd10bd4f856fb2c22a9f5534012) is weird.
I didn't see any ill effects to rasterized HTML re-adding this line in, though it would probably be a good idea to test around that as well, since the linked commit was for adding that capability in.