### PR TITLE
Raw images to honor orientation 

### DIFF
--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -268,7 +268,7 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
      * @param angle Rotation angle in degrees
      * @return Rotated image data
      */
-    private BufferedImage rotate(BufferedImage image, double angle) {
+    public static BufferedImage rotate(BufferedImage image, double angle, Object dithering, Object interpolation) {
         double rads = Math.toRadians(angle);
         double sin = Math.abs(Math.sin(rads)), cos = Math.abs(Math.cos(rads));
 
@@ -293,6 +293,10 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         g2d.dispose();
 
         return result;
+    }
+
+    private BufferedImage rotate(BufferedImage image, double angle) {
+        return rotate(image, angle, dithering, interpolation);
     }
 
     @Override

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -9,7 +9,6 @@ import qz.utils.SystemUtilities;
 
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
-import javax.print.attribute.ResolutionSyntax;
 import javax.print.attribute.standard.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -185,7 +184,7 @@ public abstract class PrintPixel {
         return imgToPrint;
     }
 
-    protected Map<RenderingHints.Key,Object> buildRenderingHints(Object dithering, Object interpolation) {
+    protected static Map<RenderingHints.Key,Object> buildRenderingHints(Object dithering, Object interpolation) {
         Map<RenderingHints.Key,Object> rhMap = new HashMap<>();
         rhMap.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
         rhMap.put(RenderingHints.KEY_DITHERING, dithering);

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -243,7 +243,7 @@ public class PrintRaw implements PrintProcessor {
 
     private ImageWrapper getWrapper(BufferedImage img, JSONObject opt, PrintOptions.Pixel pxlOpts) {
         // Rotate image using orientation or rotation before sending to ImageWrapper
-        if(pxlOpts.getOrientation() != PrintOptions.Orientation.PORTRAIT) {
+        if(pxlOpts.getOrientation() != null && pxlOpts.getOrientation() != PrintOptions.Orientation.PORTRAIT) {
             img = PrintImage.rotate(img, pxlOpts.getOrientation().getDegreesRot(), pxlOpts.getDithering(), pxlOpts.getInterpolation());
         } else if(pxlOpts.getRotation() % 360 != 0) {
             img = PrintImage.rotate(img, pxlOpts.getRotation(), pxlOpts.getDithering(), pxlOpts.getInterpolation());

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -150,19 +150,17 @@ public class PrintRaw implements PrintProcessor {
 
     private ImageWrapper getImageWrapper(String data, JSONObject opt, PrintingUtilities.Flavor flavor, PrintOptions.Pixel pxlOpts) throws IOException {
         BufferedImage bi;
-
-        boolean fromFile = flavor != PrintingUtilities.Flavor.BASE64;
         // 2.0 compat
         if (data.startsWith("data:image/") && data.contains(";base64,")) {
             String[] parts = data.split(";base64,");
             data = parts[parts.length - 1];
-            fromFile = false;
+            flavor = PrintingUtilities.Flavor.BASE64;
         }
 
-        if (fromFile) {
-            bi = ImageIO.read(ConnectionUtilities.getInputStream(data));
-        } else {
+        if (flavor == PrintingUtilities.Flavor.BASE64) {
             bi = ImageIO.read(new ByteArrayInputStream(Base64.decodeBase64(data)));
+        } else {
+            bi = ImageIO.read(ConnectionUtilities.getInputStream(data));
         }
 
         return getWrapper(bi, opt, pxlOpts);


### PR DESCRIPTION
Adds the ability for a raw job to handle rotate or orientation normally reserved for pixel jobs.

This will cause backwards compat issues for customer unknowingly passing orientation to a raw job.

Closes #762 