### PR TITLE
Dialog Location Validation

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -231,8 +231,8 @@ var qz = (function() {
 
                         // track requesting monitor
                         obj.position = {
-                            x: typeof screen !== 'undefined' ? ((screen.availWidth || screen.width) / 2) + (screen.left || screen.availLeft) : 0,
-                            y: typeof screen !== 'undefined' ? ((screen.availHeight || screen.height) / 2) + (screen.top || screen.availTop) : 0
+                            x: typeof screen !== 'undefined' ? ((screen.availWidth || screen.width) / 2) + (screen.left || screen.availLeft || 0) : 0,
+                            y: typeof screen !== 'undefined' ? ((screen.availHeight || screen.height) / 2) + (screen.top || screen.availTop || 0) : 0
                         };
 
                         try {

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -469,8 +469,9 @@ public class SystemUtilities {
      * @return <code>true</code> if the operation is successful
      */
     public static void centerDialog(Dialog dialog, Point position) {
-        if (position == null) {
-            log.debug("No dialog position provided, we'll center on the primary monitor instead");
+        // Assume 0,0 are bad coordinates
+        if (position == null || (position.getX() == 0 && position.getY() == 0)) {
+            log.debug("Invalid dialog position provided: {}, we'll center on first monitor instead", position);
             dialog.setLocationRelativeTo(null);
             return;
         }

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -469,8 +469,8 @@ public class SystemUtilities {
      * @return <code>true</code> if the operation is successful
      */
     public static void centerDialog(Dialog dialog, Point position) {
-        if (position == null || position.getX() == 0 || position.getY() == 0) {
-            log.debug("Invalid dialog position provided: {}, we'll center on the primary monitor instead", position);
+        if (position == null) {
+            log.debug("No dialog position provided, we'll center on the primary monitor instead");
             dialog.setLocationRelativeTo(null);
             return;
         }
@@ -484,16 +484,17 @@ public class SystemUtilities {
         }
 
         Rectangle rect = new Rectangle((int)(position.x * dpiScale), (int)(position.y * dpiScale), dialog.getWidth(), dialog.getHeight());
+        rect.translate(-dialog.getWidth() / 2, -dialog.getHeight() / 2);
         Point p = new Point((int)rect.getCenterX(), (int)rect.getCenterY());
         log.debug("Calculated dialog centered at: {}", p);
 
         if (!isWindowLocationValid(rect)) {
-            log.debug("Dialog position provided is out of bounds: {}, we'll center on the primary monitor instead", position);
+            log.debug("Dialog position provided is out of bounds: {}, we'll center on the primary monitor instead", p);
             dialog.setLocationRelativeTo(null);
             return;
         }
 
-        dialog.setLocation(p);
+        dialog.setLocation(rect.getLocation());
     }
 
     public static boolean isWindowLocationValid(Rectangle window) {

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -498,11 +498,18 @@ public class SystemUtilities {
         dialog.setLocation(rect.getLocation());
     }
 
+    /**
+     * Validates if a given rectangle is within screen bounds
+     */
     public static boolean isWindowLocationValid(Rectangle window) {
+        if(GraphicsEnvironment.isHeadless()) {
+            return false;
+        }
+
         GraphicsDevice[] devices = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
         Area area = new Area();
-        for (GraphicsDevice gd : devices) {
-            for (GraphicsConfiguration gc :  gd.getConfigurations()) {
+        for(GraphicsDevice gd : devices) {
+            for(GraphicsConfiguration gc : gd.getConfigurations()) {
                 area.add(new Area(gc.getBounds()));
             }
         }


### PR DESCRIPTION
Added a check to verify a dialog is entirely inside of the screen. If the dialog is not, it will be centered on the primary screen as per the old logic. This logic supports multiple monitors on windows.

Fixes #1013 

Tests for @Vzor- : 
- Does this work with multiple screens on other OSs
- Does this work with multiple monitors in other modes such as duplicate