### PR TITLE
Fix blank HTML printing on sample.html

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -2926,7 +2926,7 @@
 
     function updateConfig(cleanConditions) {
         var pxlSize = null;
-        if (isChecked($("#pxlSizeActive"), cleanConditions['pxlSizeActive'])) {
+        if (isChecked($("#pxlSizeActive"), cleanConditions['pxlSizeActive']) && (($("#pxlSizeWidth").val() !== '') && ($("#pxlSizeHeight").val() !== ''))) {
             pxlSize = {
                 width: $("#pxlSizeWidth").val(),
                 height: $("#pxlSizeHeight").val()

--- a/sample.html
+++ b/sample.html
@@ -2926,7 +2926,7 @@
 
     function updateConfig(cleanConditions) {
         var pxlSize = null;
-        if (isChecked($("#pxlSizeActive"), cleanConditions['pxlSizeActive']) && (($("#pxlSizeWidth").val() !== '') && ($("#pxlSizeHeight").val() !== ''))) {
+        if (isChecked($("#pxlSizeActive"), cleanConditions['pxlSizeActive']) && (($("#pxlSizeWidth").val() !== '') || ($("#pxlSizeHeight").val() !== ''))) {
             pxlSize = {
                 width: $("#pxlSizeWidth").val(),
                 height: $("#pxlSizeHeight").val()

--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -335,7 +335,11 @@ public class PrintOptions {
                     catch(JSONException e) { LoggerUtilities.optionWarn(log, "double", "size.height", subSize.opt("height")); }
                 }
 
-                psOptions.size = s;
+                if (s.height <= 0 && s.width <= 0) {
+                    log.warn("Page size has been set without dimensions, using default");
+                } else {
+                    psOptions.size = s;
+                }
             } else {
                 LoggerUtilities.optionWarn(log, "JSONObject", "size", configOpts.opt("size"));
             }


### PR DESCRIPTION
When size is checked on the `sample.html` page, but the height and width fields are `null`, HTML prints are blank.

This adds an additional check and only updates the `width` and `height` if there's data in the respective fields.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/12505463/116637696-9b116700-a932-11eb-928f-2191ed5169c5.png">
