### PR TITLE
fix(osx): bundle override.crt file in Contents/Resources

### DIFF
--- a/ant/apple/installer.xml
+++ b/ant/apple/installer.xml
@@ -168,6 +168,7 @@
             <fileset dir="${dist.dir}">
                 <include name="${project.filename}.jar"/>
                 <include name="LICENSE.txt"/>
+                <include name="override.crt"/>
             </fileset>
         </copy>
         <copy file="assets/branding/apple-icon.icns" tofile="${bundle.dir}/Contents/Resources/${project.filename}.icns"/>


### PR DESCRIPTION
Hello,

When building package for osx with  `-Dauthcert.use= ` override.crt is not copied from `dist` into `Contents/Resources`. 