### PR TITLE
Printer Status: Performance improvements

### DIFF
--- a/src/qz/common/CachedObject.java
+++ b/src/qz/common/CachedObject.java
@@ -1,0 +1,96 @@
+package qz.common;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * A generic class that encapsulates an object for caching. The cached object
+ * will be refreshed automatically when accessed after its lifespan has expired.
+ *
+ * @param <T> The type of object to be cached.
+ */
+public class CachedObject<T> {
+    public static final long DEFAULT_LIFESPAN = 5000; // in milliseconds
+    T lastObject;
+    Supplier<T> supplier;
+    private long timestamp;
+    private long lifespan;
+
+    /**
+     * Creates a new CachedObject with a default lifespan of 5000 milliseconds
+     *
+     * @param supplier The function to pull new values from
+     */
+    public CachedObject(Supplier<T> supplier) {
+        this(supplier, DEFAULT_LIFESPAN);
+    }
+
+    /**
+     * Creates a new CachedObject
+     *
+     * @param supplier The function to pull new values from
+     * @param lifespan The lifespan of the cached object in milliseconds
+     */
+    public CachedObject(Supplier<T> supplier, long lifespan) {
+        this.supplier = supplier;
+        setLifespan(lifespan);
+        timestamp = Long.MIN_VALUE;  // System.nanoTime() can be negative, MIN_VALUE guarantees a first-run.
+    }
+
+    /**
+     * Registers a new supplier for the CachedObject
+     *
+     * @param supplier The function to pull new values from
+     */
+    public void registerSupplier(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    /**
+     * Sets the lifespan of the cached object
+     *
+     * @param milliseconds The lifespan of the cached object in milliseconds
+     */
+    public void setLifespan(long milliseconds) {
+        lifespan = Math.max(0, milliseconds); // prevent overflow
+    }
+
+    /**
+     * Retrieves the cached object.
+     * If the cached object's lifespan has expired, it gets refreshed before being returned.
+     *
+     * @return The cached object
+     */
+    public T get() {
+        return get(false);
+    }
+
+    /**
+     * Retrieves the cached object.
+     * If the cached object's lifespan is expired or forceRefresh is true, it gets refreshed before being returned.
+     *
+     * @param forceRefresh If true, the cached object will be refreshed before being returned regardless of its lifespan
+     * @return The cached object
+     */
+    public T get(boolean forceRefresh) {
+        long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
+        // check lifespan
+        if (forceRefresh || (timestamp + lifespan <= now)) {
+            timestamp = now;
+            lastObject = supplier.get();
+        }
+        return lastObject;
+    }
+
+    // Test
+    public static void main(String ... args) throws InterruptedException {
+        final AtomicInteger testInt = new AtomicInteger(0);
+
+        CachedObject<Integer> cachedString = new CachedObject<>(testInt::incrementAndGet);
+        for(int i = 0; i < 100; i++) {
+            Thread.sleep(1500);
+            System.out.println(cachedString.get());
+        }
+    }
+}

--- a/src/qz/common/CachedObject.java
+++ b/src/qz/common/CachedObject.java
@@ -43,6 +43,7 @@ public class CachedObject<T> {
      *
      * @param supplier The function to pull new values from
      */
+    @SuppressWarnings("unused")
     public void registerSupplier(Supplier<T> supplier) {
         this.supplier = supplier;
     }

--- a/src/qz/printer/PrintServiceMatcher.java
+++ b/src/qz/printer/PrintServiceMatcher.java
@@ -29,8 +29,10 @@ import java.util.*;
 
 public class PrintServiceMatcher {
     private static final Logger log = LogManager.getLogger(PrintServiceMatcher.class);
-    //todo: include jdk version test for caching when JDK-7001133 is resolved
-    private static final boolean useCache = SystemUtilities.isMac();   // PrintService is slow, use a cache instead per JDK-7001133
+
+    // PrintService is slow in CUPS, use a cache instead per JDK-7001133
+    // TODO: Include JDK version test for caching when JDK-7001133 is fixed upstream
+    private static final boolean useCache = !SystemUtilities.isWindows();
 
     public static NativePrinterMap getNativePrinterList(boolean silent, boolean withAttributes) {
         NativePrinterMap printers = NativePrinterMap.getInstance();
@@ -67,7 +69,7 @@ public class PrintServiceMatcher {
 
         NativePrinterMap printers = NativePrinterMap.getInstance();
         if (!printers.contains(defaultService)) {
-            //todo: is this working correctly? it seems to set the printers list = to [1] {defaultPrinter}
+            // FIXME: Determine if this is this working correctly.  It seems to set the printers list = to [1] {defaultPrinter}
             printers.putAll(defaultService);
         }
 

--- a/src/qz/printer/PrintServiceMatcher.java
+++ b/src/qz/printer/PrintServiceMatcher.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import qz.printer.info.CachedPrintService;
 import qz.printer.info.CachedPrintServiceLookup;
 import qz.printer.info.NativePrinter;
 import qz.printer.info.NativePrinterMap;
@@ -32,7 +31,7 @@ public class PrintServiceMatcher {
 
     // PrintService is slow in CUPS, use a cache instead per JDK-7001133
     // TODO: Include JDK version test for caching when JDK-7001133 is fixed upstream
-    private static final boolean useCache = !SystemUtilities.isWindows();
+    private static final boolean useCache = SystemUtilities.isUnix();
 
     public static NativePrinterMap getNativePrinterList(boolean silent, boolean withAttributes) {
         NativePrinterMap printers = NativePrinterMap.getInstance();
@@ -69,7 +68,6 @@ public class PrintServiceMatcher {
 
         NativePrinterMap printers = NativePrinterMap.getInstance();
         if (!printers.contains(defaultService)) {
-            // FIXME: Determine if this is this working correctly.  It seems to set the printers list = to [1] {defaultPrinter}
             printers.putAll(false, defaultService);
         }
 

--- a/src/qz/printer/PrintServiceMatcher.java
+++ b/src/qz/printer/PrintServiceMatcher.java
@@ -36,7 +36,7 @@ public class PrintServiceMatcher {
 
     public static NativePrinterMap getNativePrinterList(boolean silent, boolean withAttributes) {
         NativePrinterMap printers = NativePrinterMap.getInstance();
-        printers.putAll(lookupPrintServices());
+        printers.putAll(true, lookupPrintServices());
         if (withAttributes) { printers.values().forEach(NativePrinter::getDriverAttributes); }
         if (!silent) { log.debug("Found {} printers", printers.size()); }
         return printers;
@@ -70,7 +70,7 @@ public class PrintServiceMatcher {
         NativePrinterMap printers = NativePrinterMap.getInstance();
         if (!printers.contains(defaultService)) {
             // FIXME: Determine if this is this working correctly.  It seems to set the printers list = to [1] {defaultPrinter}
-            printers.putAll(defaultService);
+            printers.putAll(false, defaultService);
         }
 
         return printers.get(defaultService);

--- a/src/qz/printer/PrintServiceMatcher.java
+++ b/src/qz/printer/PrintServiceMatcher.java
@@ -16,6 +16,7 @@ import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import qz.printer.info.CachedPrintService;
+import qz.printer.info.CachedPrintServiceLookup;
 import qz.printer.info.NativePrinter;
 import qz.printer.info.NativePrinterMap;
 import qz.utils.SystemUtilities;
@@ -40,13 +41,13 @@ public class PrintServiceMatcher {
     }
 
     private static PrintService[] lookupPrintServices() {
-        if (useCache) return CachedPrintService.lookupPrintServices();
-        return  PrintServiceLookup.lookupPrintServices(null, null);
+        return useCache ? CachedPrintServiceLookup.lookupPrintServices() :
+                PrintServiceLookup.lookupPrintServices(null, null);
     }
 
     private static PrintService lookupDefaultPrintService() {
-        if (useCache) return CachedPrintService.lookupDefaultPrintService();
-        return  PrintServiceLookup.lookupDefaultPrintService();
+        return useCache ? CachedPrintServiceLookup.lookupDefaultPrintService() :
+                PrintServiceLookup.lookupDefaultPrintService();
     }
 
     public static NativePrinterMap getNativePrinterList(boolean silent) {

--- a/src/qz/printer/info/CachedPrintService.java
+++ b/src/qz/printer/info/CachedPrintService.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
  * See also JDK-7001133
  */
 public class CachedPrintService implements PrintService {
-    private PrintService printService;
+    private final PrintService printService;
     private final long lifespan;
     private final CachedObject<String> cachedName;
     private final CachedObject<PrintServiceAttributeSet> cachedAttributeSet;
@@ -60,6 +60,10 @@ public class CachedPrintService implements PrintService {
     @Override
     public PrintServiceAttributeSet getAttributes() {
         return cachedAttributeSet.get();
+    }
+
+    public PrintService getJavaxPrintService() {
+        return printService;
     }
 
     @Override

--- a/src/qz/printer/info/CachedPrintService.java
+++ b/src/qz/printer/info/CachedPrintService.java
@@ -120,4 +120,14 @@ public class CachedPrintService implements PrintService {
     public ServiceUIFactory getServiceUIFactory() {
         return printService.getServiceUIFactory();
     }
+
+    public boolean equals(Object obj) {
+        return  (obj == this ||
+                (obj instanceof PrintService &&
+                        ((PrintService)obj).getName().equals(getName())));
+    }
+
+    public int hashCode() {
+        return this.getClass().hashCode()+getName().hashCode();
+    }
 }

--- a/src/qz/printer/info/CachedPrintService.java
+++ b/src/qz/printer/info/CachedPrintService.java
@@ -1,0 +1,130 @@
+package qz.printer.info;
+
+import qz.common.CachedObject;
+
+import javax.print.*;
+import javax.print.attribute.Attribute;
+import javax.print.attribute.AttributeSet;
+import javax.print.attribute.PrintServiceAttribute;
+import javax.print.attribute.PrintServiceAttributeSet;
+import javax.print.event.PrintServiceAttributeListener;
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+public class CachedPrintService implements PrintService {
+    public PrintService innerPrintService;
+    // PrintService.getName() is slow, use a cache instead per JDK-7001133
+    // TODO: Remove this comment when upstream bug report is filed
+    private static final long lifespan = CachedObject.DEFAULT_LIFESPAN;
+    private static final CachedObject<PrintService> cachedDefault = new CachedObject<>(CachedPrintService::innerLookupDefaultPrintService, lifespan);
+    private static final CachedObject<PrintService[]> cachedPrintServices = new CachedObject<>(CachedPrintService::innerLookupPrintServices, lifespan);
+    private final CachedObject<String> cachedName;
+    private final CachedObject<PrintServiceAttributeSet> cachedAttributeSet;
+    private final HashMap<Class<?>, CachedObject<?>> cachedAttributes = new HashMap<>();
+
+    public static PrintService lookupDefaultPrintService() {
+        return cachedDefault.get();
+    }
+
+    public static PrintService[] lookupPrintServices() {
+        return cachedPrintServices.get();
+    }
+
+    private static PrintService innerLookupDefaultPrintService() {
+        return new CachedPrintService(PrintServiceLookup.lookupDefaultPrintService());
+    }
+
+    private static PrintService[] innerLookupPrintServices() {
+        PrintService[] printServices = PrintServiceLookup.lookupPrintServices(null, null);
+        for (int i = 0; i < printServices.length; i++) {
+            printServices[i] = new CachedPrintService(printServices[i]);
+        }
+        return printServices;
+    }
+
+    public CachedPrintService(PrintService printService) {
+        innerPrintService = printService;
+        cachedName = new CachedObject<>(innerPrintService::getName, lifespan);
+        cachedAttributeSet = new CachedObject<>(innerPrintService::getAttributes, lifespan);
+    }
+
+    @Override
+    public String getName() {
+        return cachedName.get();
+    }
+
+    @Override
+    public DocPrintJob createPrintJob() {
+        return innerPrintService.createPrintJob();
+    }
+
+    @Override
+    public void addPrintServiceAttributeListener(PrintServiceAttributeListener listener) {
+        innerPrintService.addPrintServiceAttributeListener(listener);
+    }
+
+    @Override
+    public void removePrintServiceAttributeListener(PrintServiceAttributeListener listener) {
+        innerPrintService.removePrintServiceAttributeListener(listener);
+    }
+
+    @Override
+    public PrintServiceAttributeSet getAttributes() {
+        return cachedAttributeSet.get();
+    }
+
+    @Override
+    public <T extends PrintServiceAttribute> T getAttribute(Class<T> category) {
+        if (!cachedAttributes.containsKey(category)) {
+            Supplier<T> supplier = () -> innerPrintService.getAttribute(category);
+            CachedObject<T> cachedObject = new CachedObject<>(supplier, lifespan);
+            cachedAttributes.put(category, cachedObject);
+        }
+        return category.cast(cachedAttributes.get(category).get());
+    }
+
+    @Override
+    public DocFlavor[] getSupportedDocFlavors() {
+        return innerPrintService.getSupportedDocFlavors();
+    }
+
+    @Override
+    public boolean isDocFlavorSupported(DocFlavor flavor) {
+        return innerPrintService.isDocFlavorSupported(flavor);
+    }
+
+    @Override
+    public Class<?>[] getSupportedAttributeCategories() {
+        return innerPrintService.getSupportedAttributeCategories();
+    }
+
+    @Override
+    public boolean isAttributeCategorySupported(Class<? extends Attribute> category) {
+        return innerPrintService.isAttributeCategorySupported(category);
+    }
+
+    @Override
+    public Object getDefaultAttributeValue(Class<? extends Attribute> category) {
+        return innerPrintService.getDefaultAttributeValue(category);
+    }
+
+    @Override
+    public Object getSupportedAttributeValues(Class<? extends Attribute> category, DocFlavor flavor, AttributeSet attributes) {
+        return innerPrintService.getSupportedAttributeValues(category, flavor, attributes);
+    }
+
+    @Override
+    public boolean isAttributeValueSupported(Attribute attrval, DocFlavor flavor, AttributeSet attributes) {
+        return innerPrintService.isAttributeValueSupported(attrval, flavor, attributes);
+    }
+
+    @Override
+    public AttributeSet getUnsupportedAttributes(DocFlavor flavor, AttributeSet attributes) {
+        return innerPrintService.getUnsupportedAttributes(flavor, attributes);
+    }
+
+    @Override
+    public ServiceUIFactory getServiceUIFactory() {
+        return innerPrintService.getServiceUIFactory();
+    }
+}

--- a/src/qz/printer/info/CachedPrintServiceLookup.java
+++ b/src/qz/printer/info/CachedPrintServiceLookup.java
@@ -66,6 +66,10 @@ public class CachedPrintServiceLookup {
     private static CachedPrintService getMatch(CachedPrintService[] array, PrintService javaxPrintService) {
         if(array != null) {
             for(CachedPrintService cps : array) {
+                // Note: Order of operations can cause the defaultService pointer to differ if lookupDefaultPrintService()
+                // is called before lookupPrintServices(...) because the provider will invalidate on refreshServices() if
+                // "sun.java2d.print.polling" is set to "false". We're OK with this because worst case, we just
+                // call "lpstat" a second time.
                 if (cps.getJavaxPrintService() == javaxPrintService) return cps;
             }
         }

--- a/src/qz/printer/info/CachedPrintServiceLookup.java
+++ b/src/qz/printer/info/CachedPrintServiceLookup.java
@@ -22,11 +22,13 @@ public class CachedPrintServiceLookup {
     }
 
     public static PrintService lookupDefaultPrintService() {
-        return cachedDefault.get();
+        return cachedDefault != null ? cachedDefault.get() : null;
     }
 
     public static void setLifespan(long lifespan) {
-        cachedDefault.setLifespan(lifespan);
+        if(cachedDefault != null) {
+            cachedDefault.setLifespan(lifespan);
+        }
         cachedPrintServices.setLifespan(lifespan);
     }
 
@@ -36,6 +38,10 @@ public class CachedPrintServiceLookup {
 
     private static CachedPrintService wrapDefaultPrintService() {
         PrintService javaxPrintService = PrintServiceLookup.lookupDefaultPrintService();
+        // Skip using a CachedPrintService
+        if(javaxPrintService == null) {
+            return null;
+        }
         // If this CachedPrintService already exists, reuse it rather than wrapping a new one
         CachedPrintService cachedPrintService = getMatch(cachedPrintServicesCopy, javaxPrintService);
         if (cachedPrintService == null) {
@@ -57,7 +63,9 @@ public class CachedPrintServiceLookup {
         }
         cachedPrintServicesCopy = cachedPrintServices;
         // Immediately invalidate the defaultPrinter cache
-        cachedDefault.get(true);
+        if(cachedDefault != null) {
+            cachedDefault.get(true);
+        }
         return cachedPrintServices;
     }
 

--- a/src/qz/printer/info/CachedPrintServiceLookup.java
+++ b/src/qz/printer/info/CachedPrintServiceLookup.java
@@ -4,7 +4,6 @@ import qz.common.CachedObject;
 
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
-import java.util.Arrays;
 
 /**
  * PrintService[] cache to workaround JDK-7001133
@@ -42,9 +41,6 @@ public class CachedPrintServiceLookup {
         if (cachedPrintService == null) {
             // Wrap a new one
             cachedPrintService = new CachedPrintService(javaxPrintService);
-            // Add it to the end of the array
-            cachedPrintServicesCopy = Arrays.copyOf(cachedPrintServicesCopy, cachedPrintServicesCopy.length + 1);
-            cachedPrintServicesCopy[cachedPrintServicesCopy.length - 1] = cachedPrintService;
         }
         return cachedPrintService;
     }
@@ -60,6 +56,8 @@ public class CachedPrintServiceLookup {
             }
         }
         cachedPrintServicesCopy = cachedPrintServices;
+        // Immediately invalidate the defaultPrinter cache
+        cachedDefault.get(true);
         return cachedPrintServices;
     }
 

--- a/src/qz/printer/info/CachedPrintServiceLookup.java
+++ b/src/qz/printer/info/CachedPrintServiceLookup.java
@@ -22,13 +22,11 @@ public class CachedPrintServiceLookup {
     }
 
     public static PrintService lookupDefaultPrintService() {
-        return cachedDefault != null ? cachedDefault.get() : null;
+        return cachedDefault.get();
     }
 
     public static void setLifespan(long lifespan) {
-        if(cachedDefault != null) {
-            cachedDefault.setLifespan(lifespan);
-        }
+        cachedDefault.setLifespan(lifespan);
         cachedPrintServices.setLifespan(lifespan);
     }
 
@@ -38,7 +36,7 @@ public class CachedPrintServiceLookup {
 
     private static CachedPrintService wrapDefaultPrintService() {
         PrintService javaxPrintService = PrintServiceLookup.lookupDefaultPrintService();
-        // Skip using a CachedPrintService
+        // CachedObject's supplier returns null
         if(javaxPrintService == null) {
             return null;
         }
@@ -63,9 +61,8 @@ public class CachedPrintServiceLookup {
         }
         cachedPrintServicesCopy = cachedPrintServices;
         // Immediately invalidate the defaultPrinter cache
-        if(cachedDefault != null) {
-            cachedDefault.get(true);
-        }
+        cachedDefault.get(true);
+
         return cachedPrintServices;
     }
 

--- a/src/qz/printer/info/CachedPrintServiceLookup.java
+++ b/src/qz/printer/info/CachedPrintServiceLookup.java
@@ -1,0 +1,45 @@
+package qz.printer.info;
+
+import qz.common.CachedObject;
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+
+/**
+ * PrintService[] cache to workaround JDK-7001133
+ *
+ * See also <code>CachedPrintService</code>
+ */
+public class CachedPrintServiceLookup {
+    private static final CachedObject<PrintService> cachedDefault = new CachedObject<>(CachedPrintServiceLookup::innerLookupDefaultPrintService);
+    private static final CachedObject<PrintService[]> cachedPrintServices = new CachedObject<>(CachedPrintServiceLookup::innerLookupPrintServices);
+
+    static {
+        setLifespan(CachedObject.DEFAULT_LIFESPAN);
+    }
+
+    public static PrintService lookupDefaultPrintService() {
+        return cachedDefault.get();
+    }
+
+    public static void setLifespan(long lifespan) {
+        cachedDefault.setLifespan(lifespan);
+        cachedPrintServices.setLifespan(lifespan);
+    }
+
+    public static PrintService[] lookupPrintServices() {
+        return cachedPrintServices.get();
+    }
+
+    private static PrintService innerLookupDefaultPrintService() {
+        return new CachedPrintService(PrintServiceLookup.lookupDefaultPrintService());
+    }
+
+    private static PrintService[] innerLookupPrintServices() {
+        PrintService[] printServices = PrintServiceLookup.lookupPrintServices(null, null);
+        for (int i = 0; i < printServices.length; i++) {
+            printServices[i] = new CachedPrintService(printServices[i]);
+        }
+        return printServices;
+    }
+}

--- a/src/qz/printer/info/CupsPrinterMap.java
+++ b/src/qz/printer/info/CupsPrinterMap.java
@@ -18,8 +18,8 @@ public class CupsPrinterMap extends NativePrinterMap {
     private static final Logger log = LogManager.getLogger(CupsPrinterMap.class);
     private Map<NativePrinter, List<PrinterResolution>> resolutionMap = new HashMap<>();
 
-    public synchronized NativePrinterMap putAll(PrintService... services) {
-        ArrayList<PrintService> missing = findMissing(services);
+    public synchronized NativePrinterMap putAll(boolean exhaustive, PrintService... services) {
+        ArrayList<PrintService> missing = findMissing(exhaustive, services);
         if (missing.isEmpty()) { return this; }
 
         String output = "\n" + ShellUtilities.executeRaw(new String[] {"lpstat", "-l", "-p"});

--- a/src/qz/printer/info/NativePrinter.java
+++ b/src/qz/printer/info/NativePrinter.java
@@ -59,8 +59,7 @@ public class NativePrinter {
         public boolean equals(Object o) {
             // PrintService.equals(...) is very slow in CUPS; use the pointer instead per JDK-7001133
             if (SystemUtilities.isUnix() && value instanceof PrintService) {
-                //todo this needs to be more than a name check. maybe use attribute set
-                return ((PrintService)value).getName().equals(getName());
+                return o == value;
             }
             if (value != null) {
                 return value.equals(o);

--- a/src/qz/printer/info/NativePrinter.java
+++ b/src/qz/printer/info/NativePrinter.java
@@ -57,10 +57,6 @@ public class NativePrinter {
 
         @Override
         public boolean equals(Object o) {
-            // PrintService.equals(...) is very slow in CUPS; use the pointer instead per JDK-7001133
-            if (SystemUtilities.isUnix() && value instanceof PrintService) {
-                return o == value;
-            }
             if (value != null) {
                 return value.equals(o);
             }

--- a/src/qz/printer/info/NativePrinter.java
+++ b/src/qz/printer/info/NativePrinter.java
@@ -57,9 +57,10 @@ public class NativePrinter {
 
         @Override
         public boolean equals(Object o) {
-            // PrintService.equals(...) is very slow in CUPS; use the pointer
+            // PrintService.equals(...) is very slow in CUPS; use the pointer instead per JDK-7001133
             if (SystemUtilities.isUnix() && value instanceof PrintService) {
-                return o == value;
+                //todo this needs to be more than a name check. maybe use attribute set
+                return ((PrintService)value).getName().equals(getName());
             }
             if (value != null) {
                 return value.equals(o);
@@ -69,6 +70,7 @@ public class NativePrinter {
     }
 
     private final String printerId;
+
     private boolean outdated;
     private PrinterProperty<String> description;
     private PrinterProperty<PrintService> printService;

--- a/src/qz/printer/info/NativePrinterMap.java
+++ b/src/qz/printer/info/NativePrinterMap.java
@@ -15,7 +15,7 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
 
     private static NativePrinterMap instance;
 
-    public abstract NativePrinterMap putAll(PrintService... services);
+    public abstract NativePrinterMap putAll(boolean exhaustive, PrintService... services);
 
     abstract void fillAttributes(NativePrinter printer);
 
@@ -43,13 +43,16 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
         return null;
     }
 
-    public ArrayList<PrintService> findMissing(PrintService[] services) {
+    public ArrayList<PrintService> findMissing(boolean exhaustive, PrintService[] services) {
         ArrayList<PrintService> serviceList = new ArrayList<>(Arrays.asList(services)); // shrinking list drastically improves performance
+
         for(NativePrinter printer : values()) {
             if (serviceList.contains(printer.getPrintService())) {
                 serviceList.remove(printer.getPrintService()); // existing match
             } else {
-                printer.setOutdated(true); // no matches, mark to be removed
+                if(exhaustive) {
+                    printer.setOutdated(true); // no matches, mark to be removed
+                }
             }
         }
 
@@ -59,6 +62,7 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
                 remove(entry.getKey());
             }
         }
+
         // any remaining services are new/missing
         return serviceList;
     }

--- a/src/qz/printer/info/NativePrinterMap.java
+++ b/src/qz/printer/info/NativePrinterMap.java
@@ -43,6 +43,10 @@ public abstract class NativePrinterMap extends ConcurrentHashMap<String, NativeP
         return null;
     }
 
+    /**
+     * WARNING: Despite the function's name, if <code>exhaustive</code> is true, it will treat the listing as exhaustive and remove
+     * any PrintServices that are not part of this HashMap.
+     */
     public ArrayList<PrintService> findMissing(boolean exhaustive, PrintService[] services) {
         ArrayList<PrintService> serviceList = new ArrayList<>(Arrays.asList(services)); // shrinking list drastically improves performance
 

--- a/src/qz/printer/info/WindowsPrinterMap.java
+++ b/src/qz/printer/info/WindowsPrinterMap.java
@@ -12,8 +12,8 @@ import static com.sun.jna.platform.win32.WinReg.*;
 public class WindowsPrinterMap extends NativePrinterMap {
     private static final Logger log = LogManager.getLogger(WindowsPrinterMap.class);
 
-    public synchronized NativePrinterMap putAll(PrintService... services) {
-        for(PrintService service : findMissing(services)) {
+    public synchronized NativePrinterMap putAll(boolean exhaustive, PrintService... services) {
+        for(PrintService service : findMissing(exhaustive, services)) {
             String name = service.getName();
             if (name.equals("PageManager PDF Writer")) {
                 log.warn("Printer \"{}\" is blacklisted, removing", name); // Per https://github.com/qzind/tray/issues/599


### PR DESCRIPTION
Introduce `PrintService` caching to workaround https://bugs.openjdk.org/browse/JDK-7001133

Upstream: [`JDK-7001133`](https://bugs.openjdk.org/browse/JDK-7001133)
BellSoft: `QZ-14` (private)

Related: #1181 
Closes #1116 
Closes #1189 