### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM openjdk:11-jre as install
 RUN apt-get update
 RUN apt-get install -y libglib2.0-bin
 COPY --from=build /usr/src/tray/out/*.run /tmp
-RUN find /tmp -iname '*.run' -exec {} \;
+RUN find /tmp -iname "*.run" -exec {} \;
 WORKDIR /opt/qz-tray
 ENTRYPOINT ["/opt/qz-tray/qz-tray"]
-CMD ["--headless"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM openjdk:11 as build
+RUN apt-get update
+RUN apt-get install -y ant nsis makeself
+COPY . /usr/src/tray
+WORKDIR /usr/src/tray
+RUN ant makeself
+
+FROM openjdk:11-jre as install
+RUN apt-get update
+RUN apt-get install -y libglib2.0-bin
+COPY --from=build /usr/src/tray/out/*.run /tmp
+RUN find /tmp -iname '*.run' -exec {} \;
+WORKDIR /opt/qz-tray
+ENTRYPOINT ["/opt/qz-tray/qz-tray"]
+CMD ["--headless"]


### PR DESCRIPTION
Adds docker build file

Build:

```bash
docker build -t tray .
```

Usage:

```bash
docker run -p 8182:8182 -p 8181:8181 -it tray
```

To use a certificate in `cert.pem` file:

```bash
docker run --name tray -v $(pwd)/cert.pem:/tmp/cert.pem -p 8182:8182 -p 8181:8181 tray
docker exec tray /opt/qz-tray/qz-tray --whitelist /tmp/cert.pem
```
