### PR TITLE
Added 'default' ColorType

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -1474,7 +1474,7 @@ var qz = (function() {
              *   @param {number} [options.bounds.y=0] Distance from top for bounding box starting corner
              *   @param {number} [options.bounds.width=0] Width of bounding box
              *   @param {number} [options.bounds.height=0] Height of bounding box
-             *  @param {string} [options.colorType='color'] Valid values <code>[color | grayscale | blackwhite]</code>
+             *  @param {string} [options.colorType='color'] Valid values <code>[color | grayscale | blackwhite | default]</code>
              *  @param {number} [options.copies=1] Number of copies to be printed.
              *  @param {number|Array<number>|Object|Array<Object>|string} [options.density=0] Pixel density (DPI, DPMM, or DPCM depending on <code>[options.units]</code>).
              *      If provided as an array, uses the first supported density found (or the first entry if none found).

--- a/sample.html
+++ b/sample.html
@@ -391,6 +391,7 @@
                                                     <option value="color">Color</option>
                                                     <option value="grayscale">Grayscale</option>
                                                     <option value="blackwhite">Black & White</option>
+                                                    <option value="default">Default</option>
                                                 </select>
                                             </div>
 

--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -734,7 +734,8 @@ public class PrintOptions {
         COLOR(Chromaticity.COLOR),
         GREYSCALE(Chromaticity.MONOCHROME),
         GRAYSCALE(Chromaticity.MONOCHROME),
-        BLACKWHITE(Chromaticity.MONOCHROME);
+        BLACKWHITE(Chromaticity.MONOCHROME),
+        DEFAULT(null);
 
         private final Chromaticity chromatic;
 

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -192,7 +192,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
             settings.setJobName(pxlOpts.getJobName(Constants.HTML_PRINT));
             settings.setPrintQuality(PrintQuality.HIGH);
 
-            if (pxlOpts.getColorType() != null) {
+            if (pxlOpts.getColorType().getAsChromaticity() != null) {
                 settings.setPrintColor(getColor(pxlOpts));
             }
             if (pxlOpts.getDuplex() == Sides.DUPLEX || pxlOpts.getDuplex() == Sides.TWO_SIDED_LONG_EDGE) {

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -191,6 +191,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
             settings.setJobName(pxlOpts.getJobName(Constants.HTML_PRINT));
             settings.setPrintQuality(PrintQuality.HIGH);
 
+            // If colortype is default, leave printColor blank. The system's printer settings will be used instead.
             if (pxlOpts.getColorType() != PrintOptions.ColorType.DEFAULT) {
                 settings.setPrintColor(getColor(pxlOpts));
             }

--- a/src/qz/printer/action/PrintHTML.java
+++ b/src/qz/printer/action/PrintHTML.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 public class PrintHTML extends PrintImage implements PrintProcessor {
 
@@ -192,7 +191,7 @@ public class PrintHTML extends PrintImage implements PrintProcessor {
             settings.setJobName(pxlOpts.getJobName(Constants.HTML_PRINT));
             settings.setPrintQuality(PrintQuality.HIGH);
 
-            if (pxlOpts.getColorType().getAsChromaticity() != null) {
+            if (pxlOpts.getColorType() != PrintOptions.ColorType.DEFAULT) {
                 settings.setPrintColor(getColor(pxlOpts));
             }
             if (pxlOpts.getDuplex() == Sides.DUPLEX || pxlOpts.getDuplex() == Sides.TWO_SIDED_LONG_EDGE) {

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -37,7 +37,8 @@ public abstract class PrintPixel {
         PrintRequestAttributeSet attributes = new HashPrintRequestAttributeSet();
 
         //apply general attributes
-        if (pxlOpts.getColorType().getAsChromaticity() != null) {
+        // If colortype is default, leave printColor blank. The system's printer settings will be used instead.
+        if (pxlOpts.getColorType() != PrintOptions.ColorType.DEFAULT) {
             attributes.add(pxlOpts.getColorType().getAsChromaticity());
         }
         attributes.add(pxlOpts.getDuplex());

--- a/src/qz/printer/action/PrintPixel.java
+++ b/src/qz/printer/action/PrintPixel.java
@@ -37,7 +37,7 @@ public abstract class PrintPixel {
         PrintRequestAttributeSet attributes = new HashPrintRequestAttributeSet();
 
         //apply general attributes
-        if (pxlOpts.getColorType() != null) {
+        if (pxlOpts.getColorType().getAsChromaticity() != null) {
             attributes.add(pxlOpts.getColorType().getAsChromaticity());
         }
         attributes.add(pxlOpts.getDuplex());


### PR DESCRIPTION
Fixes #1179 
Null was intended to act as a 'default' option, but does not. Since it was not a documented feature, we will add a 'default' option rather than change the existing behavior of null.

Printers have a default color setting on windows, it can be "Black & White" or "Color". This is a table showing the test results of a given setting, with a given `colorType` in QZ.

Master:

| `colorType` | Printer: Black & White | Printer: Color |
|---|---|---|
| Grayscale | Black & White | Black & White |
| Color | Color | Color |
| Null | Color | Color |

This PR:

| `colorType` | Printer: Black & White | Printer: Color |
|---|---|---|
| Grayscale | Black & White | Black & White |
| Color | Color | Color |
| Null | Color | Color |
| Default | Black & White | Color |

Printing from HTML seems to have some issues when the printer is set to a color of 'Black & White', and QZ requests color. HTML also seems to have sticky color settings, requiring a restart after changing. I was able to verify that we are at least **attempting** to set it to the correct value in these scenarios.