### PR TITLE
Retrieve spooled file data

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1284,6 +1284,7 @@ var qz = (function() {
              * @param {Object|null} [options] Printer listener options
              *  @param {null|boolean} [options.jobData=false] Flag indicating if raw spool file content should be return as well as status information (Windows only)
              *  @param {null|number} [options.maxJobData=-1] Maximum number of bytes to returns for raw spooled file content (Windows only)
+             *  @param {null|string} [options.flavor="plain"] Flavor of data format returned. Valid flavors are <code>[base64 | hex | plain*]</code> (Windows only)
              *
              * @memberof qz.printers
              */

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1281,16 +1281,22 @@ var qz = (function() {
              * @see qz.printers.setPrinterCallbacks
              *
              * @param {null|string|Array<string>} printers Printer or list of printers to listen to, null listens to all.
+             * @param {Object|null} [options] Printer listener options
+             *  @param {null|boolean} [options.jobData=false] Flag indicating if raw spool file content should be return as well as status information (Windows only)
+             *  @param {null|number} [options.maxJobData=-1] Maximum number of bytes to returns for raw spooled file content (Windows only)
              *
              * @memberof qz.printers
              */
-            startListening: function(printers) {
+            startListening: function(printers, options) {
                 if (!Array.isArray(printers)) {
                     printers = [printers];
                 }
                 var params = {
                     printerNames: printers
                 };
+                if (options && options.jobData == true) params.jobData = true;
+                if (options && options.maxJobData) params.maxJobData = options.maxJobData;
+                if (options && options.flavor) params.flavor = options.flavor;
                 return _qz.websocket.dataPromise('printers.startListening', params);
             },
 

--- a/sample.html
+++ b/sample.html
@@ -2971,7 +2971,7 @@
             if(!streamEvent.data) {
                 // Most commonly a permissions issue reading C:\Windows\system32\spool\PRINTERS\<jobId>
                 // A custom spool location can be set using HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print\Printers\DefaultSpoolDirectory
-                jobData = "&lt;No data received, this may be a permissions issue&gt;";
+                jobData = "&lt;No data received, this may be a permissions issue or the printer may not be configured to retain documents.&gt;";
                 dataLevel = "FATAL";
             } else {
                 // Only show the first 64 characters (for display purposes)

--- a/sample.html
+++ b/sample.html
@@ -1108,7 +1108,7 @@
                                     <button type="button" class="btn btn-success" onclick="startPrintersListen($('#configPrinter').text())">
                                         Current Printer
                                     </button>
-                                    <button type="button" class="btn btn-default" onclick="getPrintersStatus()">Request current status</button>
+                                    <button type="button" class="btn btn-default" onclick="getPrintersStatus()">Request Current Status</button>
                                 </div>
                                 <div class="btn-group">
                                     <button type="button" class="btn btn-warning" onclick="stopPrintersListen()">Stop Listening</button>
@@ -1121,22 +1121,60 @@
                 <div class="row" style="margin-top: 1em;">
                     <div class="col-md-12">
                         <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h4 class="panel-title">Event Log</h4>
-                            </div>
-
                             <div class="panel-body">
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <pre id="printersLog"></pre>
+                                <fieldset>
+                                    <legend>Options</legend>
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="form-group form-inline">
+                                                <label class="tip" for="jobData" data-toggle="tooltip" title="Returns raw spool file content for printers configured to keep spooled documents (Windows only)">
+                                                    Include Raw Job Data
+                                                </label>
+                                                <input type="checkbox" id="jobData" class="pull-right"/>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 pull-right">
+                                            <div class="form-group form-inline">
+                                                <label class="tip" for="maxJobData" data-toggle="tooltip" title="Maximum size in bytes of spool file content to return (Windows only)">
+                                                Raw Job Data Size
+                                                </label>
+                                                <input type="number" id="maxJobData" class="pull-right"/>
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
-                                <hr />
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <button type="button" class="btn btn-danger pull-right" onclick="clearPrintersLog();">Clear</button>
+                                    <div class="form-group form-inline">
+                                        <label>
+                                            Job Data Type
+                                        </label>
+                                        <div class="btn-group pull-right" id="jobDataRadio" data-toggle="buttons">
+                                            <label id="jobDataPlain" class="btn btn-default active">
+                                                <input type="radio" name="jobDataRadio" value="Plain" class="toggle" autocomplete="off" checked>
+                                                Plain</label>
+                                            </label>
+                                            <label id="jobDataHex" class="btn btn-default">
+                                                <input type="radio" name="jobDataRadio" value="Hex" class="toggle" autocomplete="off">
+                                                Hex</label>
+                                            </label>
+                                            <label id="jobDataBase64" class="btn btn-default">
+                                                <input type="radio" name="jobDataRadio" value="XML" class="toggle" autocomplete="off">
+                                                Base64</label>
+                                            </label>
+                                        </div>
                                     </div>
-                                </div>
+                                    <hr />
+                                    <legend>Event Log</legend>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <pre id="printersLog"></pre>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+
+                                        </div>
+                                    </div>
+                                    <button type="button" class="btn btn-danger pull-right" onclick="clearPrintersLog();"><i class="fa fa-trash"></i> Clear</button>
+                                </fieldset>
                             </div>
                         </div>
                     </div>
@@ -2371,12 +2409,20 @@
 
     /// Status ///
     function startPrintersListen(printerName) {
+        var jobData = $("#jobData").prop("checked");
+        var jobDataFlavor = $('input[name="jobDataRadio"]:checked').val();
+        var maxJobData = $("#maxJobData").val();
         if (printerName === "NONE") {
             return displayMessage("Please search for a valid printer first", "alert-warning");
         }
         qz.printers.stopListening().then(function() {
             clearPrintersLog();
-            return qz.printers.startListening(printerName);
+            var params = {
+                jobData: jobData,
+                maxJobData: maxJobData,
+                flavor: jobDataFlavor
+            };
+            return qz.printers.startListening(printerName, params);
         }).then(function() {
             displayMessage("Started listening for " + (printerName ? printerName : "all") + " printer events");
         }).catch(displayError);
@@ -2913,8 +2959,28 @@
     }
 
     function addPrintersLog(streamEvent) {
-        var icon = '<span class="fa ' + (streamEvent.eventType == 'JOB' ? 'fa-exchange' : 'fa-print') + '"></span>&nbsp;';
-        var msg = '<p class="' + (streamEvent.severity || "") + ' text-nowrap">' + icon + new Date().toString() + ": " + streamEvent.message + "</p>";
+        var msg;
+        if (streamEvent.eventType == "JOB_DATA") {
+            var jobData;
+            var dataLevel;
+            if(!streamEvent.data) {
+                // Most commonly a permissions issue reading C:\Windows\system32\spool\PRINTERS\<jobId>
+                // A custom spool location can be set using HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print\Printers\DefaultSpoolDirectory
+                jobData = "&lt;No data received, this may be a permissions issue&gt;";
+                dataLevel = "FATAL";
+            } else {
+                // Only show the first 64 characters (for display purposes)
+                var DISPLAY_LEN = 64;
+                jobData = streamEvent.data.substring(0, DISPLAY_LEN) + (streamEvent.data.length > DISPLAY_LEN ? "..." : "");
+                dataLevel = "INFO";
+            }
+            var icon = '<span class="fa fa-file-o"></span>&nbsp;';
+            msg = '<p class="' + dataLevel + '" text-nowrap">' + icon + new Date().toString() + ": JOB DATA: " + jobData + "</p>";
+
+        } else {
+            var icon = '<span class="fa ' + (streamEvent.eventType == 'JOB' ? 'fa-exchange' : 'fa-print') + '"></span>&nbsp;';
+            msg = '<p class="' + (streamEvent.severity || "") + ' text-nowrap">' + icon + new Date().toString() + ": " + streamEvent.message + "</p>";
+        }
         var $log = $("#printersLog");
         $log.html($log.html() + msg);
     }

--- a/sample.html
+++ b/sample.html
@@ -1143,21 +1143,19 @@
                                         </div>
                                     </div>
                                     <div class="form-group form-inline">
-                                        <label>
-                                            Job Data Type
-                                        </label>
-                                        <div class="btn-group pull-right" id="jobDataRadio" data-toggle="buttons">
-                                            <label id="jobDataPlain" class="btn btn-default active">
-                                                <input type="radio" name="jobDataRadio" value="Plain" class="toggle" autocomplete="off" checked>
-                                                Plain</label>
+                                        <label>Job Data Type</label>
+                                        <div>
+                                            <label>
+                                                <input type="radio" name="jobDataRadio" id="jobFlavorPLN" value="plain" />
+                                                Plain
                                             </label>
-                                            <label id="jobDataHex" class="btn btn-default">
-                                                <input type="radio" name="jobDataRadio" value="Hex" class="toggle" autocomplete="off">
-                                                Hex</label>
+                                            <label>
+                                                <input type="radio" name="jobDataRadio" id="jobFlavorB64" value="base64" />
+                                                Base64
                                             </label>
-                                            <label id="jobDataBase64" class="btn btn-default">
-                                                <input type="radio" name="jobDataRadio" value="XML" class="toggle" autocomplete="off">
-                                                Base64</label>
+                                            <label>
+                                                <input type="radio" name="jobDataRadio" id="jobFlavorHEX" value="hex" />
+                                                Hexadecimal
                                             </label>
                                         </div>
                                     </div>
@@ -2721,6 +2719,12 @@
         $("#fileLength").val('10');
     }
 
+    function resetPrinterStatusOptions() {
+        $("#jobData").prop('checked', false);
+        $("#maxJobData").val('');
+        $("#jobFlavorPLN").prop('checked', true);
+    }
+
 
     /// Page load ///
     $(document).ready(function() {
@@ -2733,6 +2737,7 @@
         resetUsbOptions();
         resetHidOptions();
         resetFileOptions();
+        resetPrinterStatusOptions();
         updateRawButtons();
 
         startConnection();

--- a/src/qz/communication/FileParams.java
+++ b/src/qz/communication/FileParams.java
@@ -1,29 +1,23 @@
 package qz.communication;
 
-import org.apache.commons.ssl.Base64;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import qz.utils.ByteUtilities;
-import qz.utils.FileUtilities;
+import qz.utils.PrintingUtilities.Flavor;
 
 import java.io.IOException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Locale;
 
 /**
  * Created by Kyle on 2/28/2018.
  */
 public class FileParams {
     private static final Logger log = LogManager.getLogger(FileParams.class);
-
-    public enum Flavor {
-        BASE64, FILE, HEX, PLAIN
-    }
 
     private Path path;
     private String data;
@@ -38,7 +32,7 @@ public class FileParams {
     public FileParams(JSONObject params) throws JSONException {
         path = Paths.get(params.getString("path"));
         data = params.optString("data", "");
-        flavor = Flavor.valueOf(params.optString("flavor", "PLAIN").toUpperCase(Locale.ENGLISH));
+        flavor = Flavor.parse(params, Flavor.PLAIN);
 
         shared = params.optBoolean("shared", true);
         sandbox = params.optBoolean("sandbox", true);
@@ -50,36 +44,12 @@ public class FileParams {
         return path;
     }
 
-    public static String toString(Flavor flavor, byte[] bytes) {
-        switch(flavor) {
-            case BASE64:
-                return Base64.encodeBase64String(bytes);
-            case HEX:
-                return ByteUtilities.bytesToHex(bytes);
-            case FILE:
-                log.warn("FileParams.toString(...) does not support {}, defaulting to {}", Flavor.FILE, Flavor.PLAIN);
-            case PLAIN:
-            default:
-                return new String(bytes);
-        }
-    }
-
     public String toString(byte[] bytes) {
-        return toString(flavor, bytes);
+        return ByteUtilities.toString(flavor, bytes);
     }
 
     public byte[] getData() throws IOException {
-        switch(flavor) {
-            case BASE64:
-                return Base64.decodeBase64(data);
-            case FILE:
-                return FileUtilities.readRawFile(data);
-            case HEX:
-                return ByteUtilities.hexStringToByteArray(data.trim());
-            case PLAIN:
-            default:
-                return data.getBytes();
-        }
+        return flavor.read(data);
     }
 
     public Flavor getFlavor() {

--- a/src/qz/printer/action/PrintDirect.java
+++ b/src/qz/printer/action/PrintDirect.java
@@ -46,7 +46,7 @@ public class PrintDirect extends PrintRaw {
             if (data == null) { continue; }
 
             prints.add(data.getString("data"));
-            flavors.add(PrintingUtilities.Flavor.valueOf(data.optString("flavor", "PLAIN").toUpperCase(Locale.ENGLISH)));
+            flavors.add(PrintingUtilities.Flavor.parse(data, PrintingUtilities.Flavor.PLAIN));
         }
     }
 

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -14,7 +14,6 @@ import com.sun.javafx.print.PrintHelper;
 import com.sun.javafx.print.Units;
 import javafx.print.*;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.ssl.Base64;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -76,11 +75,11 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
             for(int i = 0; i < printData.length(); i++) {
                 JSONObject data = printData.getJSONObject(i);
 
-                PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "FILE").toUpperCase(Locale.ENGLISH));
+                PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.parse(data, PrintingUtilities.Flavor.FILE);
 
                 String source;
-                if (flavor == PrintingUtilities.Flavor.BASE64) {
-                    source = new String(Base64.decodeBase64(data.getString("data")), StandardCharsets.UTF_8);
+                if (flavor != PrintingUtilities.Flavor.FILE) {
+                    source = new String(flavor.read(data.getString("data")), StandardCharsets.UTF_8);
                 } else {
                     source = data.getString("data");
                 }

--- a/src/qz/printer/action/PrintImage.java
+++ b/src/qz/printer/action/PrintImage.java
@@ -10,7 +10,6 @@
  */
 package qz.printer.action;
 
-import org.apache.commons.ssl.Base64;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -74,12 +73,12 @@ public class PrintImage extends PrintPixel implements PrintProcessor, Printable 
         for(int i = 0; i < printData.length(); i++) {
             JSONObject data = printData.getJSONObject(i);
 
-            PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "FILE").toUpperCase(Locale.ENGLISH));
+            PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.parse(data, PrintingUtilities.Flavor.FILE);
 
             try {
                 BufferedImage bi;
-                if (flavor == PrintingUtilities.Flavor.BASE64) {
-                    bi = ImageIO.read(new ByteArrayInputStream(Base64.decodeBase64(data.getString("data"))));
+                if (flavor != PrintingUtilities.Flavor.FILE) {
+                    bi = ImageIO.read(new ByteArrayInputStream(flavor.read(data.getString("data"))));
                 } else {
                     bi = ImageIO.read(ConnectionUtilities.getInputStream(data.getString("data")));
                 }

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -1,7 +1,6 @@
 package qz.printer.action;
 
 import com.github.zafarkhaja.semver.Version;
-import org.apache.commons.ssl.Base64;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.io.IOUtils;
@@ -106,12 +105,12 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
                 }
             }
 
-            PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.valueOf(data.optString("flavor", "FILE").toUpperCase(Locale.ENGLISH));
+            PrintingUtilities.Flavor flavor = PrintingUtilities.Flavor.parse(data, PrintingUtilities.Flavor.FILE);
 
             try {
                 PDDocument doc;
-                if (flavor == PrintingUtilities.Flavor.BASE64) {
-                    doc = PDDocument.load(new ByteArrayInputStream(Base64.decodeBase64(data.getString("data"))));
+                if (flavor != PrintingUtilities.Flavor.FILE) {
+                    doc = PDDocument.load(new ByteArrayInputStream(flavor.read(data.getString("data"))));
                 } else {
                     doc = PDDocument.load(ConnectionUtilities.getInputStream(data.getString("data")));
                 }

--- a/src/qz/printer/status/Status.java
+++ b/src/qz/printer/status/Status.java
@@ -19,6 +19,7 @@ public class Status {
 
     enum EventType {
         JOB,
+        JOB_DATA,
         PRINTER;
     }
 

--- a/src/qz/printer/status/StatusMonitor.java
+++ b/src/qz/printer/status/StatusMonitor.java
@@ -160,10 +160,6 @@ public class StatusMonitor {
         }
     }
 
-    public synchronized static boolean isListeningTo(String PrinterName) {
-        return clientPrinterConnections.containsKey(PrinterName) || clientPrinterConnections.containsKey(ALL_PRINTERS);
-    }
-
     public synchronized static void statusChanged(Status[] statuses) {
         HashSet<SocketConnection> connections = new HashSet<>();
         for (Status status : statuses) {

--- a/src/qz/printer/status/StatusSession.java
+++ b/src/qz/printer/status/StatusSession.java
@@ -1,11 +1,47 @@
 package qz.printer.status;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.websocket.api.Session;
+import qz.App;
+import qz.printer.status.job.WmiJobStatusMap;
+import qz.utils.*;
 import qz.ws.PrintSocketClient;
 import qz.ws.StreamEvent;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static qz.printer.status.StatusMonitor.ALL_PRINTERS;
+
 public class StatusSession {
+    private static final Logger log = LogManager.getLogger(StatusSession.class);
     private Session session;
+    private HashMap<String, Spooler> printerSpoolerMap = new HashMap<>();
+
+    private class Spooler implements Cloneable {
+        public Path path;
+        public int maxJobData;
+        public PrintingUtilities.Flavor dataFlavor;
+
+        public Spooler() {
+            this(null, -1, PrintingUtilities.Flavor.PLAIN);
+        }
+
+        public Spooler(Path path, int maxJobData, PrintingUtilities.Flavor dataFlavor) {
+            this.path = path;
+            this.maxJobData = maxJobData;
+            this.dataFlavor = dataFlavor;
+        }
+
+        @Override
+        public Spooler clone() {
+            return new Spooler(path, maxJobData, dataFlavor);
+        }
+    }
 
     public StatusSession(Session session) {
         this.session = session;
@@ -13,6 +49,42 @@ public class StatusSession {
 
     public void statusChanged(Status status) {
         PrintSocketClient.sendStream(session, createStatusStream(status));
+        // If this statusSession has printers flagged to return jobData, issue a jobData event after any 'retained' job events
+        if (status.getCode() == WmiJobStatusMap.RETAINED.getParent() && isDataPrinter(status.getPrinter())) {
+            PrintSocketClient.sendStream(session, createJobDataStream(status));
+        }
+    }
+
+    public void enableJobDataOnPrinter(String printer, int maxJobData, PrintingUtilities.Flavor dataFlavor) throws UnsupportedOperationException {
+        if (!SystemUtilities.isWindows()) {
+            throw new UnsupportedOperationException("Job data listeners are only supported on Windows");
+        }
+        String spoolFileMonitoring = PrefsSearch.get(App.getTrayProperties(), "printer.status.jobdata", "false", false );
+        if (!Boolean.parseBoolean(spoolFileMonitoring)) {
+            throw new UnsupportedOperationException("Job data listeners are currently disabled");
+        }
+        if (printerSpoolerMap.containsKey(printer)) {
+            printerSpoolerMap.get(printer).maxJobData = maxJobData;
+        } else {
+            // Lookup spooler path lazily
+            printerSpoolerMap.put(printer, new Spooler(null, maxJobData, dataFlavor));
+        }
+        if (printer.equals(ALL_PRINTERS)) {
+            // If we have started job-data listening on all printer, the new parameters need to be added to all existing printers
+            for(Map.Entry<String, Spooler> entry : printerSpoolerMap.entrySet()) {
+                entry.getValue().maxJobData = maxJobData;
+            }
+        }
+    }
+
+    private StreamEvent createJobDataStream(Status status) {
+        StreamEvent streamEvent = new StreamEvent(StreamEvent.Stream.PRINTER, StreamEvent.Type.ACTION)
+                .withData("printerName", status.sanitizePrinterName())
+                .withData("eventType", Status.EventType.JOB_DATA)
+                .withData("jobID", status.getJobId())
+                .withData("jobName", status.getJobName())
+                .withData("data", getJobData(status.getJobId(), status.getPrinter()));
+        return streamEvent;
     }
 
     private StreamEvent createStatusStream(Status status) {
@@ -30,5 +102,36 @@ public class StatusSession {
             streamEvent.withData("jobName", status.getJobName());
         }
         return streamEvent;
+    }
+
+    private String getJobData(int jobId, String printer) {
+        String data = null;
+        try {
+            if (!printerSpoolerMap.containsKey(printer)) {
+                // If not listening on this printer, assume we're listening on ALL_PRINTERS
+                Spooler spooler;
+                if(printerSpoolerMap.containsKey(ALL_PRINTERS)) {
+                    spooler = printerSpoolerMap.get(ALL_PRINTERS).clone();
+                } else {
+                    // we should never get here
+                    spooler = new Spooler();
+                }
+                printerSpoolerMap.put(printer, spooler);
+            }
+            Spooler spooler = printerSpoolerMap.get(printer);
+            if (spooler.path == null) spooler.path = WindowsUtilities.getSpoolerLocation(printer);
+            if (spooler.maxJobData != -1 && Files.size(spooler.path) > spooler.maxJobData) {
+                throw new IOException("File too large, omitting result. Size:" + Files.size(spooler.path) + " MaxJobData:" + spooler.maxJobData);
+            }
+            data = spooler.dataFlavor.toString(Files.readAllBytes(spooler.path.resolve(String.format("%05d", jobId) + ".SPL")));
+        }
+        catch(IOException e) {
+            log.error("Failed to retrieve job data from job #{}", jobId, e);
+        }
+        return data;
+    }
+
+    private boolean isDataPrinter(String printer) {
+        return (printerSpoolerMap.containsKey(ALL_PRINTERS) || printerSpoolerMap.containsKey(printer));
     }
 }

--- a/src/qz/utils/ByteUtilities.java
+++ b/src/qz/utils/ByteUtilities.java
@@ -9,13 +9,13 @@
  */
 package qz.utils;
 
+import org.apache.commons.ssl.Base64;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import qz.common.ByteArrayBuilder;
 import qz.common.Constants;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Place for all raw static byte conversion functions.
@@ -26,6 +26,7 @@ import java.util.Locale;
  * @author Tres Finocchiaro
  */
 public class ByteUtilities {
+    private static final Logger log = LogManager.getLogger(ByteUtilities.class);
 
     public enum Endian {
         BIG, LITTLE
@@ -64,6 +65,20 @@ public class ByteUtilities {
         }
 
         return data;
+    }
+
+    public static String toString(PrintingUtilities.Flavor flavor, byte[] bytes) {
+        switch(flavor) {
+            case BASE64:
+                return Base64.encodeBase64String(bytes);
+            case HEX:
+                return ByteUtilities.bytesToHex(bytes);
+            case PLAIN:
+                break;
+            default:
+                log.warn("ByteUtilities.toString(...) does not support {}, defaulting to {}", PrintingUtilities.Flavor.FILE, PrintingUtilities.Flavor.PLAIN);
+        }
+        return new String(bytes);
     }
 
     public static String bytesToHex(byte[] bytes) {

--- a/src/qz/utils/ByteUtilities.java
+++ b/src/qz/utils/ByteUtilities.java
@@ -76,7 +76,7 @@ public class ByteUtilities {
             case PLAIN:
                 break;
             default:
-                log.warn("ByteUtilities.toString(...) does not support {}, defaulting to {}", PrintingUtilities.Flavor.FILE, PrintingUtilities.Flavor.PLAIN);
+                log.warn("ByteUtilities.toString(...) does not support {}, defaulting to {}", flavor, PrintingUtilities.Flavor.PLAIN);
         }
         return new String(bytes);
     }

--- a/src/qz/utils/PrefsSearch.java
+++ b/src/qz/utils/PrefsSearch.java
@@ -17,7 +17,15 @@ public class PrefsSearch {
         return get(user, app, name, null);
     }
 
+    public static String get(Properties app, String name, String defaultVal, boolean searchSystemProperties) {
+        return get(null, app, name, defaultVal, searchSystemProperties);
+    }
+
     public static String get(Properties user, Properties app, String name, String defaultVal, String... altNames) {
+        return get(user, app, name, defaultVal, true, altNames);
+    }
+
+    public static String get(Properties user, Properties app, String name, String defaultVal, boolean searchSystemProperties, String... altNames) {
         String returnVal;
 
         ArrayList<String> names = new ArrayList<>();
@@ -29,7 +37,7 @@ public class PrefsSearch {
 
         for(String n : names) {
             // First, honor System property
-            if ((returnVal = System.getProperty(n)) != null) {
+            if (searchSystemProperties && (returnVal = System.getProperty(n)) != null) {
                 log.info("Picked up system property {}={}", n, returnVal);
                 return returnVal;
             }

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -66,24 +66,24 @@ public class PrintingUtilities {
         }
 
         public byte[] read(String data, String xmlTag) throws IOException {
-            switch(this) {
-                case BASE64:
-                    return Base64.decodeBase64(data);
-                case FILE:
-                    return FileUtilities.readRawFile(data);
-                case HEX:
-                    return ByteUtilities.hexStringToByteArray(data.trim());
-                case XML:
-                    try {
-                        // Assume base64 encoded string inside the specified XML tag
-                        return Base64.decodeBase64(FileUtilities.readXMLFile(data, xmlTag).getBytes(StandardCharsets.UTF_8));
-                    } catch(Exception e) {
-                        log.warn("An error occurred parsing data from XML", e);
-                        throw new IOException("Error parsing data from XML");
-                    }
-                case PLAIN:
-                default:
-                    return data.getBytes();
+            try {
+                switch(this) {
+                    case BASE64:
+                        return Base64.decodeBase64(data);
+                    case FILE:
+                        return FileUtilities.readRawFile(data);
+                    case HEX:
+                        return ByteUtilities.hexStringToByteArray(data.trim());
+                    case XML:
+                            // Assume base64 encoded string inside the specified XML tag
+                            return Base64.decodeBase64(FileUtilities.readXMLFile(data, xmlTag).getBytes(StandardCharsets.UTF_8));
+                    case PLAIN:
+                    default:
+                        return data.getBytes();
+                }
+            } catch(Exception e) {
+                log.warn("An error occurred parsing data from " + this.name(), e);
+                throw new IOException("Error parsing data from " + this.name());
             }
         }
     }

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -278,7 +278,7 @@ public class PrintSocketClient {
                 if (!connection.hasStatusListener()) {
                     connection.startStatusListener(new StatusSession(session));
                 }
-                StatusMonitor.startListening(connection, params.getJSONArray("printerNames"));
+                StatusMonitor.startListening(connection, params);
                 sendResult(session, UID, null);
                 break;
             case PRINTERS_GET_STATUS:


### PR DESCRIPTION
Adds the ability to obtain raw, spool file data on Windows printers which have 'keep spooled documents' feature enabled.

* Requires System property `printer.status.jobdata` is set to true, e.g. 
   * ~~Environment variable QZ_OPTS: `-Dprinter.status.jobdata=true`<br>--OR--~~
   * qz-tray.properties: `printer.status.jobdata=true`.

Closes #923

Note:  This feature does not work by default on Windows 11 ARM, the spool directory permissions don't allow it.

Edited by @tresf 

---

TODO:
* [x] feature should be disabled by default
* [x] test permissions when wrong user tries to read a spooled file

see https://github.com/qzind/tray/issues/923