### PR TITLE
Add networking prefs to qz-tray.properties

### DIFF
--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
     public static final String LOG_FILE = "debug";
     public static final String PROPS_FILE = "qz-tray"; // .properties extension is assumed
     public static final String PREFS_FILE = "prefs"; // .properties extension is assumed
-    public static final String[] PERSIST_PROPS = { "file.whitelist", "file.allow" };
+    public static final String[] PERSIST_PROPS = { "file.whitelist", "file.allow", "networking.hostname", "networking.port" };
     public static final String AUTOSTART_FILE = ".autostart";
     public static final String DATA_DIR = "qz";
     public static final int LOG_SIZE = 524288;

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -573,17 +573,17 @@ public class PrintSocketClient {
                 break;
             }
             case NETWORKING_DEVICE_LEGACY:
-                JSONObject networkDevice = NetworkUtilities.getDeviceJSON(params.optString("hostname", "google.com"), params.optInt("port", 443));
+                JSONObject networkDevice = NetworkUtilities.getDeviceJSON(params);
                 JSONObject legacyDevice = new JSONObject();
                 legacyDevice.put("ipAddress", networkDevice.optString("ip", null));
                 legacyDevice.put("macAddress", networkDevice.optString("mac", null));
                 sendResult(session, UID, legacyDevice);
                 break;
             case NETWORKING_DEVICE:
-                sendResult(session, UID, NetworkUtilities.getDeviceJSON(params.optString("hostname", "google.com"), params.optInt("port", 443)));
+                sendResult(session, UID, NetworkUtilities.getDeviceJSON(params));
                 break;
             case NETWORKING_DEVICES:
-                sendResult(session, UID, NetworkUtilities.getDevicesJSON(params.optString("hostname", "google.com"), params.optInt("port", 443)));
+                sendResult(session, UID, NetworkUtilities.getDevicesJSON(params));
                 break;
             case GET_VERSION:
                 sendResult(session, UID, Constants.VERSION);

--- a/src/qz/ws/PrintSocketServer.java
+++ b/src/qz/ws/PrintSocketServer.java
@@ -31,10 +31,7 @@ import qz.installer.certificate.CertificateManager;
 import qz.installer.certificate.ExpiryTask;
 import qz.installer.certificate.KeyPairWrapper;
 import qz.installer.certificate.NativeCertificateInstaller;
-import qz.utils.ArgParser;
-import qz.utils.ArgValue;
-import qz.utils.FileUtilities;
-import qz.utils.SystemUtilities;
+import qz.utils.*;
 
 import javax.swing.*;
 import java.io.File;
@@ -89,6 +86,9 @@ public class PrintSocketServer {
             log.error("Something went critically wrong loading HTTPS", e);
         }
         Installer.getInstance().addUserSettings();
+
+        // Load overridable preferences set in qz-tray.properties file
+        NetworkUtilities.setPreferences(certificateManager.getProperties());
 
         // Linux needs the cert installed in user-space on every launch for Chrome SSL to work
         if (!SystemUtilities.isWindows() && !SystemUtilities.isMac()) {


### PR DESCRIPTION
Adds the ability for a user to override the default `hostName` and `port` values internal to QZ Tray `NetworkUtilities` which `qz.networking` will use to calculate the primary network adapter.

Closes #837