### PR TITLE
Add --file-allow command line parameter

### DIFF
--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final String LOG_FILE = "debug";
     public static final String PROPS_FILE = "qz-tray"; // .properties extension is assumed
     public static final String PREFS_FILE = "prefs"; // .properties extension is assumed
-    public static final String[] PERSIST_PROPS = { "file.whitelist" };
+    public static final String[] PERSIST_PROPS = { "file.whitelist", "file.allow" };
     public static final String AUTOSTART_FILE = ".autostart";
     public static final String DATA_DIR = "qz";
     public static final int LOG_SIZE = 524288;

--- a/src/qz/common/PropertyHelper.java
+++ b/src/qz/common/PropertyHelper.java
@@ -2,6 +2,7 @@ package qz.common;
 
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,6 +40,10 @@ public class PropertyHelper extends Properties {
         load(file);
     }
 
+    public PropertyHelper(File file) {
+        this(file == null ? null : file.getAbsolutePath());
+    }
+
     public boolean getBoolean(String key, boolean defaultVal) {
         String prop = getProperty(key);
         if (prop != null) {
@@ -50,6 +55,10 @@ public class PropertyHelper extends Properties {
 
     public void setProperty(String key, boolean value) {
         setProperty(key, "" + value);
+    }
+
+    public void load(File file) {
+        load(file == null ? null : file.getAbsolutePath());
     }
 
     public void load(String file) {
@@ -66,11 +75,13 @@ public class PropertyHelper extends Properties {
         }
     }
 
-    public void save() {
+    public boolean save() {
+        boolean success = false;
         FileOutputStream f = null;
         try {
             f = new FileOutputStream(file);
             this.store(f, null);
+            success = true;
         } catch (IOException e) {
             log.error("Error saving file: {}", file, e);
         } finally {
@@ -78,5 +89,6 @@ public class PropertyHelper extends Properties {
                 try { f.close(); } catch(Throwable ignore) {};
             }
         }
+        return success;
     }
 }

--- a/src/qz/utils/ArgParser.java
+++ b/src/qz/utils/ArgParser.java
@@ -223,7 +223,7 @@ public class ArgParser {
                 }
             } else {
                 // Show generic help
-                for(ArgType argType : ArgValue.ArgType.values()) {
+                for(ArgType argType : ArgType.values()) {
                     System.out.println(String.format("%s%s", System.lineSeparator(), argType));
                     for(ArgValue argValue : ArgValue.filter(argType)) {
                         printHelp(argValue);
@@ -294,11 +294,11 @@ public class ArgParser {
             // Handle file.allow
             String allowPath;
             if ((allowPath = valueOf(argValue = FILE_ALLOW)) != null) {
-                exitStatus = FileUtilities.writeFileAllowProperty(allowPath, valueOf(SANDBOX));
+                exitStatus = FileUtilities.addFileAllowProperty(allowPath, valueOf(SANDBOX));
                 return true;
             }
             if ((allowPath = valueOf(argValue = FILE_REMOVE)) != null) {
-                //exitStatus = FileUtilities.deleteFileAllowProperty(allowPath, valueOf(SANDBOX));
+                exitStatus = FileUtilities.removeFileAllowProperty(allowPath);
                 return true;
             }
 

--- a/src/qz/utils/ArgParser.java
+++ b/src/qz/utils/ArgParser.java
@@ -291,6 +291,17 @@ public class ArgParser {
                 return true;
             }
 
+            // Handle file.allow
+            String allowPath;
+            if ((allowPath = valueOf(argValue = FILE_ALLOW)) != null) {
+                exitStatus = FileUtilities.writeFileAllowProperty(allowPath, valueOf(SANDBOX));
+                return true;
+            }
+            if ((allowPath = valueOf(argValue = FILE_REMOVE)) != null) {
+                exitStatus = FileUtilities.deleteFileAllowProperty(allowPath, valueOf(SANDBOX));
+                return true;
+            }
+
             // Print library list
             if (hasFlag(LIBINFO)) {
                 SecurityInfo.printLibInfo();

--- a/src/qz/utils/ArgParser.java
+++ b/src/qz/utils/ArgParser.java
@@ -298,7 +298,7 @@ public class ArgParser {
                 return true;
             }
             if ((allowPath = valueOf(argValue = FILE_REMOVE)) != null) {
-                exitStatus = FileUtilities.deleteFileAllowProperty(allowPath, valueOf(SANDBOX));
+                //exitStatus = FileUtilities.deleteFileAllowProperty(allowPath, valueOf(SANDBOX));
                 return true;
             }
 

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -25,8 +25,8 @@ public enum ArgValue {
           "--block", "--blacklist", "-b"),
     FILE_ALLOW(ACTION, String.format("Add the specified file.allow entry to %s.properties for FileIO operations, sandboxed to a specified certificate if provided", Constants.PROPS_FILE), "--file-allow /my/file/path [--sandbox \"Company Name\"]",
           "--file-allow"),
-    FILE_REMOVE(ACTION, String.format("Removes the specified file.allow entry from %s.properties for FileIO operations", Constants.PROPS_FILE), "--file-allow /my/file/path [--sandbox \"Company Name\"]",
-               "--file-allow"),
+    FILE_REMOVE(ACTION, String.format("Removes the specified file.allow entry from %s.properties for FileIO operations", Constants.PROPS_FILE), "--file-remove /my/file/path",
+               "--file-remove"),
 
     // Options
     AUTOSTART(OPTION,"Read and honor any autostart preferences before launching.", null,

--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -23,6 +23,10 @@ public enum ArgValue {
           "--allow", "--whitelist", "-a"),
     BLOCK(ACTION, String.format("Add the specified certificate to %s.dat.", Constants.BLOCK_FILE), "--block cert.pem",
           "--block", "--blacklist", "-b"),
+    FILE_ALLOW(ACTION, String.format("Add the specified file.allow entry to %s.properties for FileIO operations, sandboxed to a specified certificate if provided", Constants.PROPS_FILE), "--file-allow /my/file/path [--sandbox \"Company Name\"]",
+          "--file-allow"),
+    FILE_REMOVE(ACTION, String.format("Removes the specified file.allow entry from %s.properties for FileIO operations", Constants.PROPS_FILE), "--file-allow /my/file/path [--sandbox \"Company Name\"]",
+               "--file-allow"),
 
     // Options
     AUTOSTART(OPTION,"Read and honor any autostart preferences before launching.", null,
@@ -91,6 +95,10 @@ public enum ArgValue {
      * Child/parent for options
      */
     public enum ArgValueOption {
+        // action
+        SANDBOX(ArgValue.FILE_ALLOW, "Treats the allow entry as a sandboxed location.  Only certificates with an exact Common Name can access this location",
+             "--sandbox"),
+
         // install
         DEST(ArgValue.INSTALL, "Installs to the specified destination.  If omitted, a sane default will be used.",
              "--dest", "-d"),

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -346,7 +346,7 @@ public class FileUtilities {
             }
         }
         if(!found) {
-            paths.add(new AbstractMap.SimpleEntry<>(Paths.get(path).normalize().toAbsolutePath(), FIELD_SEPARATOR + commonNameEscaped + FIELD_SEPARATOR));
+            paths.add(new AbstractMap.SimpleEntry<>(Paths.get(path).normalize().toAbsolutePath(), commonNameEscaped.isEmpty() ? "" : FIELD_SEPARATOR + commonNameEscaped + FIELD_SEPARATOR));
             updated = true;
         }
         if(updated) {

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -325,7 +325,7 @@ public class FileUtilities {
         PropertyHelper props = new PropertyHelper(new File(CertificateManager.getWritableLocation(), Constants.PROPS_FILE + ".properties"));
 
         StringBuilder before = getFileAllowProperty(props);
-        if(!before.isEmpty() && !StringUtils.endsWith(before, ";")) {
+        if(!before.toString().isEmpty() && !StringUtils.endsWith(before, ";")) {
             before.append(";");
         }
 
@@ -353,10 +353,10 @@ public class FileUtilities {
         StringBuilder propString = new StringBuilder();
         if(props != null) {
             propString.append(props.getProperty("file.allow", ""));
-            if (propString.isEmpty()) {
+            if (propString.toString().isEmpty()) {
                 // Deprecated
                 propString.append(props.getProperty("file.whitelist", ""));
-                if (!propString.isEmpty()) {
+                if (!propString.toString().isEmpty()) {
                     log.warn("Property \"file.whitelist\" is deprecated and will be removed in a future version.  Please use \"file.whitelist\" instead.");
                 }
             }

--- a/src/qz/utils/FileUtilities.java
+++ b/src/qz/utils/FileUtilities.java
@@ -509,7 +509,7 @@ public class FileUtilities {
 
     /**
      * Escapes invalid chars from filenames. This does not cause collisions. Escape char is <code>ESCAPE_CHAR</code>
-     * Characters escaped, ^ \ / : ; * ? " < > |</>
+     * Characters escaped, ^ \ / : * ? " < > |</>
      * Warning: Restricted filenames such as lpt1, com1, aux... are not escaped by this function
      *
      * @param fileName file name to escape


### PR DESCRIPTION
Add two new command line parameters for easier FileIO deployment:

```bash
# allow a file io location
java -jar qz-tray.jar --file-allow /path/to/location --sandbox "Cert Common Name"

# remove a file io location
java -jar qz-tray.jar --file-remove /path/to/location
```

Closes #729