### PR TITLE
Clear Queue (cancel-jobs)

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1399,6 +1399,25 @@ var qz = (function() {
             },
 
             /**
+             * @param {string|Object} [options] Name of todo:
+             *  @param {string} [options.printerName] todo
+             *  @param {number} [options.jobId] todo
+             *
+             * @returns {Promise<null|Error>} todo.
+             * @since 2.2.4
+             *
+             * @memberof qz.printers
+             */
+            clearQueue: function(options) {
+                if (typeof options !== 'object') {
+                    options = {
+                        printerName: options
+                    };
+                }
+                return _qz.websocket.dataPromise('printers.clearQueue', options);
+            },
+
+            /**
              * Stop listening for printer status actions.
              *
              * @returns {Promise<null|Error>}

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1399,11 +1399,13 @@ var qz = (function() {
             },
 
             /**
-             * @param {string|Object} [options] Name of todo:
+             * Clear the queue of a specified printer or printers. Does not delete retained jobs.
+             *
+             * @param {string|Object} [options] Name of printer to clear
              *  @param {string} [options.printerName] todo
              *  @param {number} [options.jobId] todo
              *
-             * @returns {Promise<null|Error>} todo.
+             * @returns {Promise<null|Error>}
              * @since 2.2.4
              *
              * @memberof qz.printers

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1402,8 +1402,8 @@ var qz = (function() {
              * Clear the queue of a specified printer or printers. Does not delete retained jobs.
              *
              * @param {string|Object} [options] Name of printer to clear
-             *  @param {string} [options.printerName] todo
-             *  @param {number} [options.jobId] todo
+             *  @param {string} [options.printerName] Name of printer to clear
+             *  @param {number} [options.jobId] Cancel a job of a specific JobId instead of canceling all. Must include a printerName.
              *
              * @returns {Promise<null|Error>}
              * @since 2.2.4

--- a/sample.html
+++ b/sample.html
@@ -123,6 +123,7 @@
                             <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#askFileModal">Set To File</button>
                             <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#askHostModal">Set To Host</button>
                         </div>
+                        <button type="button" class="btn btn-warning btn-sm" onclick="clearQueue($('#printerSearch').val());">Clear Queue</button>
                     </div>
                 </div>
             </div>
@@ -2082,6 +2083,9 @@
         qz.print(config, printData).catch(displayError);
     }
 
+    function clearQueue(printer) {
+        qz.printers.clearQueue(printer).catch(displayError);
+    }
 
     /// Pixel Printers ///
     function printHTML() {

--- a/src/qz/communication/WinspoolEx.java
+++ b/src/qz/communication/WinspoolEx.java
@@ -1,0 +1,24 @@
+package qz.communication;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Winspool;
+import com.sun.jna.win32.W32APIOptions;
+
+@SuppressWarnings("unused")
+public interface WinspoolEx extends Winspool {
+    WinspoolEx INSTANCE = Native.load("Winspool.drv", WinspoolEx.class, W32APIOptions.DEFAULT_OPTIONS);
+
+    int JOB_CONTROL_NONE = 0x00000000; // Perform no additional action.
+    int JOB_CONTROL_PAUSE = 0x00000001; // Pause the print job.
+    int JOB_CONTROL_RESUME = 0x00000002; // Resume a paused print job.
+    int JOB_CONTROL_CANCEL = 0x00000003; // Delete a print job.
+    int JOB_CONTROL_RESTART = 0x00000004; // Restart a print job.
+    int JOB_CONTROL_DELETE = 0x00000005; // Delete a print job.
+    int JOB_CONTROL_SENT_TO_PRINTER = 0x00000006; // Used by port monitors to signal that a print job has been sent to the printer. This value SHOULD NOT be used remotely.
+    int JOB_CONTROL_LAST_PAGE_EJECTED = 0x00000007; // Used by language monitors to signal that the last page of a print job has been ejected from the printer. This value SHOULD NOT be used remotely.
+    int JOB_CONTROL_RETAIN = 0x00000008; // Keep the print job in the print queue after it prints.
+    int JOB_CONTROL_RELEASE = 0x00000009; // Release the print job, undoing the effect of a JOB_CONTROL_RETAIN action.
+
+    boolean SetJob(Pointer hPrinter, int JobId, int Level, Pointer pJob, int Command);
+}

--- a/src/qz/communication/WinspoolEx.java
+++ b/src/qz/communication/WinspoolEx.java
@@ -6,6 +6,9 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.Winspool;
 import com.sun.jna.win32.W32APIOptions;
 
+/**
+ * TODO: Remove when JNA 5.14.0+ is bundled
+ */
 @SuppressWarnings("unused")
 public interface WinspoolEx extends Winspool {
     WinspoolEx INSTANCE = Native.load("Winspool.drv", WinspoolEx.class, W32APIOptions.DEFAULT_OPTIONS);

--- a/src/qz/communication/WinspoolEx.java
+++ b/src/qz/communication/WinspoolEx.java
@@ -2,6 +2,7 @@ package qz.communication;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.Winspool;
 import com.sun.jna.win32.W32APIOptions;
 
@@ -20,5 +21,5 @@ public interface WinspoolEx extends Winspool {
     int JOB_CONTROL_RETAIN = 0x00000008; // Keep the print job in the print queue after it prints.
     int JOB_CONTROL_RELEASE = 0x00000009; // Release the print job, undoing the effect of a JOB_CONTROL_RETAIN action.
 
-    boolean SetJob(Pointer hPrinter, int JobId, int Level, Pointer pJob, int Command);
+    boolean SetJob(WinNT.HANDLEByReference hPrinter, int JobId, int Level, Pointer pJob, int Command);
 }

--- a/src/qz/communication/WinspoolEx.java
+++ b/src/qz/communication/WinspoolEx.java
@@ -21,5 +21,5 @@ public interface WinspoolEx extends Winspool {
     int JOB_CONTROL_RETAIN = 0x00000008; // Keep the print job in the print queue after it prints.
     int JOB_CONTROL_RELEASE = 0x00000009; // Release the print job, undoing the effect of a JOB_CONTROL_RETAIN action.
 
-    boolean SetJob(WinNT.HANDLEByReference hPrinter, int JobId, int Level, Pointer pJob, int Command);
+    boolean SetJob(WinNT.HANDLE hPrinter, int JobId, int Level, Pointer pJob, int Command);
 }

--- a/src/qz/printer/status/Cups.java
+++ b/src/qz/printer/status/Cups.java
@@ -31,6 +31,8 @@ public interface Cups extends Library {
         public static int CREATE_PRINTER_SUBSCRIPTION = INSTANCE.ippOpValue("Create-Printer-Subscription");
         public static int CREATE_JOB_SUBSCRIPTION = INSTANCE.ippOpValue("Create-Job-Subscription");
         public static int CANCEL_SUBSCRIPTION = INSTANCE.ippOpValue("Cancel-Subscription");
+        public static int GET_JOBS = INSTANCE.ippOpValue("Get-Jobs");
+        public static int CANCEL_JOB = INSTANCE.ippOpValue("Cancel-Job");
 
         public static final int OP_PRINT_JOB = 0x02;
         public static final int INT_ERROR = 0;

--- a/src/qz/printer/status/Cups.java
+++ b/src/qz/printer/status/Cups.java
@@ -5,6 +5,7 @@ import com.sun.jna.*;
 /**
  * Created by kyle on 3/14/17.
  */
+@SuppressWarnings("unused")
 public interface Cups extends Library {
 
     Cups INSTANCE = Native.load("cups", Cups.class);

--- a/src/qz/printer/status/CupsUtils.java
+++ b/src/qz/printer/status/CupsUtils.java
@@ -167,7 +167,7 @@ public class CupsUtils {
     }
 
     static void startSubscription(int rssPort) {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> freeIppObjs()));
+        Runtime.getRuntime().addShutdownHook(new Thread(CupsUtils::freeIppObjs));
 
         String[] subscriptions = {"job-state-changed", "printer-state-changed"};
         Pointer request = cups.ippNewRequest(IPP.CREATE_JOB_SUBSCRIPTION);
@@ -227,7 +227,6 @@ public class CupsUtils {
         Pointer response = doRequest(request, "/");
         cups.ippDelete(response);
     }
-
 
     public synchronized static void freeIppObjs() {
         if (http != null) {
@@ -291,6 +290,6 @@ public class CupsUtils {
         if (attrName == null){
             return "------------------------";
         }
-        return String.format("%s: %d %s {%s}", attrName, attrCount, Cups.INSTANCE.ippTagString(valueTag), data.toString());
+        return String.format("%s: %d %s {%s}", attrName, attrCount, Cups.INSTANCE.ippTagString(valueTag), data);
     }
 }

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -247,7 +247,7 @@ public class PrintingUtilities {
                         deletedCount++;
                     } else {
                         Win32Exception e = new Win32Exception(Kernel32.INSTANCE.GetLastError());
-                        log.warn("Job deletion error for job#{}, error :{}", job.JobId, e);
+                        log.warn("Job deletion error for job#{}, {}", job.JobId, e);
                     }
                 }
                 log.info("Deleting {} jobs", deletedCount);

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -262,6 +262,7 @@ public class PrintingUtilities {
     private static void cancelJobById(int jobId, NativePrinter printer) {
         if (SystemUtilities.isWindows()) {
             WinNT.HANDLEByReference phPrinter = getWmiPrinter(printer);
+             // TODO: Change to "Winspool" when JNA 5.14.0+ is bundled
             if (!WinspoolEx.INSTANCE.SetJob(phPrinter.getValue(), jobId, 0, null, WinspoolEx.JOB_CONTROL_DELETE)) {
                 Win32Exception e = new Win32Exception(Kernel32.INSTANCE.GetLastError());
                 log.warn("Job deletion error for job#{}, {}", jobId, e);
@@ -290,6 +291,7 @@ public class PrintingUtilities {
 
     private static WinNT.HANDLEByReference getWmiPrinter(NativePrinter printer) throws Win32Exception {
         WinNT.HANDLEByReference phPrinter = new WinNT.HANDLEByReference();
+        // TODO: Change to "Winspool" when JNA 5.14.0+ is bundled
         if (!WinspoolEx.INSTANCE.OpenPrinter(printer.getName(), /*out*/ phPrinter, null)) {
             throw new Win32Exception(Kernel32.INSTANCE.GetLastError());
         }

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -22,6 +22,8 @@ import qz.printer.action.PrintProcessor;
 import qz.printer.action.ProcessorFactory;
 import qz.printer.info.NativePrinter;
 import qz.printer.status.CupsUtils;
+import qz.printer.status.job.WmiJobStatusMap;
+import qz.printer.status.printer.WmiPrinterStatusMap;
 import qz.ws.PrintSocketClient;
 
 import java.awt.print.PrinterAbortException;
@@ -237,6 +239,8 @@ public class PrintingUtilities {
                 WinspoolEx.INSTANCE.OpenPrinter(printer.getName(), phPrinter, null);
                 Winspool.JOB_INFO_1[] jobs =  WinspoolUtil.getJobInfo1(phPrinter);
                 for (Winspool.JOB_INFO_1 job : jobs) {
+                    // skip retained jobs
+                    if ((job.Status & (int)WmiJobStatusMap.RETAINED.getRawCode()) != 0) continue;
                     log.warn("deleting job " + job.toString());
                     log.warn("result: " + WinspoolEx.INSTANCE.SetJob(phPrinter.getValue(), job.JobId, 0, null, WinspoolEx.JOB_CONTROL_DELETE));
                     log.warn(Kernel32.INSTANCE.GetLastError());

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -241,6 +241,7 @@ public class PrintingUtilities {
                 for (Winspool.JOB_INFO_1 job : jobs) {
                     // skip retained jobs
                     if ((job.Status & (int)WmiJobStatusMap.RETAINED.getRawCode()) != 0) continue;
+                    if ((job.Status & (int)WmiJobStatusMap.PRINTED.getRawCode()) != 0) continue;
                     log.warn("deleting job " + job.toString());
                     log.warn("result: " + WinspoolEx.INSTANCE.SetJob(phPrinter.getValue(), job.JobId, 0, null, WinspoolEx.JOB_CONTROL_DELETE));
                     log.warn(Kernel32.INSTANCE.GetLastError());

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -238,7 +238,7 @@ public class PrintingUtilities {
                 Winspool.JOB_INFO_1[] jobs =  WinspoolUtil.getJobInfo1(phPrinter);
                 for (Winspool.JOB_INFO_1 job : jobs) {
                     log.warn("deleting job " + job.toString());
-                    log.warn("result: " + WinspoolEx.INSTANCE.SetJob(phPrinter, job.JobId, 0, null, WinspoolEx.JOB_CONTROL_DELETE));
+                    log.warn("result: " + WinspoolEx.INSTANCE.SetJob(phPrinter.getValue(), job.JobId, 0, null, WinspoolEx.JOB_CONTROL_DELETE));
                     log.warn(Kernel32.INSTANCE.GetLastError());
                 }
             } else {

--- a/src/qz/utils/PrintingUtilities.java
+++ b/src/qz/utils/PrintingUtilities.java
@@ -244,6 +244,7 @@ public class PrintingUtilities {
                     String error = "Job# " + paramJobId + " is not part of the '" + printer.getName() + "' print queue";
                     log.error(error);
                     PrintSocketClient.sendError(session, UID, error);
+                    return;
                 }
             }
             log.info("Canceling {} jobs from {}", jobIds.size(), printer.getName());

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -307,6 +307,10 @@ public class PrintSocketClient {
                 StatusMonitor.stopListening(connection);
                 sendResult(session, UID, null);
                 break;
+            case PRINTERS_CLEAR_QUEUE:
+                PrintingUtilities.cancelJobs(session, UID, params);
+                sendResult(session, UID, null);
+                break;
             case PRINT:
                 PrintingUtilities.processPrintRequest(session, UID, params);
                 break;

--- a/src/qz/ws/SocketMethod.java
+++ b/src/qz/ws/SocketMethod.java
@@ -5,6 +5,7 @@ public enum SocketMethod {
     PRINTERS_FIND("printers.find", true, "access connected printers"),
     PRINTERS_DETAIL("printers.detail", true, "access connected printers"),
     PRINTERS_START_LISTENING("printers.startListening", true, "listen for printer status"),
+    PRINTERS_CLEAR_QUEUE("printers.clearQueue", true, "cancel all pending jobs for a given printer"),
     PRINTERS_GET_STATUS("printers.getStatus", false),
     PRINTERS_STOP_LISTENING("printers.stopListening", false),
     PRINT("print", true, "print to %s"),


### PR DESCRIPTION
This is a feature addition requested in #1185. It adds the ability to clear a specific printer's queue. The delete jobs should be pending only, leaving behind 'printed' and 'retained' jobs. 

Todo: 
- [x] Support specific jobIDs

closes #1185