### PR TITLE
Add debug information for printer crawling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,12 @@ jobs:
           distribution: 'temurin'
       - run: brew install nsis makeself
       - run: ant pkgbuild
+      - run: echo "Setting CA trust settings to 'allow' (https://github.com/actions/runner-images/issues/4519)"
+      - run: security authorizationdb read com.apple.trust-settings.admin > /tmp/trust-settings-backup.xml
+      - run: sudo security authorizationdb write com.apple.trust-settings.admin allow
       - run: sudo installer -pkg out/qz-tray-*.pkg -target /
+      - run: echo "Restoring CA trust settings back to default"
+      - run: sudo security authorizationdb write com.apple.trust-settings.admin < /tmp/trust-settings-backup.xml
       - run: "'/Applications/QZ Tray.app/Contents/MacOS/QZ Tray' --version"
       - run: ant makeself
       - run: ant nsis

--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -63,6 +63,7 @@ public class Constants {
     public static final String PREFS_STRICT_MODE = "tray.strictmode";
     public static final String PREFS_IDLE_PRINTERS = "tray.idle.printers";
     public static final String PREFS_IDLE_JFX = "tray.idle.javafx";
+    public static final String PREFS_DEBUG_PRINTERS = "tray.debug.printers";
 
     public static final String ALLOW_SITES_TEXT = "Permanently allowed \"%s\" to access local resources";
     public static final String BLOCK_SITES_TEXT = "Permanently blocked \"%s\" from accessing local resources";

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -21,6 +21,7 @@ import qz.auth.RequestState;
 import qz.installer.shortcut.ShortcutCreator;
 import qz.printer.PrintServiceMatcher;
 import qz.printer.action.WebApp;
+import qz.printer.info.NativePrinterMap;
 import qz.ui.*;
 import qz.ui.component.IconCache;
 import qz.ui.tray.TrayType;
@@ -97,6 +98,9 @@ public class TrayManager {
 
         // Set strict certificate mode preference
         Certificate.setTrustBuiltIn(!getPref(Constants.PREFS_STRICT_MODE, false));
+
+        // Set verbose printer crawling preference
+        NativePrinterMap.setDebugPrinters(getPref(Constants.PREFS_DEBUG_PRINTERS, false));
 
         //headless if turned on by user or unsupported by environment
         headless = isHeadless || getPref(Constants.PREFS_HEADLESS, false) || GraphicsEnvironment.isHeadless();
@@ -277,6 +281,13 @@ public class TrayManager {
         notificationsItem.addActionListener(notificationsListener);
         diagnosticMenu.add(notificationsItem);
 
+        JCheckBoxMenuItem debugPrintersItem = new JCheckBoxMenuItem("Debug printer information");
+        debugPrintersItem.setToolTipText("Log detailed steps when crawling printer information");
+        debugPrintersItem.setMnemonic(KeyEvent.VK_P);
+        debugPrintersItem.setState(getPref(Constants.PREFS_DEBUG_PRINTERS, false));
+        debugPrintersItem.addActionListener(debugPrintersListener);
+        diagnosticMenu.add(debugPrintersItem);
+
         JCheckBoxMenuItem monocleItem = new JCheckBoxMenuItem("Use Monocle for HTML");
         monocleItem.setToolTipText("Use monocle platform for HTML printing (restart required)");
         monocleItem.setMnemonic(KeyEvent.VK_U);
@@ -373,6 +384,15 @@ public class TrayManager {
         @Override
         public void actionPerformed(ActionEvent e) {
             prefs.setProperty(Constants.PREFS_NOTIFICATIONS, ((JCheckBoxMenuItem)e.getSource()).getState());
+        }
+    };
+
+    private final ActionListener debugPrintersListener = new ActionListener() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            JCheckBoxMenuItem j = (JCheckBoxMenuItem)e.getSource();
+            prefs.setProperty(Constants.PREFS_DEBUG_PRINTERS, j.getState());
+            NativePrinterMap.setDebugPrinters(j.getState());
         }
     };
 

--- a/src/qz/printer/PrintServiceMatcher.java
+++ b/src/qz/printer/PrintServiceMatcher.java
@@ -166,6 +166,9 @@ public class PrintServiceMatcher {
             jsonService.put("name", ps.getName());
 
             if (includeDetails) {
+                if(NativePrinterMap.isDebugPrinters()) {
+                    log.debug("Getting media attributes for printer: {}", printer.getName());
+                }
                 jsonService.put("driver", printer.getDriver().value());
                 jsonService.put("connection", printer.getConnection());
                 jsonService.put("default", ps == defaultService);

--- a/src/qz/printer/info/NativePrinterMap.java
+++ b/src/qz/printer/info/NativePrinterMap.java
@@ -14,6 +14,7 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
     private static final Logger log = LogManager.getLogger(NativePrinterMap.class);
 
     private static NativePrinterMap instance;
+    private static boolean debugPrinters = false;
 
     public abstract NativePrinterMap putAll(PrintService... services);
     abstract void fillAttributes(NativePrinter printer);
@@ -76,5 +77,13 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
             }
         }
         return null;
+    }
+
+    public static void setDebugPrinters(boolean debugPrinters) {
+        NativePrinterMap.debugPrinters = debugPrinters;
+    }
+
+    public static boolean isDebugPrinters() {
+        return debugPrinters;
     }
 }

--- a/src/qz/printer/info/WindowsPrinterMap.java
+++ b/src/qz/printer/info/WindowsPrinterMap.java
@@ -15,6 +15,9 @@ public class WindowsPrinterMap extends NativePrinterMap {
     public synchronized NativePrinterMap putAll(PrintService... services) {
         for (PrintService service : findMissing(services)) {
             String name = service.getName();
+            if(isDebugPrinters()) {
+                log.debug("Creating {} object for printer: {}", NativePrinter.class.getSimpleName(), name);
+            }
             if(name.equals("PageManager PDF Writer")) {
                 log.warn("Printer \"{}\" is blacklisted, removing", name); // Per https://github.com/qzind/tray/issues/599
                 continue;
@@ -28,6 +31,9 @@ public class WindowsPrinterMap extends NativePrinterMap {
     }
 
     synchronized void fillAttributes(NativePrinter printer) {
+        if(isDebugPrinters()) {
+            log.debug("Getting driver attributes for printer: {}", printer.getName());
+        }
         String keyName = printer.getPrinterId().replaceAll("\\\\", ",");
         String key = "SYSTEM\\CurrentControlSet\\Control\\Print\\Printers\\" + keyName;
         String driver = WindowsUtilities.getRegString(HKEY_LOCAL_MACHINE, key, "Printer Driver");


### PR DESCRIPTION
Adds debug printer crawling information (especially for Windows, where drivers are known to crash the Java Runtime) as a configurable parameter.  This is OFF by default.

This can be toggled ON two ways:
* **QZ Tray menu > Advanced > Diagnostic > Debug printer information**<br>-- OR --
* Add a custom entry to `prefs.properties`
   1. Close QZ Tray
   2. Open `%appdata%\qz\prefs.properties` in a text editor
   3. Add the following line:
      ```properties
      tray.debug.printers=true
      ```


Note, this PR Is for the 2.1 branch and must be ported to 2.2 manually.