### PR TITLE
Add support for experimental Firefox releases

### DIFF
--- a/src/qz/installer/certificate/firefox/locator/AppAlias.java
+++ b/src/qz/installer/certificate/firefox/locator/AppAlias.java
@@ -5,7 +5,9 @@ import java.util.Locale;
 public enum AppAlias {
     // Tor Browser intentionally excluded; Tor's proxy blocks localhost connections
     FIREFOX(
-            new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox", true), // Windows
+            new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox", true),
+            new Alias("Mozilla", "Firefox Developer Edition", "org.mozilla.firefox", true),
+            new Alias("Mozilla", "Firefox Nightly", "org.mozilla.firefox", true),
             new Alias("Mozilla", "SeaMonkey", "org.mozilla.seamonkey", false),
             new Alias("Waterfox", "Waterfox", "net.waterfox.waterfoxcurrent", true),
             new Alias("Waterfox", "Waterfox Classic", "org.waterfoxproject.waterfox classic", false),

--- a/src/qz/installer/certificate/firefox/locator/AppAlias.java
+++ b/src/qz/installer/certificate/firefox/locator/AppAlias.java
@@ -6,8 +6,8 @@ public enum AppAlias {
     // Tor Browser intentionally excluded; Tor's proxy blocks localhost connections
     FIREFOX(
             new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox", true),
-            new Alias("Mozilla", "Firefox Developer Edition", "org.mozilla.firefox", true),
-            new Alias("Mozilla", "Firefox Nightly", "org.mozilla.firefox", true),
+            new Alias("Mozilla", "Firefox Developer Edition", "org.mozilla.firefoxdevelopereditionx", true),
+            new Alias("Mozilla", "Firefox Nightly", "org.mozilla.nightly", true),
             new Alias("Mozilla", "SeaMonkey", "org.mozilla.seamonkey", false),
             new Alias("Waterfox", "Waterfox", "net.waterfox.waterfoxcurrent", true),
             new Alias("Waterfox", "Waterfox Classic", "org.waterfoxproject.waterfox classic", false),

--- a/src/qz/installer/certificate/firefox/locator/AppAlias.java
+++ b/src/qz/installer/certificate/firefox/locator/AppAlias.java
@@ -6,7 +6,7 @@ public enum AppAlias {
     // Tor Browser intentionally excluded; Tor's proxy blocks localhost connections
     FIREFOX(
             new Alias("Mozilla", "Mozilla Firefox", "org.mozilla.firefox", true),
-            new Alias("Mozilla", "Firefox Developer Edition", "org.mozilla.firefoxdevelopereditionx", true),
+            new Alias("Mozilla", "Firefox Developer Edition", "org.mozilla.firefoxdeveloperedition", true),
             new Alias("Mozilla", "Firefox Nightly", "org.mozilla.nightly", true),
             new Alias("Mozilla", "SeaMonkey", "org.mozilla.seamonkey", false),
             new Alias("Waterfox", "Waterfox", "net.waterfox.waterfoxcurrent", true),

--- a/src/qz/installer/certificate/firefox/locator/AppInfo.java
+++ b/src/qz/installer/certificate/firefox/locator/AppInfo.java
@@ -73,7 +73,15 @@ public class AppInfo {
                 version = version + ".0";
             }
             return Version.valueOf(version);
-        } catch(Exception ignore) {}
+        } catch(Exception ignore1) {
+            // Catch poor formatting (e.g. "97.0a1"), try to use major version only
+            if(version.split("\\.").length > 0) {
+                try {
+                    String[] tryFix = version.split("\\.");
+                    return Version.valueOf(tryFix[0] + ".0.0-unknown");
+                } catch(Exception ignore2) {}
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
Closes #217, #889

As @sheck points out in #889, Firefox Developer Edition is not properly supported on MacOS.  This PR adds support for detecting these browsers for Policy File installation.