### PR TITLE
Wmi: Fix "Local Downlevel Document", remove duplicate COMPLETE messages

### DIFF
--- a/src/qz/printer/status/StatusMonitor.java
+++ b/src/qz/printer/status/StatusMonitor.java
@@ -35,7 +35,8 @@ public class StatusMonitor {
         for (Winspool.PRINTER_INFO_2 printer : printers) {
             printerNameList.add(printer.pPrinterName);
             if (!notificationThreadCollection.containsKey(printer.pPrinterName)) {
-                Thread notificationThread = new WmiPrinterStatusThread(printer.pPrinterName);
+                boolean holdsJobs = (printer.Attributes & Winspool.PRINTER_ATTRIBUTE_KEEPPRINTEDJOBS) > 0;
+                Thread notificationThread = new WmiPrinterStatusThread(printer.pPrinterName, holdsJobs);
                 notificationThreadCollection.put(printer.pPrinterName, notificationThread);
                 notificationThread.start();
             }

--- a/src/qz/printer/status/WmiPrinterStatusThread.java
+++ b/src/qz/printer/status/WmiPrinterStatusThread.java
@@ -50,10 +50,18 @@ public class WmiPrinterStatusThread extends Thread {
     Winspool.PRINTER_NOTIFY_OPTIONS listenOptions;
     Winspool.PRINTER_NOTIFY_OPTIONS statusOptions;
 
-    private static final ArrayList<String> invalidNames = new ArrayList<String>() {{
-        add("Local Downlevel Document");
-        add("Remote Downlevel Document");
-    }};
+    // Honor translated strings, if available
+    static ArrayList<String> invalidNames;
+    static {
+        try {
+            invalidNames.add(User32Util.loadString("%SystemRoot%\\system32\\localspl.dll,108"));
+            invalidNames.add(User32Util.loadString("%SystemRoot%\\system32\\localspl.dll,107"));
+        } catch(Exception e) {
+            log.warn("Unable to obtain strings, defaulting to en-US values.", e);
+            invalidNames.add("Local Downlevel Document");
+            invalidNames.add("Remote Downlevel Document");
+        }
+    }
 
     public WmiPrinterStatusThread(String name, boolean holdsJobs) {
         super("Printer Status Monitor " + name);

--- a/src/qz/printer/status/WmiPrinterStatusThread.java
+++ b/src/qz/printer/status/WmiPrinterStatusThread.java
@@ -51,7 +51,7 @@ public class WmiPrinterStatusThread extends Thread {
     Winspool.PRINTER_NOTIFY_OPTIONS statusOptions;
 
     // Honor translated strings, if available
-    static ArrayList<String> invalidNames;
+    private static final ArrayList<String> invalidNames = new ArrayList<>();
     static {
         try {
             invalidNames.add(User32Util.loadString("%SystemRoot%\\system32\\localspl.dll,108"));

--- a/src/qz/printer/status/job/NativeJobStatus.java
+++ b/src/qz/printer/status/job/NativeJobStatus.java
@@ -20,7 +20,7 @@ public enum NativeJobStatus implements NativeStatus {
     PAPEROUT(Level.WARN),
     RETAINED(Level.INFO),
     PAUSED(Level.WARN),
-    PRINTED(Level.INFO),
+    SENT(Level.INFO),
     RESTART(Level.WARN),
     RENDERING_LOCALLY(Level.INFO),
     USER_INTERVENTION(Level.WARN),

--- a/src/qz/printer/status/job/WmiJobStatusMap.java
+++ b/src/qz/printer/status/job/WmiJobStatusMap.java
@@ -21,7 +21,7 @@ public enum WmiJobStatusMap implements NativeStatus.NativeMap {
     DELETED(NativeJobStatus.DELETED, 0x00000100), // Job has been deleted
     BLOCKED_DEVQ(NativeJobStatus.ABORTED, 0x00000200), // The driver cannot print the job
     RESTART(NativeJobStatus.RESTART, 0x00000800), // Job has been restarted
-    COMPLETE(NativeJobStatus.PRINTED, 0x00001000), // Windows XP and later: Job is sent to the printer, but the job may not be printed yet
+    COMPLETE(NativeJobStatus.SENT, 0x00001000), // Windows XP and later: Job is sent to the printer, but the job may not be printed yet
     RETAINED(NativeJobStatus.RETAINED, 0x00002000), // Windows Vista and later: Job has been retained in the print queue and cannot be deleted
     RENDERING_LOCALLY(NativeJobStatus.RENDERING_LOCALLY, 0x00004000), // Job rendering locally on the client
     USER_INTERVENTION(NativeJobStatus.USER_INTERVENTION, 0x40000000); // Printer has an error that requires the user to do something


### PR DESCRIPTION
* Changed `PRINTED` to `SENT` to avoid confusion with `COMPLETE`
* Waits for `Local Downlevel Document` to clear before triggering spooling event
* Remove occasional duplicate `COMPLETE` messages