### PR TITLE
Make logs configurable

### DIFF
--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -84,6 +84,17 @@ public class App {
     }
 
     private static void setupFileLogging() {
+        //disable jetty logging
+        System.setProperty("org.eclipse.jetty.util.log.class", "org.eclipse.jetty.util.log.StdErrLog");
+        System.setProperty("org.eclipse.jetty.LEVEL", "OFF");
+
+        Properties app = CertificateManager.loadProperties();
+        if(PrefsSearch.get(app, "log.disable", false)) {
+            return;
+        }
+
+        int logSize = PrefsSearch.get(app, "log.size", Constants.DEFAULT_LOG_SIZE);
+        int logRotations = PrefsSearch.get(app, "log.rotations", Constants.DEFAULT_LOG_ROTATIONS);
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)
@@ -91,16 +102,12 @@ public class App {
                 .setFilter(ThresholdFilter.createFilter(Level.DEBUG, Filter.Result.ACCEPT, Filter.Result.DENY))
                 .withFileName(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".log")
                 .withFilePattern(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".%i.log")
-                .withStrategy(DefaultRolloverStrategy.newBuilder().withMax(String.valueOf(Constants.LOG_ROTATIONS)).build())
-                .withPolicy(SizeBasedTriggeringPolicy.createPolicy(String.valueOf(Constants.LOG_SIZE)))
+                .withStrategy(DefaultRolloverStrategy.newBuilder().withMax(String.valueOf(logRotations)).build())
+                .withPolicy(SizeBasedTriggeringPolicy.createPolicy(String.valueOf(logSize)))
                 .withImmediateFlush(true)
                 .build();
         fileAppender.start();
 
         LoggerUtilities.getRootLogger().addAppender(fileAppender);
-
-        //disable jetty logging
-        System.setProperty("org.eclipse.jetty.util.log.class", "org.eclipse.jetty.util.log.StdErrLog");
-        System.setProperty("org.eclipse.jetty.LEVEL", "OFF");
     }
 }

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -89,12 +89,12 @@ public class App {
         System.setProperty("org.eclipse.jetty.LEVEL", "OFF");
 
         Properties app = CertificateManager.loadProperties();
-        if(PrefsSearch.get(app, "log.disable", false)) {
+        if(PrefsSearch.get(app, Constants.PREFS_LOG_DISABLE, false)) {
             return;
         }
 
-        int logSize = PrefsSearch.get(app, "log.size", Constants.DEFAULT_LOG_SIZE);
-        int logRotate = PrefsSearch.get(app, "log.rotate", Constants.DEFAULT_LOG_ROTATIONS);
+        int logSize = PrefsSearch.get(app, Constants.PREFS_LOG_SIZE, Constants.DEFAULT_LOG_SIZE);
+        int logRotate = PrefsSearch.get(app, Constants.PREFS_LOG_ROTATE, Constants.DEFAULT_LOG_ROTATIONS);
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -94,7 +94,7 @@ public class App {
         }
 
         int logSize = PrefsSearch.get(app, "log.size", Constants.DEFAULT_LOG_SIZE);
-        int logRotations = PrefsSearch.get(app, "log.rotations", Constants.DEFAULT_LOG_ROTATIONS);
+        int logRotate = PrefsSearch.get(app, "log.rotate", Constants.DEFAULT_LOG_ROTATIONS);
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)
@@ -102,7 +102,7 @@ public class App {
                 .setFilter(ThresholdFilter.createFilter(Level.DEBUG, Filter.Result.ACCEPT, Filter.Result.DENY))
                 .withFileName(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".log")
                 .withFilePattern(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".%i.log")
-                .withStrategy(DefaultRolloverStrategy.newBuilder().withMax(String.valueOf(logRotations)).build())
+                .withStrategy(DefaultRolloverStrategy.newBuilder().withMax(String.valueOf(logRotate)).build())
                 .withPolicy(SizeBasedTriggeringPolicy.createPolicy(String.valueOf(logSize)))
                 .withImmediateFlush(true)
                 .build();

--- a/src/qz/auth/Certificate.java
+++ b/src/qz/auth/Certificate.java
@@ -37,8 +37,6 @@ public class Certificate {
 
     private static final Logger log = LogManager.getLogger(Certificate.class);
     private static final String QUIETLY_FAIL = "quiet";
-    public static final String OVERRIDE_CA_FLAG = "trustedRootCert";
-    public static final String OVERRIDE_CA_PROPERTY = "authcert.override";
 
     public enum Algorithm {
         SHA1("SHA1withRSA"),
@@ -142,13 +140,13 @@ public class Certificate {
     public static void scanAdditionalCAs() {
         ArrayList<Map.Entry<Path, String>> certPaths = new ArrayList<>();
         // First, look for "-DtrustedRootCert" command line property
-        certPaths.addAll(FileUtilities.parseDelimitedPaths(System.getProperty(OVERRIDE_CA_FLAG)));
+        certPaths.addAll(FileUtilities.parseDelimitedPaths(System.getProperty(Constants.PREFS_OVERRIDE_CA_CLI)));
 
         // Second, look for "override.crt" within App directory
         certPaths.add(new AbstractMap.SimpleEntry<>(SystemUtilities.getJarParentPath().resolve(Constants.OVERRIDE_CERT), QUIETLY_FAIL));
 
         // Third, look for "authcert.override" property in qz-tray.properties
-        certPaths.addAll(FileUtilities.parseDelimitedPaths(App.getTrayProperties(), OVERRIDE_CA_PROPERTY));
+        certPaths.addAll(FileUtilities.parseDelimitedPaths(App.getTrayProperties(), Constants.PREFS_OVERRIDE_CA));
 
         for(Map.Entry<Path, String> certPath : certPaths) {
             if(certPath.getKey() != null) {

--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -28,8 +28,8 @@ public class Constants {
     public static final String[] PERSIST_PROPS = {"file.whitelist", "file.allow", "networking.hostname", "networking.port", STEAL_WEBSOCKET_PROPERTY };
     public static final String AUTOSTART_FILE = ".autostart";
     public static final String DATA_DIR = "qz";
-    public static final int LOG_SIZE = 524288;
-    public static final int LOG_ROTATIONS = 5;
+    public static final int DEFAULT_LOG_SIZE = 524288;
+    public static final int DEFAULT_LOG_ROTATIONS = 5;
 
     public static final int BORDER_PADDING = 10;
 

--- a/src/qz/common/Constants.java
+++ b/src/qz/common/Constants.java
@@ -69,6 +69,15 @@ public class Constants {
     public static final String PREFS_FILEIO_ENABLED = "security.file.enabled";
     public static final String PREFS_FILEIO_STRICT = "security.file.strict";
 
+    public static final String PREFS_LOG_DISABLE = "log.disable";
+    public static final String PREFS_LOG_ROTATE = "log.rotate";
+    public static final String PREFS_LOG_SIZE = "log.size";
+
+    public static final String PREFS_OVERRIDE_CA = "authcert.override";
+    public static final String PREFS_OVERRIDE_CA_CLI = "trustedRootCert";
+
+    public static final String PREFS_PRINTER_JOB_DATA = "printer.status.jobdata";
+
     public static final String ALLOW_SITES_TEXT = "Permanently allowed \"%s\" to access local resources";
     public static final String BLOCK_SITES_TEXT = "Permanently blocked \"%s\" from accessing local resources";
 

--- a/src/qz/printer/status/StatusSession.java
+++ b/src/qz/printer/status/StatusSession.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.websocket.api.Session;
 import qz.App;
+import qz.common.Constants;
 import qz.printer.status.job.WmiJobStatusMap;
 import qz.utils.*;
 import qz.ws.PrintSocketClient;
@@ -59,7 +60,7 @@ public class StatusSession {
         if (!SystemUtilities.isWindows()) {
             throw new UnsupportedOperationException("Job data listeners are only supported on Windows");
         }
-        String spoolFileMonitoring = PrefsSearch.get(App.getTrayProperties(), "printer.status.jobdata", "false", false );
+        String spoolFileMonitoring = PrefsSearch.get(App.getTrayProperties(), Constants.PREFS_PRINTER_JOB_DATA, "false", false );
         if (!Boolean.parseBoolean(spoolFileMonitoring)) {
             throw new UnsupportedOperationException("Job data listeners are currently disabled");
         }

--- a/src/qz/utils/PrefsSearch.java
+++ b/src/qz/utils/PrefsSearch.java
@@ -21,6 +21,17 @@ public class PrefsSearch {
         return get(null, app, name, defaultVal, searchSystemProperties);
     }
 
+    public static int get(Properties app, String name, int defaultVal) {
+        try {
+            return Integer.parseInt(get(app, name, "", true));
+        } catch(NumberFormatException ignore) {}
+        return defaultVal;
+    }
+
+    public static boolean get(Properties app, String name, boolean defaultVal) {
+        return Boolean.parseBoolean(get(app, name, "" + defaultVal, true));
+    }
+
     public static String get(Properties user, Properties app, String name, String defaultVal, String... altNames) {
         return get(user, app, name, defaultVal, true, altNames);
     }


### PR DESCRIPTION
Adds the ability to configure logs via environment variable or via `qz-tray.properties`.

```bash
QZ_OPTS="-Dlog.disable=true"
```

```bash
QZ_OPTS="-Dlog.size=2097152"
```

```bash
QZ_OPTS="-Dlog.rotate=9"
```

---- 

OR

----

```properties
#Thu Jul 06 21:55:37 EDT 2023
log.size=2097152
log.rotate=9
# log.disable=true


ca.storepass=abcdefghijklmnop
wss.host=0.0.0.0
wss.storepass=abcdefghijklmnop
wss.alias=qz-tray
ca.alias=root-ca
ca.keystore=/Library/Application Support/qz/ssl/root-ca.p12
wss.keystore=/Library/Application Support/qz/ssl/qz-tray.p12
```


* Closes #1162
* Closes #214 