### PR TITLE
Add base64 HTML support, raw image rotation

### DIFF
--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -76,9 +76,12 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
 
                 PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "FILE").toUpperCase(Locale.ENGLISH));
 
-                String source = flavor == PrintingUtilities.Flavor.BASE64 ?
-                        new String(Base64.decodeBase64(data.getString("data")), StandardCharsets.UTF_8) :
-                        data.getString("data");
+                String source;
+                if (flavor == PrintingUtilities.Flavor.BASE64) {
+                    source = new String(Base64.decodeBase64(data.getString("data")), StandardCharsets.UTF_8);
+                } else {
+                    source = data.getString("data");
+                }
 
                 double pageZoom = (pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()) / 72.0;
                 if (pageZoom <= 1) { pageZoom = 1; }

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -14,6 +14,7 @@ import com.sun.javafx.print.PrintHelper;
 import com.sun.javafx.print.Units;
 import javafx.print.*;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.ssl.Base64;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -37,6 +38,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -71,9 +73,12 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
 
             for(int i = 0; i < printData.length(); i++) {
                 JSONObject data = printData.getJSONObject(i);
-                String source = data.getString("data");
 
                 PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "FILE").toUpperCase(Locale.ENGLISH));
+
+                String source = flavor == PrintingUtilities.Flavor.BASE64 ?
+                        new String(Base64.decodeBase64(data.getString("data")), StandardCharsets.UTF_8) :
+                        data.getString("data");
 
                 double pageZoom = (pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch()) / 72.0;
                 if (pageZoom <= 1) { pageZoom = 1; }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -268,7 +268,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
      * @param angle Rotation angle in degrees
      * @return Rotated image data
      */
-    private BufferedImage rotate(BufferedImage image, double angle) {
+    public static BufferedImage rotate(BufferedImage image, double angle, Object dithering, Object interpolation) {
         double rads = Math.toRadians(angle);
         double sin = Math.abs(Math.sin(rads)), cos = Math.abs(Math.cos(rads));
 
@@ -293,6 +293,10 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         g2d.dispose();
 
         return result;
+    }
+
+    private BufferedImage rotate(BufferedImage image, double angle) {
+        return rotate(image, angle, dithering, interpolation);
     }
 
     @Override

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -9,7 +9,6 @@ import qz.utils.SystemUtilities;
 
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
-import javax.print.attribute.ResolutionSyntax;
 import javax.print.attribute.standard.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -185,7 +184,7 @@ public abstract class PrintPixel {
         return imgToPrint;
     }
 
-    protected Map<RenderingHints.Key,Object> buildRenderingHints(Object dithering, Object interpolation) {
+    protected static Map<RenderingHints.Key,Object> buildRenderingHints(Object dithering, Object interpolation) {
         Map<RenderingHints.Key,Object> rhMap = new HashMap<>();
         rhMap.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
         rhMap.put(RenderingHints.KEY_DITHERING, dithering);

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -43,6 +43,7 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.Socket;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -109,7 +110,7 @@ public class PrintRaw implements PrintProcessor {
             try {
                 switch(format) {
                     case HTML:
-                        commands.append(getHtmlWrapper(cmd, opt, flavor != PrintingUtilities.Flavor.PLAIN, options.getPixelOptions()).getImageCommand(opt));
+                        commands.append(getHtmlWrapper(cmd, opt, flavor, options.getPixelOptions()).getImageCommand(opt));
                         break;
                     case IMAGE:
                         commands.append(getImageWrapper(cmd, opt, flavor != PrintingUtilities.Flavor.BASE64).getImageCommand(opt));
@@ -188,7 +189,9 @@ public class PrintRaw implements PrintProcessor {
         return getWrapper(bi, opt);
     }
 
-    private ImageWrapper getHtmlWrapper(String data, JSONObject opt, boolean fromFile, PrintOptions.Pixel pxlOpts) throws IOException {
+    private ImageWrapper getHtmlWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
+        String source = flavor == PrintingUtilities.Flavor.BASE64 ?  new String(Base64.decodeBase64(data), StandardCharsets.UTF_8) : data;
+
         double density = (pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch());
         if (density <= 1) {
             density = LanguageType.getType(opt.optString("language")).getDefaultDensity();
@@ -199,7 +202,7 @@ public class PrintRaw implements PrintProcessor {
         double pageHeight = opt.optInt("pageHeight") / density * 72;
 
         BufferedImage bi;
-        WebAppModel model = new WebAppModel(data, !fromFile, pageWidth, pageHeight, false, pageZoom);
+        WebAppModel model = new WebAppModel(source, (flavor != PrintingUtilities.Flavor.FILE), pageWidth, pageHeight, false, pageZoom);
 
         try {
             WebApp.initialize(); //starts if not already started

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -103,6 +103,7 @@ public class PrintRaw implements PrintProcessor {
             PrintingUtilities.Format format = PrintingUtilities.Format.valueOf(data.optString("format", "COMMAND").toUpperCase(Locale.ENGLISH));
             PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "PLAIN").toUpperCase(Locale.ENGLISH));
             PrintOptions.Raw rawOpts = options.getRawOptions();
+            PrintOptions.Pixel pxlOpts = options.getPixelOptions();
 
             encoding = rawOpts.getEncoding();
             if (encoding == null || encoding.isEmpty()) { encoding = Charset.defaultCharset().name(); }
@@ -110,13 +111,13 @@ public class PrintRaw implements PrintProcessor {
             try {
                 switch(format) {
                     case HTML:
-                        commands.append(getHtmlWrapper(cmd, opt, flavor, options.getPixelOptions()).getImageCommand(opt));
+                        commands.append(getHtmlWrapper(cmd, opt, flavor, pxlOpts).getImageCommand(opt));
                         break;
                     case IMAGE:
-                        commands.append(getImageWrapper(cmd, opt, flavor != PrintingUtilities.Flavor.BASE64).getImageCommand(opt));
+                        commands.append(getImageWrapper(cmd, opt, flavor, pxlOpts).getImageCommand(opt));
                         break;
                     case PDF:
-                        commands.append(getPdfWrapper(cmd, opt, flavor != PrintingUtilities.Flavor.BASE64).getImageCommand(opt));
+                        commands.append(getPdfWrapper(cmd, opt, flavor, pxlOpts).getImageCommand(opt));
                         break;
                     case COMMAND:
                     default:
@@ -147,32 +148,31 @@ public class PrintRaw implements PrintProcessor {
         }
     }
 
-    private ImageWrapper getImageWrapper(String data, JSONObject opt, boolean fromFile) throws IOException {
+    private ImageWrapper getImageWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
         BufferedImage bi;
-
         // 2.0 compat
         if (data.startsWith("data:image/") && data.contains(";base64,")) {
             String[] parts = data.split(";base64,");
             data = parts[parts.length - 1];
-            fromFile = false;
+            flavor = PrintingUtilities.Flavor.BASE64;
         }
 
-        if (fromFile) {
-            bi = ImageIO.read(ConnectionUtilities.getInputStream(data));
-        } else {
+        if (flavor == PrintingUtilities.Flavor.BASE64) {
             bi = ImageIO.read(new ByteArrayInputStream(Base64.decodeBase64(data)));
+        } else {
+            bi = ImageIO.read(ConnectionUtilities.getInputStream(data));
         }
 
-        return getWrapper(bi, opt);
+        return getWrapper(bi, opt, pxlOpts);
     }
 
-    private ImageWrapper getPdfWrapper(String data, JSONObject opt, boolean fromFile) throws IOException {
+    private ImageWrapper getPdfWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
         PDDocument doc;
 
-        if (fromFile) {
-            doc = PDDocument.load(ConnectionUtilities.getInputStream(data));
-        } else {
+        if (flavor == PrintingUtilities.Flavor.BASE64) {
             doc = PDDocument.load(new ByteArrayInputStream(Base64.decodeBase64(data)));
+        } else {
+            doc = PDDocument.load(ConnectionUtilities.getInputStream(data));
         }
 
         double scale;
@@ -186,7 +186,7 @@ public class PrintRaw implements PrintProcessor {
         if (scale <= 0) { scale = 1.0; }
 
         BufferedImage bi = new PDFRenderer(doc).renderImage(0, (float)scale);
-        return getWrapper(bi, opt);
+        return getWrapper(bi, opt, pxlOpts);
     }
 
     private ImageWrapper getHtmlWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
@@ -236,10 +236,17 @@ public class PrintRaw implements PrintProcessor {
             }
         }
 
-        return getWrapper(bi, opt);
+        return getWrapper(bi, opt, pxlOpts);
     }
 
-    private ImageWrapper getWrapper(BufferedImage img, JSONObject opt) {
+    private ImageWrapper getWrapper(BufferedImage img, JSONObject opt, PrintOptions.Pixel pxlOpts) {
+        // Rotate image using orientation or rotation before sending to ImageWrapper
+        if(pxlOpts.getOrientation() != null && pxlOpts.getOrientation() != PrintOptions.Orientation.PORTRAIT) {
+            img = PrintImage.rotate(img, pxlOpts.getOrientation().getDegreesRot(), pxlOpts.getDithering(), pxlOpts.getInterpolation());
+        } else if(pxlOpts.getRotation() % 360 != 0) {
+            img = PrintImage.rotate(img, pxlOpts.getRotation(), pxlOpts.getDithering(), pxlOpts.getInterpolation());
+        }
+
         ImageWrapper iw = new ImageWrapper(img, LanguageType.getType(opt.optString("language")));
         iw.setCharset(Charset.forName(encoding));
 

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -190,7 +190,9 @@ public class PrintRaw implements PrintProcessor {
     }
 
     private ImageWrapper getHtmlWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
-        String source = flavor == PrintingUtilities.Flavor.BASE64 ?  new String(Base64.decodeBase64(data), StandardCharsets.UTF_8) : data;
+        if (flavor == PrintingUtilities.Flavor.BASE64) {
+            data = new String(Base64.decodeBase64(data), StandardCharsets.UTF_8);
+        }
 
         double density = (pxlOpts.getDensity() * pxlOpts.getUnits().as1Inch());
         if (density <= 1) {
@@ -202,7 +204,7 @@ public class PrintRaw implements PrintProcessor {
         double pageHeight = opt.optInt("pageHeight") / density * 72;
 
         BufferedImage bi;
-        WebAppModel model = new WebAppModel(source, (flavor != PrintingUtilities.Flavor.FILE), pageWidth, pageHeight, false, pageZoom);
+        WebAppModel model = new WebAppModel(data, (flavor != PrintingUtilities.Flavor.FILE), pageWidth, pageHeight, false, pageZoom);
 
         try {
             WebApp.initialize(); //starts if not already started


### PR DESCRIPTION
* Adds `BASE64` as a data flavor to HTML printing
* Adds the ability for a raw job to handle `{ rotation: ... }` or `{ orientation: ... }` normally reserved for pixel jobs.

:warning: WARNING: This will cause backwards compat issues for customer unknowingly passing `{ orientation: ... }` to a raw image/pdf/html job.

Closes #762
Closes #760