### PR TITLE
Added basic accessibility

### DIFF
--- a/src/qz/build/JLink.java
+++ b/src/qz/build/JLink.java
@@ -233,7 +233,7 @@ public class JLink {
         }
         switch(targetPlatform) {
             case WINDOWS:
-                // Java accessibility bridge dependency, see https://github.com/adoptium/adoptium-support/issues/1234
+                // Java accessibility bridge dependency, see https://github.com/qzind/tray/issues/1234
                 depList.add("jdk.accessibility");
             default:
                 // "jar:" URLs create transient zipfs dependency, see https://stackoverflow.com/a/57846672/3196753

--- a/src/qz/build/JLink.java
+++ b/src/qz/build/JLink.java
@@ -233,6 +233,8 @@ public class JLink {
                 depList.add(item);
             }
         }
+        // the jdk.accessibility package is used if JAB is enabled; JDeps misses this, leading to a missing class runtime error. see #1234
+        if (targetPlatform == Platform.WINDOWS) depList.add("jdk.accessibility");
         // "jar:" URLs create transient zipfs dependency, see https://stackoverflow.com/a/57846672/3196753
         depList.add("jdk.zipfs");
         // fix for https://github.com/qzind/tray/issues/894 solution from https://github.com/adoptium/adoptium-support/issues/397
@@ -283,7 +285,8 @@ public class JLink {
             String keepExt;
             switch(targetPlatform) {
                 case WINDOWS:
-                    keepFiles = new String[]{ "java.exe", "javaw.exe" };
+                    // Jabswitch is a tool for enabling and disabling accessibility support on windows
+                    keepFiles = new String[]{ "java.exe", "javaw.exe", "jabswitch.exe"};
                     // Windows stores ".dll" files in bin
                     keepExt = ".dll";
                     break;

--- a/src/qz/ui/DetailsDialog.java
+++ b/src/qz/ui/DetailsDialog.java
@@ -31,12 +31,16 @@ public class DetailsDialog extends JPanel {
 
         requestTable = new RequestTable(iconCache);
         reqScrollPane = new JScrollPane(requestTable);
+        requestTable.getAccessibleContext().setAccessibleName("Request Details");
+        requestTable.getAccessibleContext().setAccessibleDescription("This table provides details about this request.");
 
         certLabel = new JLabel("Certificate");
         certLabel.setAlignmentX(CENTER_ALIGNMENT);
 
         certTable = new CertificateTable(iconCache);
         certScrollPane = new JScrollPane(certTable);
+        certTable.getAccessibleContext().setAccessibleName("Certificate Details");
+        certTable.getAccessibleContext().setAccessibleDescription("This table provides details about the certificate used in this request.");
 
         add(requestLabel);
         add(reqScrollPane);

--- a/src/qz/ui/DetailsDialog.java
+++ b/src/qz/ui/DetailsDialog.java
@@ -31,16 +31,18 @@ public class DetailsDialog extends JPanel {
 
         requestTable = new RequestTable(iconCache);
         reqScrollPane = new JScrollPane(requestTable);
-        requestTable.getAccessibleContext().setAccessibleName("Request Details");
-        requestTable.getAccessibleContext().setAccessibleDescription("This table provides details about this request.");
+        requestTable.getAccessibleContext().setAccessibleName(requestLabel.getText() + " Details");
+        requestTable.getAccessibleContext().setAccessibleDescription("Signing details about this request.");
+        requestLabel.setLabelFor(requestTable);
 
         certLabel = new JLabel("Certificate");
         certLabel.setAlignmentX(CENTER_ALIGNMENT);
 
         certTable = new CertificateTable(iconCache);
         certScrollPane = new JScrollPane(certTable);
-        certTable.getAccessibleContext().setAccessibleName("Certificate Details");
-        certTable.getAccessibleContext().setAccessibleDescription("This table provides details about the certificate used in this request.");
+        certTable.getAccessibleContext().setAccessibleName(certLabel.getText() + " Details");
+        certTable.getAccessibleContext().setAccessibleDescription("Certificate details about this request.");
+        certLabel.setLabelFor(certTable);
 
         add(requestLabel);
         add(reqScrollPane);

--- a/src/qz/ui/component/EmLabel.java
+++ b/src/qz/ui/component/EmLabel.java
@@ -7,25 +7,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Create a label at the multiplier of it's normal size, similar to CSS's "em" tag
+ * Create a label at the multiplier of its normal size, similar to CSS's "em" tag
  */
 public class EmLabel extends JLabel {
-    public EmLabel() {}
-    public EmLabel(String text) {
-        super(text);
-    }
     public EmLabel(String text, float multiplier) {
         this(text, multiplier, true);
     }
     public EmLabel(String text, float multiplier, boolean underline) {
         super(text);
-        Font template = getFont().deriveFont(multiplier * getFont().getSize());
+        stylizeComponent(this, multiplier, underline);
+    }
+
+    public static void stylizeComponent(Component j, float multiplier, boolean underline) {
+        Font template = j.getFont().deriveFont(multiplier * j.getFont().getSize());
         if (!underline) {
             Map<TextAttribute,Object> attributes = new HashMap<>(template.getAttributes());
             attributes.remove(TextAttribute.UNDERLINE);
-            setFont(template.deriveFont(attributes));
+            j.setFont(template.deriveFont(attributes));
         } else {
-            setFont(template);
+            j.setFont(template);
         }
     }
 }

--- a/src/qz/ui/component/LinkLabel.java
+++ b/src/qz/ui/component/LinkLabel.java
@@ -8,11 +8,9 @@ import qz.utils.ShellUtilities;
 
 import javax.accessibility.AccessibleContext;
 import javax.accessibility.AccessibleRole;
+import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
+import java.awt.event.*;
 import java.awt.font.TextAttribute;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -72,7 +70,6 @@ public class LinkLabel extends EmLabel implements Themeable {
         addActionListener(ae -> ShellUtilities.browseDirectory(filePath.isDirectory()? filePath.getPath():filePath.getParent()));
     }
 
-
     private void initialize() {
         Map<TextAttribute,Object> attributes = new HashMap<>(getFont().getAttributes());
         attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
@@ -80,6 +77,17 @@ public class LinkLabel extends EmLabel implements Themeable {
         setFocusable(true);
 
         actionListeners = new ArrayList<>();
+
+        this.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke("released SPACE"), "pressed");
+        this.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke("pressed ENTER"), "pressed");
+        this.getActionMap().put("pressed", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                for(ActionListener actionListener : actionListeners) {
+                    actionListener.actionPerformed(new ActionEvent(e.getSource(), e.getID(), "keyClicked"));
+                }
+            }
+        });
 
         addMouseListener(new MouseListener() {
             @Override

--- a/src/qz/ui/component/LinkLabel.java
+++ b/src/qz/ui/component/LinkLabel.java
@@ -6,6 +6,8 @@ import qz.common.Constants;
 import qz.ui.Themeable;
 import qz.utils.ShellUtilities;
 
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.font.TextAttribute;
@@ -80,5 +82,18 @@ public class LinkLabel extends JButton implements Themeable {
         setBorder(null);
         setOpaque(false);
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    public AccessibleContext getAccessibleContext() {
+        if (accessibleContext == null) {
+            accessibleContext = new AccessibleLinkLabel();
+        }
+        return accessibleContext;
+    }
+
+    protected class AccessibleLinkLabel extends AccessibleJButton {
+        public AccessibleRole getAccessibleRole() {
+            return AccessibleRole.HYPERLINK;
+        }
     }
 }

--- a/src/qz/ui/component/LinkLabel.java
+++ b/src/qz/ui/component/LinkLabel.java
@@ -6,6 +6,8 @@ import qz.common.Constants;
 import qz.ui.Themeable;
 import qz.utils.ShellUtilities;
 
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -75,6 +77,7 @@ public class LinkLabel extends EmLabel implements Themeable {
         Map<TextAttribute,Object> attributes = new HashMap<>(getFont().getAttributes());
         attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
         setFont(getFont().deriveFont(attributes));
+        setFocusable(true);
 
         actionListeners = new ArrayList<>();
 
@@ -121,4 +124,18 @@ public class LinkLabel extends EmLabel implements Themeable {
         actionListeners.remove(action);
     }
 
+    @Override
+    public AccessibleContext getAccessibleContext() {
+        if (accessibleContext == null) {
+            accessibleContext = new AccessibleLinkLabel();
+        }
+        return accessibleContext;
+    }
+
+    protected class AccessibleLinkLabel extends AccessibleJLabel {
+        @Override
+        public AccessibleRole getAccessibleRole() {
+            return AccessibleRole.HYPERLINK;
+        }
+    }
 }

--- a/src/qz/ui/component/LinkLabel.java
+++ b/src/qz/ui/component/LinkLabel.java
@@ -79,7 +79,6 @@ public class LinkLabel extends JButton implements Themeable {
         setBorderPainted(false);
         setBorder(null);
         setOpaque(false);
-        setFocusable(true);
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 }

--- a/src/qz/ui/component/LinkLabel.java
+++ b/src/qz/ui/component/LinkLabel.java
@@ -6,27 +6,25 @@ import qz.common.Constants;
 import qz.ui.Themeable;
 import qz.utils.ShellUtilities;
 
-import javax.accessibility.AccessibleContext;
-import javax.accessibility.AccessibleRole;
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.*;
 import java.awt.font.TextAttribute;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
+ * Creates a JButton which visually appears as a clickable link
+ *
+ * TODO: Rename this class.  Since switching from JLabel to a JButton, this class now has a misleading name.
+ *
  * Created by Tres on 2/19/2015.
  */
-public class LinkLabel extends EmLabel implements Themeable {
+public class LinkLabel extends JButton implements Themeable {
 
     private static final Logger log = LogManager.getLogger(LinkLabel.class);
-
-    private ArrayList<ActionListener> actionListeners;
 
     public LinkLabel() {
         super();
@@ -39,7 +37,8 @@ public class LinkLabel extends EmLabel implements Themeable {
     }
 
     public LinkLabel(String text, float multiplier, boolean underline) {
-        super(text, multiplier, underline);
+        super(text);
+        EmLabel.stylizeComponent(this, multiplier, underline);
         initialize();
     }
 
@@ -53,15 +52,12 @@ public class LinkLabel extends EmLabel implements Themeable {
     }
 
     public void setLinkLocation(final URL location) {
-        addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent ae) {
-                try {
-                    Desktop.getDesktop().browse(location.toURI());
-                }
-                catch(Exception e) {
-                    log.error("", e);
-                }
+        addActionListener(ae -> {
+            try {
+                Desktop.getDesktop().browse(location.toURI());
+            }
+            catch(Exception e) {
+                log.error("", e);
             }
         });
     }
@@ -74,76 +70,16 @@ public class LinkLabel extends EmLabel implements Themeable {
         Map<TextAttribute,Object> attributes = new HashMap<>(getFont().getAttributes());
         attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
         setFont(getFont().deriveFont(attributes));
-        setFocusable(true);
-
-        actionListeners = new ArrayList<>();
-
-        this.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke("released SPACE"), "pressed");
-        this.getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke("pressed ENTER"), "pressed");
-        this.getActionMap().put("pressed", new AbstractAction() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                for(ActionListener actionListener : actionListeners) {
-                    actionListener.actionPerformed(new ActionEvent(e.getSource(), e.getID(), "keyClicked"));
-                }
-            }
-        });
-
-        addMouseListener(new MouseListener() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                for(ActionListener actionListener : actionListeners) {
-                    actionListener.actionPerformed(new ActionEvent(e.getSource(), e.getID(), "mouseClicked"));
-                }
-            }
-
-            @Override
-            public void mousePressed(MouseEvent e) {}
-
-            @Override
-            public void mouseReleased(MouseEvent e) {}
-
-            @Override
-            public void mouseEntered(MouseEvent e) {
-                setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            }
-
-            @Override
-            public void mouseExited(MouseEvent e) {
-                setCursor(Cursor.getDefaultCursor());
-            }
-        });
-
         refresh();
     }
 
     @Override
     public void refresh() {
         setForeground(Constants.TRUSTED_COLOR);
-    }
-
-    public void addActionListener(ActionListener action) {
-        if (!actionListeners.contains(action)) {
-            actionListeners.add(action);
-        }
-    }
-
-    public void removeActionListener(ActionListener action) {
-        actionListeners.remove(action);
-    }
-
-    @Override
-    public AccessibleContext getAccessibleContext() {
-        if (accessibleContext == null) {
-            accessibleContext = new AccessibleLinkLabel();
-        }
-        return accessibleContext;
-    }
-
-    protected class AccessibleLinkLabel extends AccessibleJLabel {
-        @Override
-        public AccessibleRole getAccessibleRole() {
-            return AccessibleRole.HYPERLINK;
-        }
+        setBorderPainted(false);
+        setBorder(null);
+        setOpaque(false);
+        setFocusable(true);
+        setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 }


### PR DESCRIPTION
Fixes #1234 by bundling the accessibility bridge components when compiling for Windows.

> ```
> Assistive Technology not found: com.sun.java.accessibility.AccessBridge
> ```

Alternately, we could use `System.setProperty("javax.accessibility.assistive_technologies", "");` to avoid issues with accessibility by completely removing the feature, even when enabled globally on the system. That was my initial solution, and to enable accessibility using a build flag. Originally I was concerned about the security implications of the JAB (Java Access Bridge) which is used to communicate accessibility information on windows. After reading a bit on the topic though, I believe the JAB  is safe, and decided to instead support it.

I tested it with the NVDA screen reader, as JAWS requires a license, and Windows Narrator seems to be completely blind to swing. There were a few issues, such as our 'LinkLabel' not being selectable with tab. Some issues still exist, such as our tables capture the cursor when tabbing, and don't allow it to escape. This is observable on our 'View Request Details' window.