### PR TITLE
Attempt to detect redirected pages

### DIFF
--- a/src/qz/printer/action/WebApp.java
+++ b/src/qz/printer/action/WebApp.java
@@ -70,6 +70,12 @@ public class WebApp extends Application {
         log.trace("New state: {} > {}", oldState, newState);
 
         if (newState == Worker.State.SUCCEEDED) {
+            boolean hasBody = (boolean)webView.getEngine().executeScript("document.body != null");
+            if (!hasBody) {
+                log.warn("Loaded page has no body - likely a redirect, skipping state");
+                return;
+            }
+
             //ensure html tag doesn't use scrollbars, clipping page instead
             Document doc = webView.getEngine().getDocument();
             NodeList tags = doc.getElementsByTagName("html");


### PR DESCRIPTION
Potential fix for #739 
Issue is caused by page requested being redirected so there is no document body. Error will throw for the js call and then the blank page printed while the actual content gets loaded and thrown away in the background.

The JFX webengine however does not seem to have a listener for http status codes. So this solution uses a null check on the js document.body to assume a redirect is occurring. I'm not sure if this will catch all forms of redirects or if there are instances where body could be null without a redirect, causing the print to be endlessly stuck.