### PR TITLE
Cleanup old log format

### DIFF
--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -94,7 +94,7 @@ public class App {
 
         int logSize = PrefsSearch.getInt(ArgValue.LOG_SIZE);
         int logRotate = PrefsSearch.getInt(ArgValue.LOG_ROTATE);
-        Installer.getInstance().removeLegacyLogs(Math.max(logRotate, 5));
+        Installer.getInstance().cleanupLegacyLogs(Math.max(logRotate, 5));
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -94,6 +94,7 @@ public class App {
 
         int logSize = PrefsSearch.getInt(ArgValue.LOG_SIZE);
         int logRotate = PrefsSearch.getInt(ArgValue.LOG_ROTATE);
+        Installer.getInstance().removeLegacyLogs(logRotate);
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -94,7 +94,7 @@ public class App {
 
         int logSize = PrefsSearch.getInt(ArgValue.LOG_SIZE);
         int logRotate = PrefsSearch.getInt(ArgValue.LOG_ROTATE);
-        Installer.getInstance().removeLegacyLogs(logRotate);
+        Installer.getInstance().removeLegacyLogs(Math.max(logRotate, 5));
         RollingFileAppender fileAppender = RollingFileAppender.newBuilder()
                 .setName("log-file")
                 .withAppend(true)

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -102,7 +102,10 @@ public class App {
                 .setFilter(ThresholdFilter.createFilter(Level.DEBUG, Filter.Result.ACCEPT, Filter.Result.DENY))
                 .withFileName(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".log")
                 .withFilePattern(FileUtilities.USER_DIR + File.separator + Constants.LOG_FILE + ".%i.log")
-                .withStrategy(DefaultRolloverStrategy.newBuilder().withMax(String.valueOf(logRotate)).build())
+                .withStrategy(DefaultRolloverStrategy.newBuilder()
+                                      .withMax(String.valueOf(logRotate))
+                                      .withFileIndex("min")
+                                      .build())
                 .withPolicy(SizeBasedTriggeringPolicy.createPolicy(String.valueOf(logSize)))
                 .withImmediateFlush(true)
                 .build();

--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -174,24 +174,24 @@ public abstract class Installer {
         // Convert old < 2.2.3 log file format
         Path logLocation = USER_DIR;
         int oldIndex = 0;
+        int newIndex = 0;
         File oldFile;
         do {
             // Old: debug.log.1
             oldFile = logLocation.resolve("debug.log." + ++oldIndex).toFile();
             if(oldFile.exists()) {
                 // New: debug.1.log
-                File newFile = getNextLogFile(logLocation, 0);
+                File newFile;
+                do {
+                    newFile = oldFile.toPath().getParent().resolve("debug." + ++newIndex + ".log").toFile();
+                } while(newFile.exists());
+
                 oldFile.renameTo(newFile);
                 log.info("Migrated log file {} to new location {}", oldFile, newFile);
             }
         } while(oldFile.exists() || oldIndex <= rolloverCount);
 
         return this;
-    }
-
-    private File getNextLogFile(Path logLocation, int index) {
-        File newFile = logLocation.resolve("debug." + ++index + ".log").toFile();
-        return !newFile.exists() ? newFile : getNextLogFile(logLocation, index);
     }
 
     public Installer removeLegacyFiles() {

--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -170,7 +170,7 @@ public abstract class Installer {
         return this;
     }
 
-    public Installer removeLegacyLogs(int rolloverCount) {
+    public Installer cleanupLegacyLogs(int rolloverCount) {
         // Convert old < 2.2.3 log file format
         Path logLocation = USER_DIR;
         int nextFile = 0;

--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -173,23 +173,29 @@ public abstract class Installer {
     public Installer cleanupLegacyLogs(int rolloverCount) {
         // Convert old < 2.2.3 log file format
         Path logLocation = USER_DIR;
-        int nextFile = 0;
-        for(int i = 1; i <= rolloverCount; i++) {
+        int oldIndex = 0;
+        int newIndex = 0;
+        while(true) {
             // Old: debug.log.1
-            File oldFile = logLocation.resolve("debug.log." + i).toFile();
+            File oldFile = logLocation.resolve("debug.log." + oldIndex++).toFile();
             if(oldFile.exists()) {
                 // Rename to new format
                 inner:
                 while(true) {
                     // New: debug.1.log
-                    File newFile = logLocation.resolve("debug." + ++nextFile + ".log").toFile();
+                    File newFile = logLocation.resolve("debug." + ++newIndex + ".log").toFile();
                     if (!newFile.exists()) {
                         oldFile.renameTo(newFile);
                         log.info("Migrated log file {} to new location {}", oldFile, newFile);
                         break inner;
                     }
                 }
+                continue;
             }
+            // Loop at least as high as our rollover strategy in case there are human made gaps
+            if(oldIndex <= rolloverCount) continue;
+            break;
+
         }
 
         return this;

--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -170,6 +170,24 @@ public abstract class Installer {
         return this;
     }
 
+    public Installer removeLegacyLogs(int rolloverCount) {
+        // Cleanup old < 2.2.3 log file format
+        Path logLocation = USER_DIR;
+        for(int i = 1; i <= rolloverCount; i++) {
+            // Old: debug.log.1
+            File newFile = logLocation.resolve("debug." + i + ".log").toFile();
+            // New: debug.1.log
+            File oldFile = logLocation.resolve("debug.log." + i).toFile();
+            // Only delete old if an adjacent new copy exists
+            if(oldFile.exists() && newFile.exists()) {
+                log.info("Cleaning up old log file {}", oldFile);
+                oldFile.delete();
+            }
+        }
+
+        return this;
+    }
+
     public Installer removeLegacyFiles() {
         ArrayList<String> dirs = new ArrayList<>();
         ArrayList<String> files = new ArrayList<>();

--- a/src/qz/installer/Installer.java
+++ b/src/qz/installer/Installer.java
@@ -183,7 +183,7 @@ public abstract class Installer {
                 // New: debug.1.log
                 File newFile;
                 do {
-                    newFile = oldFile.toPath().getParent().resolve("debug." + ++newIndex + ".log").toFile();
+                    newFile = logLocation.resolve("debug." + ++newIndex + ".log").toFile();
                 } while(newFile.exists());
 
                 oldFile.renameTo(newFile);


### PR DESCRIPTION
Perform cleanup of old log file rotations:
* `debug.log.1` 
* `debug.log.2` 
* `debug.log.3` 
* `debug.log.4` 
* `debug.log.5` 

In favor of new format introduced in #1160:
* `debug.1.log` 
* `debug.2.log` 
* `debug.3.log` 
* `debug.4.log` 
* `debug.5.log` 

... but not without ensuring a replacement adjacent log exists first, to avoid any debugging data loss.

Closes #1196 