### PR TITLE
Allow idle tasks to be flagged as disabled

### DIFF
--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -61,6 +61,8 @@ public class Constants {
     public static final String PREFS_HEADLESS = "tray.headless";
     public static final String PREFS_MONOCLE = "tray.monocle";
     public static final String PREFS_STRICT_MODE = "tray.strictmode";
+    public static final String PREFS_IDLE_PRINTERS = "tray.idle.printers";
+    public static final String PREFS_IDLE_JFX = "tray.idle.javafx";
 
     public static final String ALLOW_SITES_TEXT = "Permanently allowed \"%s\" to access local resources";
     public static final String BLOCK_SITES_TEXT = "Permanently blocked \"%s\" from accessing local resources";

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -95,10 +95,10 @@ public class TrayManager {
         prefs = new PropertyHelper(FileUtilities.USER_DIR + File.separator + Constants.PREFS_FILE + ".properties");
 
         // Set strict certificate mode preference
-        Certificate.setTrustBuiltIn(!prefs.getBoolean(Constants.PREFS_STRICT_MODE, false));
+        Certificate.setTrustBuiltIn(!getPref(Constants.PREFS_STRICT_MODE, false));
 
         //headless if turned on by user or unsupported by environment
-        headless = isHeadless || prefs.getBoolean(Constants.PREFS_HEADLESS, false) || GraphicsEnvironment.isHeadless();
+        headless = isHeadless || getPref(Constants.PREFS_HEADLESS, false) || GraphicsEnvironment.isHeadless();
         if (headless) {
             log.info("Running in headless mode");
         }
@@ -202,14 +202,14 @@ public class TrayManager {
         idleTimers = new ArrayList<>();
 
         // Slow to find printers the first time if a lot of printers are installed
-        if (prefs.getBoolean(Constants.PREFS_IDLE_PRINTERS, true)) {
+        if (getPref(Constants.PREFS_IDLE_PRINTERS, true)) {
             performIfIdle((int)TimeUnit.SECONDS.toMillis(10), evt -> {
                 log.debug("IDLE: Performing first run of find printers");
                 PrintServiceMatcher.getNativePrinterList(false, true);
             });
         }
         // Slow to start JavaFX the first time
-        if (prefs.getBoolean(Constants.PREFS_IDLE_JFX, true)) {
+        if (getPref(Constants.PREFS_IDLE_JFX, true)) {
             performIfIdle((int)TimeUnit.SECONDS.toMillis(60), evt -> {
                 log.debug("IDLE: Starting up JFX for HTML printing");
                 try {
@@ -273,14 +273,14 @@ public class TrayManager {
         JCheckBoxMenuItem notificationsItem = new JCheckBoxMenuItem("Show all notifications");
         notificationsItem.setToolTipText("Shows all connect/disconnect messages, useful for debugging purposes");
         notificationsItem.setMnemonic(KeyEvent.VK_S);
-        notificationsItem.setState(prefs.getBoolean(Constants.PREFS_NOTIFICATIONS, false));
+        notificationsItem.setState(getPref(Constants.PREFS_NOTIFICATIONS, false));
         notificationsItem.addActionListener(notificationsListener);
         diagnosticMenu.add(notificationsItem);
 
         JCheckBoxMenuItem monocleItem = new JCheckBoxMenuItem("Use Monocle for HTML");
         monocleItem.setToolTipText("Use monocle platform for HTML printing (restart required)");
         monocleItem.setMnemonic(KeyEvent.VK_U);
-        monocleItem.setState(prefs.getBoolean(Constants.PREFS_MONOCLE, true));
+        monocleItem.setState(getPref(Constants.PREFS_MONOCLE, true));
         if(!SystemUtilities.hasMonocle()) {
             log.warn("Monocle engine was not detected");
             monocleItem.setEnabled(false);
@@ -463,7 +463,7 @@ public class TrayManager {
 
     private final ActionListener exitListener = new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-            boolean showAllNotifications = prefs.getBoolean(Constants.PREFS_NOTIFICATIONS, false);
+            boolean showAllNotifications = getPref(Constants.PREFS_NOTIFICATIONS, false);
             if (!showAllNotifications || confirmDialog.prompt("Exit " + name + "?")) { exit(0); }
         }
     };
@@ -650,7 +650,7 @@ public class TrayManager {
         if (!headless) {
             if (tray != null) {
                 SwingUtilities.invokeLater(() -> {
-                    boolean showAllNotifications = prefs.getBoolean(Constants.PREFS_NOTIFICATIONS, false);
+                    boolean showAllNotifications = getPref(Constants.PREFS_NOTIFICATIONS, false);
                     if (showAllNotifications || level != TrayIcon.MessageType.INFO) {
                         tray.displayMessage(caption, text, level);
                     }
@@ -670,11 +670,18 @@ public class TrayManager {
     }
 
     public boolean isMonoclePreferred() {
-        return prefs.getBoolean(Constants.PREFS_MONOCLE, true);
+        return getPref(Constants.PREFS_MONOCLE, true);
     }
 
     public boolean isHeadless() {
         return headless;
+    }
+
+    /**
+     * Get boolean user pref: Searching "user", "app" and <code>System.getProperty(...)</code>.
+     */
+    private boolean getPref(String name, boolean defaultVal) {
+        return PrefsSearch.get(prefs, PrintSocketServer.getTrayProperties(), name, defaultVal + "").equalsIgnoreCase("true");
     }
 
     private void performIfIdle(int idleQualifier, ActionListener performer) {

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -202,20 +202,24 @@ public class TrayManager {
         idleTimers = new ArrayList<>();
 
         // Slow to find printers the first time if a lot of printers are installed
-        performIfIdle((int)TimeUnit.SECONDS.toMillis(10), evt -> {
-            log.debug("IDLE: Performing first run of find printers");
-            PrintServiceMatcher.getNativePrinterList(false, true);
-        });
+        if (prefs.getBoolean(Constants.PREFS_IDLE_PRINTERS, true)) {
+            performIfIdle((int)TimeUnit.SECONDS.toMillis(10), evt -> {
+                log.debug("IDLE: Performing first run of find printers");
+                PrintServiceMatcher.getNativePrinterList(false, true);
+            });
+        }
         // Slow to start JavaFX the first time
-        performIfIdle((int)TimeUnit.SECONDS.toMillis(60), evt -> {
-            log.debug("IDLE: Starting up JFX for HTML printing");
-            try {
-                WebApp.initialize();
-            }
-            catch(IOException e) {
-                log.error("Idle runner failed to preemptively start JavaFX service");
-            }
-        });
+        if (prefs.getBoolean(Constants.PREFS_IDLE_JFX, true)) {
+            performIfIdle((int)TimeUnit.SECONDS.toMillis(60), evt -> {
+                log.debug("IDLE: Starting up JFX for HTML printing");
+                try {
+                    WebApp.initialize();
+                }
+                catch(IOException e) {
+                    log.error("Idle runner failed to preemptively start JavaFX service");
+                }
+            });
+        }
     }
 
     /**

--- a/src/qz/utils/PrefsSearch.java
+++ b/src/qz/utils/PrefsSearch.java
@@ -1,0 +1,57 @@
+package qz.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+
+/**
+ * Convenience class for searching for preferences on a user, app and <code>System.getProperty(...)</code> level
+ */
+public class PrefsSearch {
+    protected static final Logger log = LoggerFactory.getLogger(PrefsSearch.class);
+
+    public static String get(Properties user, Properties app, String name) {
+        return get(user, app, name, null, null);
+    }
+
+    public static String get(Properties user, Properties app, String name, String defaultVal, String ... altNames) {
+        String returnVal;
+
+        ArrayList<String> names = new ArrayList();
+        names.add(name);
+
+        if(altNames != null && altNames.length > 0) {
+            names.addAll(Arrays.asList(altNames));
+        }
+
+        for(String n : names) {
+            // First, honor System property
+            if ((returnVal = System.getProperty(n)) != null) {
+                log.info("Picked up system property {}={}", n, returnVal);
+                return returnVal;
+            }
+
+            // Second, honor user preference
+            if (user != null) {
+                if ((returnVal = user.getProperty(n)) != null) {
+                    log.info("Picked up user preference {}={}", n, returnVal);
+                    return returnVal;
+                }
+            }
+
+            // Third, honor app property
+            if (app != null) {
+                if ((returnVal = app.getProperty(n)) != null) {
+                    log.info("Picked up app property {}={}", n, returnVal);
+                    return returnVal;
+                }
+            }
+        }
+
+        // Last, return default property
+        return defaultVal;
+    }
+}


### PR DESCRIPTION
For #924

Closes #926 

Idle tasks can be disabled by adding `tray.idle.printers=false` or `tray.idle.javafx=false` to the prefs.properties file.