### PR TITLE
Add native macOS Security support

### DIFF
--- a/src/org/dyorgio/jna/platform/mac/Security.java
+++ b/src/org/dyorgio/jna/platform/mac/Security.java
@@ -21,7 +21,6 @@ import com.sun.jna.Pointer;
 import com.sun.jna.platform.mac.CoreFoundation;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
-import qz.printer.status.Cups;
 
 /**
  * The JNA library interface to access the Security library under MacOS.
@@ -32,35 +31,37 @@ public interface Security extends Library {
 
     Security INSTANCE = Native.load("Security", Security.class);
 
-    enum SecBase {
-        errSecSuccess(0, "No error."),
-        errSecUnimplemented(-4, "Function or operation not implemented."),
-        errSecIO(-36, "I/O error (bummers)"),
-        errSecOpWr(-49, "file already open with with write permission"),
-        errSecParam(-50, "One or more parameters passed to a function where not valid."),
-        errSecAllocate(-108, "Failed to allocate memory."),
-        errSecUserCanceled(-128, "User canceled the operation."),
-        errSecBadReq(-909, "Bad parameter or invalid state for operation."),
-        errSecInternalComponent(-2070,"Internal component failure"),
-        errSecNotAvailable(-25291, "No keychain is available. You may need to restart your computer."),
-        errSecDuplicateItem(-25299, "The specified item already exists in the keychain."),
-        errSecItemNotFound(-25300, "The specified item could not be found in the keychain."),
-        errSecInteractionNotAllowed(-25308, "User interaction is not allowed."),
-        errSecDecode (-26275, "Unable to decode the provided data."),
-        errSecAuthFailed(-25293, "The user name or passphrase you entered is not correct."),
-        UNKNOWN(-99999, "Code not mapped");
+    enum Status {
+        SUCCESS("errSecSuccess", 0, "No error."),
+        UNIMPLEMENTED("errSecUnimplemented", -4, "Function or operation not implemented."),
+        IO("errSecIO", -36, "I/O error (bummers)"),
+        OPWR("errSecOpWr", -49, "File already open with write permission"),
+        PARAM("errSecParam", -50, "One or more parameters passed to a function where not valid."),
+        ALLOCATE("errSecAllocate", -108, "Failed to allocate memory."),
+        USER_CANCELED("errSecUserCanceled", -128, "User canceled the operation."),
+        BAD_REQ("errSecBadReq", -909, "Bad parameter or invalid state for operation."),
+        INTERNAL_COMPONENT("errSecInternalComponent", -2070,"Internal component failure"),
+        NOT_AVAILABLE("errSecNotAvailable", -25291, "No keychain is available. You may need to restart your computer."),
+        DUPLICATE_ITEM("errSecDuplicateItem", -25299, "The specified item already exists in the keychain."),
+        ITEM_NOT_FOUND("errSecItemNotFound", -25300, "The specified item could not be found in the keychain."),
+        INTERACTION_NOT_ALLOWED("errSecInteractionNotAllowed", -25308, "User interaction is not allowed."),
+        DECODE ("errSecDecode", -26275, "Unable to decode the provided data."),
+        AUTH_FAILED("errSecAuthFailed", -25293, "The user name or passphrase you entered is not correct."),
+        UNKNOWN("unknown", -99999, "Code not mapped");
 
         int code;
+        String name;
         String message;
-        SecBase(int code, String message) {
+        Status(String name, int code, String message) {
+            this.name = name;
             this.code = code;
             this.message = message;
         }
 
-        public static SecBase parse(int code) {
-            for(SecBase secBase : SecBase.values()) {
-                if(code == secBase.code) {
-                    return secBase;
+        public static Status parse(int code) {
+            for(Status status : Status.values()) {
+                if(code == status.code) {
+                    return status;
                 }
             }
             return UNKNOWN;
@@ -68,7 +69,7 @@ public interface Security extends Library {
 
         @Override
         public String toString() {
-            return String.format("(%d) [%s] %s", this.code, this.name(), this.message);
+            return String.format("(%d) [%s] %s", this.code, name, this.message);
         }
     }
 

--- a/src/org/dyorgio/jna/platform/mac/Security.java
+++ b/src/org/dyorgio/jna/platform/mac/Security.java
@@ -1,0 +1,270 @@
+/*
+ *    Copyright (C) 2015 QAware GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.dyorgio.jna.platform.mac;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
+import qz.printer.status.Cups;
+
+/**
+ * The JNA library interface to access the Security library under MacOS.
+ *
+ * @author lreimer
+ */
+public interface Security extends Library {
+
+    Security INSTANCE = Native.load("Security", Security.class);
+
+    enum SecBase {
+        errSecSuccess(0, "No error."),
+        errSecUnimplemented(-4, "Function or operation not implemented."),
+        errSecIO(-36, "I/O error (bummers)"),
+        errSecOpWr(-49, "file already open with with write permission"),
+        errSecParam(-50, "One or more parameters passed to a function where not valid."),
+        errSecAllocate(-108, "Failed to allocate memory."),
+        errSecUserCanceled(-128, "User canceled the operation."),
+        errSecBadReq(-909, "Bad parameter or invalid state for operation."),
+        errSecInternalComponent(-2070,"Internal component failure"),
+        errSecNotAvailable(-25291, "No keychain is available. You may need to restart your computer."),
+        errSecDuplicateItem(-25299, "The specified item already exists in the keychain."),
+        errSecItemNotFound(-25300, "The specified item could not be found in the keychain."),
+        errSecInteractionNotAllowed(-25308, "User interaction is not allowed."),
+        errSecDecode (-26275, "Unable to decode the provided data."),
+        errSecAuthFailed(-25293, "The user name or passphrase you entered is not correct."),
+        UNKNOWN(-99999, "Code not mapped");
+
+        int code;
+        String message;
+        SecBase(int code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public static SecBase parse(int code) {
+            for(SecBase secBase : SecBase.values()) {
+                if(code == secBase.code) {
+                    return secBase;
+                }
+            }
+            return UNKNOWN;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%d) [%s] %s", this.code, this.name(), this.message);
+        }
+    }
+
+    /**
+     * Returns one or more keychain items that match a search query, or copies attributes of specific keychain items.
+     * <br/>
+     * OSStatus SecItemCopyMatching ( CFDictionaryRef query, CFTypeRef _Nullable *result );
+     *
+     * @param query  A dictionary containing an item class specification (Keychain Item Class Keys and Values) and optional attributes for controlling the search. See Keychain Services Constants for a description of currently defined search attributes.
+     * @param result On return, a reference to the found items. The exact type of the result is based on the search attributes supplied in the query, as discussed below.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecItemCopyMatching(Pointer query, PointerByReference result);
+
+    /**
+     * Adds one or more items to a keychain.
+     * <br/>
+     * OSStatus SecItemAdd ( CFDictionaryRef attributes, CFTypeRef _Nullable *result );
+     *
+     * @param attributes A dictionary containing an item class key-value pair (Keychain Item Class Keys and Values) and optional attribute key-value pairs (Attribute Item Keys and Values) specifying the item's attribute values.
+     * @param result     On return, a reference to the newly added items. The exact type of the result is based on the values supplied in attributes, as discussed below. Pass NULL if this result is not required.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecItemAdd(Pointer attributes, PointerByReference result);
+
+    /**
+     * Modifies items that match a search query.
+     * <br/>
+     * OSStatus SecItemUpdate ( CFDictionaryRef query, CFDictionaryRef attributesToUpdate );
+     *
+     * @param query              A dictionary containing an item class specification and optional attributes for controlling the search. Specify the items whose values you wish to change. See Search Keys for a description of currently defined search attributes.
+     * @param attributesToUpdate A dictionary containing the attributes whose values should be changed, along with the new values. Only real keychain attributes are permitted in this dictionary (no "meta" attributes are allowed.) See Attribute Item Keys and Values for a description of currently defined value attributes.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecItemUpdate(Pointer query, Pointer attributesToUpdate);
+
+    /**
+     * Deletes items that match a search query.
+     * <br/>
+     * OSStatus SecItemDelete ( CFDictionaryRef query );
+     *
+     * @param query A dictionary containing an item class specification and optional attributes for controlling the search. See Search Keys for a description of currently defined search attributes.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecItemDelete(Pointer query);
+
+    /**
+     * Returns a string explaining the meaning of a security result code.
+     * <br/>
+     * CFStringRef SecCopyErrorMessageString ( OSStatus status, void *reserved );
+     *
+     * @param status   A result code of type OSStatus or CSSM_RETURN, returned by a security or CSSM function.
+     * @param reserved Reserved for future use. Pass NULL for this parameter.
+     * @return A human-readable string describing the result, or NULL if no string is available for the specified result code. You must call the CFRelease function to release this object when you are finished using it.
+     */
+    Pointer SecCopyErrorMessageString(int status, Pointer reserved);
+
+    /**
+     * Opens a keychain.
+     *
+     * @param pathName    A constant character string representing the POSIX path to the keychain to open.
+     * @param keychainRef On return, a pointer to the keychain object. You must call the CFRelease function to release this object when you are finished using it.
+     * @return A result code. See Keychain Services Result Codes. The result code errSecNoDefaultKeychain indicates that no default keychain could be found. The result code errSecDuplicateItem indicates that you tried to add a password that already exists in the keychain. The result code errSecDataTooLarge indicates that you tried to add more data than is allowed for a structure of this type. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainOpen(String pathName, PointerByReference keychainRef);
+
+    /**
+     * Adds a new generic password to a keychain.
+     * <br/>
+     * OSStatus SecKeychainAddGenericPassword ( SecKeychainRef keychain, UInt32 serviceNameLength, const char *serviceName, UInt32 accountNameLength, const char *accountName, UInt32 passwordLength, const void *passwordData, SecKeychainItemRef _Nullable *itemRef );
+     *
+     * @param keychain          A reference to the keychain in which to store a generic password. Pass NULL to specify the default keychain.
+     * @param serviceNameLength The length of the serviceName character string.
+     * @param serviceName       A UTF-8 encoded character string representing the service name.
+     * @param accountNameLength The length of the accountName character string.
+     * @param accountName       A UTF-8 encoded character string representing the account name.
+     * @param passwordLength    The length of the passwordData buffer.
+     * @param passwordData      A pointer to a buffer containing the password data to be stored in the keychain. Before calling this function, allocate enough memory for the buffer to hold the data you want to store.
+     * @param itemRef           On return, a pointer to a reference to the new keychain item. Pass NULL if you don’t want to obtain this object. You must allocate the memory for this pointer. You must call the CFRelease function to release this object when you are finished using it.
+     * @return A result code. See Keychain Services Result Codes. The result code errSecNoDefaultKeychain indicates that no default keychain could be found. The result code errSecDuplicateItem indicates that you tried to add a password that already exists in the keychain. The result code errSecDataTooLarge indicates that you tried to add more data than is allowed for a structure of this type. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainAddGenericPassword(Pointer keychain, int serviceNameLength, byte[] serviceName, int accountNameLength, byte[] accountName, int passwordLength, byte[] passwordData, PointerByReference itemRef);
+
+    /**
+     * Finds the first generic password based on the attributes passed.
+     * <br/>
+     * OSStatus SecKeychainFindGenericPassword ( CFTypeRef keychainOrArray, UInt32 serviceNameLength, const char *serviceName, UInt32 accountNameLength, const char *accountName, UInt32 *passwordLength, void * _Nullable *passwordData, SecKeychainItemRef _Nullable *itemRef );
+     *
+     * @param keychainOrArray   A reference to an array of keychains to search, a single keychain, or NULL to search the user’s default keychain search list.
+     * @param serviceNameLength The length of the serviceName character string.
+     * @param serviceName       A UTF-8 encoded character string representing the service name.
+     * @param accountNameLength The length of the accountName character string.
+     * @param accountName       A UTF-8 encoded character string representing the account name.
+     * @param passwordLength    On return, the length of the buffer pointed to by passwordData.
+     * @param passwordData      On return, a pointer to a buffer that holds the password data. Pass NULL if you want to obtain the item object but not the password data. In this case, you must also pass NULL in the passwordLength parameter. You should use the SecKeychainItemFreeContent function to free the memory pointed to by this parameter.
+     * @param itemRef           On return, a pointer to the item object of the generic password. You are responsible for releasing your reference to this object. Pass NULL if you don’t want to obtain this object.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainFindGenericPassword(Pointer keychainOrArray, int serviceNameLength, byte[] serviceName, int accountNameLength, byte[] accountName, IntByReference passwordLength, PointerByReference passwordData, PointerByReference itemRef);
+
+
+    /**
+     * Adds a new Internet password to a keychain.
+     * <br/>
+     * OSStatus SecKeychainAddInternetPassword ( SecKeychainRef keychain, UInt32 serverNameLength, const char *serverName, UInt32 securityDomainLength, const char *securityDomain, UInt32 accountNameLength, const char *accountName, UInt32 pathLength, const char *path, UInt16 port, SecProtocolType protocol, SecAuthenticationType authenticationType, UInt32 passwordLength, const void *passwordData, SecKeychainItemRef _Nullable *itemRef );
+     *
+     * @param keychain             A reference to the keychain in which to store an Internet password. Pass NULL to specify the user’s default keychain.
+     * @param serverNameLength     The length of the serverName character string.
+     * @param serverName           A UTF-8 encoded character string representing the server name.
+     * @param securityDomainLength The length of the securityDomain character string.
+     * @param securityDomain       A UTF-8 encoded character string representing the security domain. This parameter is optional. Pass NULL if the protocol does not require it.
+     * @param accountNameLength    The length of the accountName character string.
+     * @param accountName          A UTF-8 encoded character string representing the account name.
+     * @param pathLength           The length of the path character string.
+     * @param path                 A UTF-8 encoded character string representing the path.
+     * @param port                 The TCP/IP port number. If no specific port number is associated with this password, pass 0.
+     * @param protocol             The protocol associated with this password. See Keychain Protocol Type Constants for a description of possible values.
+     * @param authenticationType   The authentication scheme used. See Keychain Authentication Type Constants for a description of possible values. Pass the constant kSecAuthenticationTypeDefault, to specify the default authentication scheme.
+     * @param passwordLength       The length of the passwordData buffer.
+     * @param passwordData         A pointer to a buffer containing the password data to be stored in the keychain.
+     * @param itemRef              On return, a pointer to a reference to the new keychain item. Pass NULL if you don’t want to obtain this object. You must allocate the memory for this pointer. You must call the CFRelease function to release this object when you are finished using it.
+     * @return A result code. See Keychain Services Result Codes. The result code errSecNoDefaultKeychain indicates that no default keychain could be found. The result code errSecDuplicateItem indicates that you tried to add a password that already exists in the keychain. The result code errSecDataTooLarge indicates that you tried to add more data than is allowed for a structure of this type. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainAddInternetPassword(Pointer keychain, int serverNameLength, byte[] serverName, int securityDomainLength, byte[] securityDomain, int accountNameLength, byte[] accountName, int pathLength, byte[] path, int port, int protocol, int authenticationType, int passwordLength, byte[] passwordData, PointerByReference itemRef);
+
+    /**
+     * Finds the first Internet password based on the attributes passed.
+     * <br/>
+     * OSStatus SecKeychainFindInternetPassword ( CFTypeRef keychainOrArray, UInt32 serverNameLength, const char *serverName, UInt32 securityDomainLength, const char *securityDomain, UInt32 accountNameLength, const char *accountName, UInt32 pathLength, const char *path, UInt16 port, SecProtocolType protocol, SecAuthenticationType authenticationType, UInt32 *passwordLength, void * _Nullable *passwordData, SecKeychainItemRef _Nullable *itemRef );
+     *
+     * @param keychainOrArray      A reference to an array of keychains to search, a single keychain or NULL to search the user’s default keychain search list.
+     * @param serverNameLength     The length of the serverName character string.
+     * @param serverName           A UTF-8 encoded character string representing the server name.
+     * @param securityDomainLength The length of the securityDomain character string.
+     * @param securityDomain       A UTF-8 encoded character string representing the security domain. This parameter is optional, as not all protocols require it. Pass NULL if it is not required.
+     * @param accountNameLength    The length of the accountName character string.
+     * @param accountName          A UTF-8 encoded character string representing the account name.
+     * @param pathLength           The length of the path character string.
+     * @param path                 A UTF-8 encoded character string representing the path.
+     * @param port                 The TCP/IP port number. Pass 0 to ignore the port number.
+     * @param protocol             The protocol associated with this password. See Keychain Protocol Type Constants for a description of possible values.
+     * @param authenticationType   The authentication scheme used. See Keychain Authentication Type Constants for a description of possible values. Pass the constant kSecAuthenticationTypeDefault, to specify the default authentication scheme.
+     * @param passwordLength       On return, the length of the buffer pointed to by passwordData.
+     * @param passwordData         On return, a pointer to a buffer containing the password data. Pass NULL if you want to obtain the item object but not the password data. In this case, you must also pass NULL in the passwordLength parameter. You should use the SecKeychainItemFreeContent function to free the memory pointed to by this parameter.
+     * @param itemRef              On return, a pointer to the item object of the Internet password. You are responsible for releasing your reference to this object. Pass NULL if you don’t want to obtain this object.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainFindInternetPassword(Pointer keychainOrArray, int serverNameLength, byte[] serverName, int securityDomainLength, byte[] securityDomain, int accountNameLength, byte[] accountName, int pathLength, byte[] path, int port, int protocol, int authenticationType, IntByReference passwordLength, PointerByReference passwordData, PointerByReference itemRef);
+
+    /**
+     * Deletes a keychain item from the default keychain’s permanent data store.
+     * <br/>
+     * OSStatus SecKeychainItemDelete ( SecKeychainItemRef itemRef );
+     *
+     * @param itemRef A keychain item object of the item to delete. You must call the CFRelease function to release this object when you are finished using it.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainItemDelete(Pointer itemRef);
+
+
+    /**
+     * Updates an existing keychain item after changing its attributes and/or data.
+     * <br/>
+     * OSStatus SecKeychainItemModifyContent ( SecKeychainItemRef itemRef, const SecKeychainAttributeList *attrList, UInt32 length, const void *data );
+     *
+     * @param itemRef  A reference to the keychain item to modify.
+     * @param attrList A pointer to the list of attributes to set and their new values. Pass NULL if you have no need to modify attributes.
+     * @param length   The length of the buffer pointed to by the data parameter. Pass 0 if you pass NULL in the data parameter.
+     * @param data     A pointer to a buffer containing the data to store. Pass NULL if you do not need to modify the data.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainItemModifyContent(Pointer itemRef, Pointer attrList, int length, byte[] data);
+
+    /**
+     * Releases the memory used by the keychain attribute list and the keychain data retrieved in a call to the SecKeychainItemCopyContent function.
+     * <br/>
+     * OSStatus SecKeychainItemFreeContent ( SecKeychainAttributeList *attrList, void *data );
+     *
+     * @param attrList A pointer to the attribute list to release. Pass NULL if there is no attribute list to release.
+     * @param data     A pointer to the data buffer to release. Pass NULL if there is no data to release.
+     * @return A result code. See Keychain Services Result Codes. Call SecCopyErrorMessageString (OS X only) to get a human-readable string explaining the result.
+     */
+    int SecKeychainItemFreeContent(Pointer attrList, Pointer data);
+
+    /**
+     * Returns a DER representation of a certificate given a certificate object.
+     *
+     * @param certificate The certificate object for which you wish to return the DER (Distinguished Encoding Rules)
+     *                    representation of the X.509 certificate.
+     * @return The DER representation of the certificate. Call the CFRelease function to release this object when you
+     * are finished with it. Returns NULL if the data passed in the certificate parameter is not a valid certificate
+     * object.
+     */
+    CoreFoundation.CFDataRef SecCertificateCopyData(CoreFoundation.CFDataRef certificate);
+
+    CoreFoundation.CFTypeRef SecCertificateCreateWithData(Pointer allocator, CoreFoundation.CFDataRef data);
+
+    CoreFoundation.CFStringRef SecCertificateCopySubjectSummary(CoreFoundation.CFTypeRef certificate);
+}

--- a/src/org/dyorgio/jna/platform/mac/Security_Main_Temp.java
+++ b/src/org/dyorgio/jna/platform/mac/Security_Main_Temp.java
@@ -19,11 +19,10 @@ public class Security_Main_Temp {
         CFStringRef kSecClassCertificate = CFStringRef.createCFString("kSecClassCertificate");
         CFStringRef cfLabel = CFStringRef.createCFString("My Certificate");
         CFDataRef cfValueAsData = getCFDataCert(DER_ENCODED_CERT);
-        //CFStringRef cfValueAsString = CFStringRef.createCFString(DER_ENCODED_CERT);
         CFTypeRef cfValueAsCert = Security.INSTANCE.SecCertificateCreateWithData(null, cfValueAsData);
 
         CFStringRef summary = Security.INSTANCE.SecCertificateCopySubjectSummary(cfValueAsCert);
-        System.out.println(summary.stringValue());
+        System.out.println("SecCertificateCopySubjectSummary: " + summary.stringValue());
         summary.release();
 
         // Write to dictionary
@@ -33,11 +32,11 @@ public class Security_Main_Temp {
 
         // Call SecAddItem
         int retVal = Security.INSTANCE.SecItemAdd(dict.getPointer(), null);
-        Security.SecBase code = Security.SecBase.parse(retVal);
+        Security.Status code = Security.Status.parse(retVal);
 
         // Show output
         switch(code) {
-            case errSecSuccess:
+            case SUCCESS:
                 System.out.println(code);
                 break;
             default:
@@ -51,8 +50,7 @@ public class Security_Main_Temp {
 
         kSecClassCertificate.release();
         cfLabel.release();
-        // cfValueAsData.release();
-        //cfValueAsString.release();
+        cfValueAsData.release();
 
         dict.release();
         alloc.release();

--- a/src/org/dyorgio/jna/platform/mac/Security_Main_Temp.java
+++ b/src/org/dyorgio/jna/platform/mac/Security_Main_Temp.java
@@ -1,0 +1,119 @@
+package org.dyorgio.jna.platform.mac;
+
+import com.sun.jna.Memory;
+import org.apache.commons.ssl.Base64;
+
+import static com.sun.jna.platform.mac.CoreFoundation.*;
+
+public class Security_Main_Temp {
+    public static void main(String ... args) {
+        CFAllocatorRef alloc = INSTANCE.CFAllocatorGetDefault();
+        CFMutableDictionaryRef dict = INSTANCE.CFDictionaryCreateMutable(alloc, new CFIndex(2), null, null);
+
+        // Keys
+        CFStringRef kSecClass = CFStringRef.createCFString("kSecClass");
+        CFStringRef kSecAttrLabel = CFStringRef.createCFString("kSecAttrLabel");
+        CFStringRef kSecValueRef = CFStringRef.createCFString("kSecValueRef");
+
+        // Values
+        CFStringRef kSecClassCertificate = CFStringRef.createCFString("kSecClassCertificate");
+        CFStringRef cfLabel = CFStringRef.createCFString("My Certificate");
+        CFDataRef cfValueAsData = getCFDataCert(DER_ENCODED_CERT);
+        //CFStringRef cfValueAsString = CFStringRef.createCFString(DER_ENCODED_CERT);
+        CFTypeRef cfValueAsCert = Security.INSTANCE.SecCertificateCreateWithData(null, cfValueAsData);
+
+        CFStringRef summary = Security.INSTANCE.SecCertificateCopySubjectSummary(cfValueAsCert);
+        System.out.println(summary.stringValue());
+        summary.release();
+
+        // Write to dictionary
+        dict.setValue(kSecClass, kSecClassCertificate);
+        dict.setValue(kSecAttrLabel, cfLabel);
+        dict.setValue(kSecValueRef, cfValueAsCert);
+
+        // Call SecAddItem
+        int retVal = Security.INSTANCE.SecItemAdd(dict.getPointer(), null);
+        Security.SecBase code = Security.SecBase.parse(retVal);
+
+        // Show output
+        switch(code) {
+            case errSecSuccess:
+                System.out.println(code);
+                break;
+            default:
+                System.err.println(code);
+        }
+
+        // Dispose
+        kSecClass.release();
+        kSecAttrLabel.release();
+        kSecValueRef.release();
+
+        kSecClassCertificate.release();
+        cfLabel.release();
+        // cfValueAsData.release();
+        //cfValueAsString.release();
+
+        dict.release();
+        alloc.release();
+    }
+
+    // Attempt to convert data bytes to CFDataRef
+    private static CFDataRef getCFDataCert(String derEncodedData) {
+        String certFixed = DER_ENCODED_CERT.split("-----")[2];
+        byte[] certBytes = Base64.decodeBase64(certFixed);
+        Memory nativeBytes = new Memory(certBytes.length);
+        nativeBytes.write(0, certBytes, 0, certBytes.length);
+        return INSTANCE.CFDataCreate(null, nativeBytes, new CFIndex(certBytes.length));
+    }
+
+
+    // SEE ALSO: https://www.andyibanez.com/posts/using-ios-keychain-swift/
+
+    /**
+     * let secCert = SecCertificateCreateWithData(nil, certInDer as CFData) // certInDer is Certificate(.der) data
+     *         var keychainQueryDictionary = [String : Any]()
+     *
+     *         if let tempSecCert = secCert {
+     *             keychainQueryDictionary = [kSecClass as String : kSecClassCertificate, kSecValueRef as String : tempSecCert, kSecAttrLabel as String: "My Certificate"]
+     *         }
+     *
+     *         let summary = SecCertificateCopySubjectSummary(secCert!)! as String
+     *         print("Cert summary: \(summary)")
+     *
+     *         let status = SecItemAdd(keychainQueryDictionary as CFDictionary, nil)
+     *
+     *         guard status == errSecSuccess else {
+     *             print("Error")
+     *             return
+     *         }
+     *
+     *         print("success")
+     */
+
+    static String DER_ENCODED_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIELzCCAxegAwIBAgIJALm151zCHDxiMA0GCSqGSIb3DQEBCwUAMIGsMQswCQYD\n" +
+            "VQQGEwJVUzELMAkGA1UECAwCTlkxEjAQBgNVBAcMCUNhbmFzdG90YTEbMBkGA1UE\n" +
+            "CgwSUVogSW5kdXN0cmllcywgTExDMRswGQYDVQQLDBJRWiBJbmR1c3RyaWVzLCBM\n" +
+            "TEMxGTAXBgNVBAMMEHF6aW5kdXN0cmllcy5jb20xJzAlBgkqhkiG9w0BCQEWGHN1\n" +
+            "cHBvcnRAcXppbmR1c3RyaWVzLmNvbTAgFw0xNTAzMDEyMzM4MjlaGA8yMTE1MDMw\n" +
+            "MjIzMzgyOVowgawxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJOWTESMBAGA1UEBwwJ\n" +
+            "Q2FuYXN0b3RhMRswGQYDVQQKDBJRWiBJbmR1c3RyaWVzLCBMTEMxGzAZBgNVBAsM\n" +
+            "ElFaIEluZHVzdHJpZXMsIExMQzEZMBcGA1UEAwwQcXppbmR1c3RyaWVzLmNvbTEn\n" +
+            "MCUGCSqGSIb3DQEJARYYc3VwcG9ydEBxemluZHVzdHJpZXMuY29tMIIBIjANBgkq\n" +
+            "hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuWsBa6uk+RM4OKBZTRfIIyqaaFD71FAS\n" +
+            "7kojAQ+ySMpYuqLjIVZuCh92o1FGBvyBKUFc6knAHw5749yhLCYLXhzWwiNW2ri1\n" +
+            "Jwx/d83Wnaw6qA3lt++u3tmiA8tsFtss0QZW0YBpFsIqhamvB3ypwu0bdUV/oH7g\n" +
+            "/s8TFR5LrDfnfxlLFYhTUVWuWzMqEFAGnFG3uw/QMWZnQgkGbx0LMcYzdqFb7/vz\n" +
+            "rTSHfjJsisUTWPjo7SBnAtNYCYaGj0YH5RFUdabnvoTdV2XpA5IPYa9Q597g/M0z\n" +
+            "icAjuaK614nKXDaAUCbjki8RL3OK9KY920zNFboq/jKG6rKW2t51ZQIDAQABo1Aw\n" +
+            "TjAdBgNVHQ4EFgQUA0XGTcD6jqkL2oMPQaVtEgZDqV4wHwYDVR0jBBgwFoAUA0XG\n" +
+            "TcD6jqkL2oMPQaVtEgZDqV4wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC\n" +
+            "AQEAijcT5QMVqrWWqpNEe1DidzQfSnKo17ZogHW+BfUbxv65JbDIntnk1XgtLTKB\n" +
+            "VAdIWUtGZbXxrp16NEsh96V2hjDIoiAaEpW+Cp6AHhIVgVh7Q9Knq9xZ1t6H8PL5\n" +
+            "QiYQKQgJ0HapdCxlPKBfUm/Mj1ppNl9mPFJwgHmzORexbxrzU/M5i2jlies+CXNq\n" +
+            "cvmF2l33QNHnLwpFGwYKs08pyHwUPp6+bfci6lRvavztgvnKroWWIRq9ZPlC0yVK\n" +
+            "FFemhbCd7ZVbrTo0NcWZM1PTAbvlOikV9eh3i1Vot+3dJ8F27KwUTtnV0B9Jrxum\n" +
+            "W9P3C48mvwTxYZJFOu0N9UBLLg==\n" +
+            "-----END CERTIFICATE-----";
+}


### PR DESCRIPTION
### Goal

Create a `MacCertificateInstaller` similar to [`WindowsCertificateInstaller`](https://github.com/qzind/tray/blob/60e4c8c87d952963aec18c63ae182ed0533ae285/src/qz/installer/certificate/WindowsCertificateInstaller.java) that leverages JNA and native system libraries for interacting with the computer certificate store.

### Milestones

* [ ] Add certificate (started)
* [ ] Remove certificate
* [ ] Verify certificate

Fixes #1076 