### PR TITLE
Unofficial support for bundled arm32 builds

### DIFF
--- a/ant/javafx.xml
+++ b/ant/javafx.xml
@@ -195,6 +195,13 @@
         </condition>
         <property name="fx.arch.fixed" value="${fx.arch}" description="fallback value"/>
 
+        <!-- Fix underscore when "monocle" is missing -->
+        <condition property="fx.url" value="${javafx.mirror}/${fx.majver}/openjfx-${fx.urlver}_${fx.os.fixed}-${fx.arch.fixed}_bin-sdk.zip">
+            <not>
+                <contains string="${fx.urlver}" substring="monocle"/>
+            </not>
+        </condition>
+
         <property name="fx.url" value="${javafx.mirror}/${fx.majver}/openjfx-${fx.urlver}-${fx.os.fixed}-${fx.arch.fixed}_bin-sdk.zip"/>
         <property name="fx.zip" value="${out.dir}/${fx.id}.zip"/>
 

--- a/ant/linux/installer.xml
+++ b/ant/linux/installer.xml
@@ -10,7 +10,7 @@
         <condition property="linux.target.arch" value="arm64">
             <isset property="target.arch.aarch64"/>
         </condition>
-        <property name="linux.target.arch" value="x86_64" description="fallback value"/>
+        <property name="linux.target.arch" value="${target.arch}" description="fallback value"/>
 
         <copy file="assets/branding/linux-icon.svg" tofile="${dist.dir}/${project.filename}.svg"/>
 
@@ -56,6 +56,10 @@
                 <!--aarch64-->
                 <include name="**/linux-aarch64/*" if="target.arch.aarch64"/> <!-- jna/hid4java/usb4java -->
                 <include name="**/linux_arm64/*" if="target.arch.aarch64"/> <!-- jssc -->
+                <!--arm32-->
+                <include name="**/linux-arm/*" if="target.arch.arm32"/> <!-- jna/hid4java -->
+                <include name="**/linux-arm/*" if="target.arch.arm32"/> <!-- usb4java -->
+                <include name="**/linux_arm/*" if="target.arch.arm32"/> <!-- jssc -->
             </fileset>
         </copy>
     </target>

--- a/ant/linux/installer.xml
+++ b/ant/linux/installer.xml
@@ -57,8 +57,7 @@
                 <include name="**/linux-aarch64/*" if="target.arch.aarch64"/> <!-- jna/hid4java/usb4java -->
                 <include name="**/linux_arm64/*" if="target.arch.aarch64"/> <!-- jssc -->
                 <!--arm32-->
-                <include name="**/linux-arm/*" if="target.arch.arm32"/> <!-- jna/hid4java -->
-                <include name="**/linux-arm/*" if="target.arch.arm32"/> <!-- usb4java -->
+                <include name="**/linux-arm/*" if="target.arch.arm32"/> <!-- jna/hid4java/usb4java -->
                 <include name="**/linux_arm/*" if="target.arch.arm32"/> <!-- jssc -->
             </fileset>
         </copy>

--- a/ant/platform-detect.xml
+++ b/ant/platform-detect.xml
@@ -135,6 +135,9 @@
             <equals arg1="aarch64" arg2="${target.arch}"/>
         </condition>
         <!-- Warning: Placeholder only! 32-bit builds are not supported -->
+        <condition property="target.arch.arm32">
+            <equals arg1="arm32" arg2="${target.arch}"/>
+        </condition>
         <condition property="target.arch.x86">
             <equals arg1="x86" arg2="${target.arch}"/>
         </condition>

--- a/src/qz/build/jlink/Arch.java
+++ b/src/qz/build/jlink/Arch.java
@@ -5,7 +5,8 @@ package qz.build.jlink;
  */
 public enum Arch implements Parsable {
     AMD64("amd64", "x86_64", "x64"),
-    AARCH64("aarch64", "arm64");
+    AARCH64("aarch64", "arm64"),
+    ARM32("arm", "arm32", "arm32hf", "aarch32", "aarch32hf");
 
     public final String[] matches;
     Arch(String ... matches) { this.matches = matches; }

--- a/src/qz/build/jlink/Vendor.java
+++ b/src/qz/build/jlink/Vendor.java
@@ -47,6 +47,20 @@ public enum Vendor implements Parsable {
             case AARCH64:
                 // All vendors seem to use "aarch64" universally
                 return "aarch64";
+            case ARM32:
+                switch(this) {
+                    case BELLSOFT:
+                        return "arm32-vfp-hflt";
+                    case AZUL:
+                        return "aarch32hf";
+                    case MICROSOFT:
+                    case IBM:
+                        throw new UnsupportedOperationException("Vendor does not provide builds for this architecture");
+                    case AMAZON:
+                    case ECLIPSE:
+                    default:
+                        return "arm";
+                }
             case AMD64:
                 switch(this) {
                     // BellSoft uses "amd64"


### PR DESCRIPTION
Adds ability to build for 32-bit armhf.

To compile:

* `javafx.version` must be changed from `19_monocle` to `19`.  This is because JavaFX 19 isn't offered in `monocle` form through Gluon for arm32.

   ```bash
   ant -Dtarget.arch=arm32 -Djavafx.version=19 makeself
   ```