### PR TITLE
Add debugging to Apple installer

### DIFF
--- a/ant/apple/apple-postinstall.sh.in
+++ b/ant/apple/apple-postinstall.sh.in
@@ -7,7 +7,7 @@ set -e
 DIR=$(cd "$(dirname "$0")" && pwd)
 pushd "$DIR/payload/${project.name}.app/Contents/MacOS/"
 
-./"${project.name}" install
+./"${project.name}" install >> "/tmp/${project.datadir}-install.log" 2>&1
 popd
 
 # Use install target from pkgbuild, an undocumented feature; fallback on sane location
@@ -17,7 +17,7 @@ else
     pushd "/Applications/${project.name}.app/Contents/MacOS/"
 fi
 
-./"${project.name}" certgen
+./"${project.name}" certgen >> "/tmp/${project.datadir}-install.log" 2>&1
 
 # Start qz by calling open on the .app as an ordinary user
 su "$USER" -c "open ../../" || true

--- a/ant/apple/apple-postinstall.sh.in
+++ b/ant/apple/apple-postinstall.sh.in
@@ -7,7 +7,7 @@ set -e
 DIR=$(cd "$(dirname "$0")" && pwd)
 pushd "$DIR/payload/${project.name}.app/Contents/MacOS/"
 
-./"${project.name}" install >> "/tmp/${project.datadir}-install.log" 2>&1
+./"${project.name}" install >> "${install.log}" 2>&1
 popd
 
 # Use install target from pkgbuild, an undocumented feature; fallback on sane location
@@ -17,7 +17,7 @@ else
     pushd "/Applications/${project.name}.app/Contents/MacOS/"
 fi
 
-./"${project.name}" certgen >> "/tmp/${project.datadir}-install.log" 2>&1
+./"${project.name}" certgen >> "${install.log}" 2>&1
 
 # Start qz by calling open on the .app as an ordinary user
 su "$USER" -c "open ../../" || true

--- a/ant/apple/apple-preinstall.sh.in
+++ b/ant/apple/apple-preinstall.sh.in
@@ -14,4 +14,4 @@ if ! ./"${project.name}" --version; then
     exit 1
 fi
 
-./"${project.name}" preinstall
+./"${project.name}" preinstall > "/tmp/${project.datadir}-install.log" 2>&1

--- a/ant/apple/apple-preinstall.sh.in
+++ b/ant/apple/apple-preinstall.sh.in
@@ -3,15 +3,29 @@
 # Halt on first error
 set -e
 
+# Clear the log for writing
+> "${install.log}"
+
+# Log helper
+dbg () {
+    echo -e "[BASH] $(date -Iseconds)\n\t$1" >> "${install.log}" 2>&1
+}
+
 # Get working directory
+dbg "Calculating working directory..."
 DIR=$(cd "$(dirname "$0")" && pwd)
-pushd "$DIR/payload/${project.name}.app/Contents/MacOS/"
+dbg "Using working directory $DIR"
+dbg "Switching to payload directory $DIR/payload/${project.name}.app/Contents/MacOS/"
+pushd "$DIR/payload/${project.name}.app/Contents/MacOS/" >> "${install.log}" 2>&1
 
 # Offer to download Java if missing
-if ! ./"${project.name}" --version; then
+dbg "Checking for Java in payload directory..."
+if ! ./"${project.name}" --version >> "${install.log}" 2>&1; then
+    dbg "Java was not found"
     osascript -e "tell app \"Installer\" to display dialog \"Java is required.  Please install Java and try again.\""
     sudo -u "$USER" open "${java.download}"
     exit 1
 fi
 
-./"${project.name}" preinstall > "${install.log}" 2>&1
+dbg "Java was found in payload directory, running preinstall"
+./"${project.name}" preinstall >> "${install.log}" 2>&1

--- a/ant/apple/apple-preinstall.sh.in
+++ b/ant/apple/apple-preinstall.sh.in
@@ -14,4 +14,4 @@ if ! ./"${project.name}" --version; then
     exit 1
 fi
 
-./"${project.name}" preinstall > "/tmp/${project.datadir}-install.log" 2>&1
+./"${project.name}" preinstall > "${install.log}" 2>&1

--- a/ant/linux/linux-installer.sh.in
+++ b/ant/linux/linux-installer.sh.in
@@ -20,12 +20,15 @@ mask=755
 
 echo -e "Starting install...\n"
 
+# Clear the log for writing
+> "${install.log}"
+
 run_task () {
     echo -e "Running $1 task..."
     if [ -n "$DEBUG" ]; then
         "./${project.filename}" $@ && ret_val=$? || ret_val=$?
     else
-        "./${project.filename}" $@ &> /dev/null && ret_val=$? || ret_val=$?
+        "./${project.filename}" $@ &>> "${install.log}" && ret_val=$? || ret_val=$?
     fi
 
     if [ $ret_val -eq 0 ]; then

--- a/ant/project.properties
+++ b/ant/project.properties
@@ -9,6 +9,7 @@ project.datadir=qz
 
 install.opts=-Djna.nosys=true
 launch.opts=-Xms512m ${install.opts}
+install.log=/tmp/${project.datadir}-install.log
 # jdk9+ flags
 # - Dark theme requires workaround https://github.com/bobbylight/Darcula/issues/8
 launch.jigsaw=--add-exports java.desktop/sun.swing=ALL-UNNAMED


### PR DESCRIPTION
Closes #1150 

Installation logs for MacOS and Linux are now located at `/tmp/qz-install.log`

.. or for company branded builds `/tmp/<Vendor Abbreviation>-install.log`