### PR TITLE
Small changes around remote connections

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -1401,17 +1401,19 @@
     }
 
     function startConnection(config) {
-        host = $('#connectionHost').val().trim();
-        usingSecure = $("#connectionUsingSecure").prop('checked');
+        var host = $('#connectionHost').val().trim();
+        var usingSecure = $("#connectionUsingSecure").prop('checked');
+
         // Connect to a print-server instance, if specified
-        if(host != "" && host != 'localhost') {
-            if(config) {
+        if (host != "" && host != 'localhost') {
+            if (config) {
                 config.host = host;
                 config.usingSecure = usingSecure;
             } else {
-                config = { host: host,  usingSecure: usingSecure };
+                config = { host: host, usingSecure: usingSecure };
             }
         }
+
         if (!qz.websocket.isActive()) {
             updateState('Waiting', 'default');
 
@@ -1456,8 +1458,7 @@
 
         qz.networking.devices().then(function(data) {
             var list = '';
-            var hostname = '';
-            var username = '';
+
             for(var i = 0; i < data.length; i++) {
                 var info = data[i];
 
@@ -1466,8 +1467,8 @@
                         "   <strong>Hostname:</strong> <code>" + info.hostname + "</code>" +
                         "</li>" +
                         "<li>" +
-                        "   <strong>Username:</strong> <code>" + info.username + "</code>"
-                    "</li>";
+                        "   <strong>Username:</strong> <code>" + info.username + "</code>" +
+                        "</li>";
                 }
                 list += "<li>" +
                     "   <strong>Interface:</strong> <code>" + (info.name || "UNKNOWN") + (info.id ? "</code> (<code>" + info.id + "</code>)" : "</code>") +
@@ -2407,7 +2408,14 @@
     function resetGeneralOptions() {
         //connection
         $("#connectionHost").val('localhost');
-        $("#connectionUsingSecure").prop('disabled', location.protocol !== 'https:');
+
+        var secureOpt = $("#connectionUsingSecure");
+        if (location.protocol !== 'https:') {
+            secureOpt.prop('disabled', true);
+            secureOpt.prop('checked', false);
+        } else {
+            secureOpt.prop('disabled', false);
+        }
     }
 
     function resetRawOptions() {

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -6,6 +6,7 @@ import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.websocket.api.CloseException;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketException;
 import org.eclipse.jetty.websocket.api.annotations.*;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
 
 
 @WebSocket
@@ -82,6 +84,12 @@ public class PrintSocketClient {
     @OnWebSocketError
     public void onError(Session session, Throwable error) {
         if (error instanceof EOFException) { return; }
+
+        if (error instanceof CloseException && error.getCause() instanceof TimeoutException) {
+            log.error("Timeout error (Lost connection with client)", error);
+            return;
+        }
+
         log.error("Connection error", error);
         trayManager.displayErrorMessage(error.getMessage());
     }


### PR DESCRIPTION
A couple of small changes from attempting to debug #691 

1. On sample page - deselect the 'secure' checkbox when disabled if a secure connection wasn't possible so any connections attempt won't still try to use wss.
2. In qz app - prevent any client timeout exceptions from displaying an error message to users (still sent to the logs though).