### PR TITLE
Disable JDK-8283686 patch for WebKit >= 612.1.0

### DIFF
--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -140,13 +140,13 @@
         <loadresource property="host.fx.majver">
             <propertyresource name="host.fx.ver"/>
             <filterchain>
-                <replaceregex pattern="[-.].*" replace="" />
+                <replaceregex pattern="[-_.].*" replace="" />
             </filterchain>
         </loadresource>
         <loadresource property="target.fx.majver">
             <propertyresource name="target.fx.ver"/>
             <filterchain>
-                <replaceregex pattern="[-.].*" replace="" />
+                <replaceregex pattern="[-_.].*" replace="" />
             </filterchain>
         </loadresource>
         <property description="suppress property warning" name="target.fx.majver" value="something went wrong"/>

--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -110,17 +110,6 @@
         To package: We need javafx to download a javafx which matches "target.os" and "target.arch"
      -->
     <target name="get-javafx-versions" depends="platform-detect">
-        <condition property="host.fx.ver" value="${javafx.unstable.version}">
-            <not>
-                <equals arg1="${host.arch}" arg2="${javafx.arch}"/>
-            </not>
-        </condition>
-        <condition property="target.fx.ver" value="${javafx.unstable.version}">
-            <not>
-                <equals arg1="${target.arch}" arg2="${javafx.arch}"/>
-            </not>
-        </condition>
-
         <!-- Fallback to sane values -->
         <property name="host.fx.ver" value="${javafx.version}"/>
         <property name="target.fx.ver" value="${javafx.version}"/>

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -36,7 +36,7 @@ java.download=https://bell-sw.com/pages/downloads/#/java-11-lts
 # jre.skip=true
 
 # JavaFX version
-javafx.version=18-ea+1_monocle
+javafx.version=19_monocle
 javafx.mirror=https://download2.gluonhq.com/openjfx
 
 # Mask tray toggle (Apple only)

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -35,14 +35,9 @@ java.download=https://bell-sw.com/pages/downloads/#/java-11-lts
 # Skip bundling the java runtime
 # jre.skip=true
 
-# JavaFX 15.ea+3 is only available for x86_64
-javafx.version=15.ea+3_monocle
-javafx.arch=x86_64
+# JavaFX version
+javafx.version=18-ea+1_monocle
 javafx.mirror=https://download2.gluonhq.com/openjfx
-
-# JavaFX 17 has bugs, but we have no choice on other platforms
-javafx.unstable.version=17-ea+9_monocle
-javafx.unstable.mirror=https://download2.gluonhq.com/openjfx/17
 
 # Mask tray toggle (Apple only)
 java.mask.tray=true

--- a/src/qz/printer/action/html/WebApp.java
+++ b/src/qz/printer/action/html/WebApp.java
@@ -64,6 +64,11 @@ public class WebApp extends Application {
     private static IntPredicate printAction;
     private static final AtomicReference<Throwable> thrown = new AtomicReference<>();
 
+    // JDK-8283686: Printing WebView may results in empty page
+    private static final Version JDK_8283686_START = Version.valueOf(/* WebKit */ "609.1.0");
+    private static final Version JDK_8283686_END = Version.valueOf(/* WebKit */ "612.1.0");
+    private static final int JDK_8283686_VECTOR_FRAMES = 30;
+
 
     //listens for a Succeeded state to activate image capture
     private static ChangeListener<Worker.State> stateListener = (ov, oldState, newState) -> {
@@ -220,10 +225,12 @@ public class WebApp extends Application {
 
         webView = new WebView();
 
-        // Fix blank pages for WebKit > 609.1
+        // JDK-8283686: Printing WebView may results in empty page
         // See also https://github.com/qzind/tray/issues/778
-        if(getWebkitVersion() == null || getWebkitVersion().greaterThan(Version.forIntegers(609, 1, 0))) {
-            VECTOR_FRAMES = 30; // 30 pulses needed for vector graphics
+        if(getWebkitVersion() == null ||
+                (getWebkitVersion().greaterThan(JDK_8283686_START) &&
+                        getWebkitVersion().lessThan(JDK_8283686_END))) {
+            VECTOR_FRAMES = JDK_8283686_VECTOR_FRAMES; // Additional pulses needed for vector graphics
         }
 
         st.setScene(new Scene(webView));


### PR DESCRIPTION
Should fix the blank pages that were introduced with "recent" JavaFX versions as this has since been patched upstream.

@bberenz I would appreciate a code review.
@klabarge if you can do some rigorous testing on the various platforms, that's greatly appreciated.

Related: https://github.com/qzind/tray/issues/778
Upstream: https://bugs.openjdk.org/browse/JDK-8283686