### PR TITLE
Add "legacy" ESCPOS striping support

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -853,6 +853,17 @@ var qz = (function() {
                     }
                 }
 
+                if(_qz.tools.versionCompare(2, 2, 4) < 0) {
+                    for(var i = 0; i < printData.length; i++) {
+                        if (printData[i].constructor === Object) {
+                            // Allow dotDensity "double" fallback behavior for newly added "legacy-double", etc.
+                            if (printData[i].options && typeof printData[i].options.dotDensity === 'string') {
+                                printData[i].options.dotDensity = printData[i].options.dotDensity.toLowerCase().replace("legacy-", "");
+                            }
+                        }
+                    }
+                }
+
                 if (_qz.tools.isVersion(2, 0)) {
                     /*
                     2.0.x conversion

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -856,7 +856,7 @@ var qz = (function() {
                 if(_qz.tools.versionCompare(2, 2, 4) < 0) {
                     for(var i = 0; i < printData.length; i++) {
                         if (printData[i].constructor === Object) {
-                            // Allow dotDensity "double" fallback behavior for newly added "double-legacy", etc.
+                            // dotDensity: "double-legacy|single-legacy" since 2.2.4.  Fallback to "double|single"
                             if (printData[i].options && typeof printData[i].options.dotDensity === 'string') {
                                 printData[i].options.dotDensity = printData[i].options.dotDensity.toLowerCase().replace("-legacy", "");
                             }

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -856,9 +856,9 @@ var qz = (function() {
                 if(_qz.tools.versionCompare(2, 2, 4) < 0) {
                     for(var i = 0; i < printData.length; i++) {
                         if (printData[i].constructor === Object) {
-                            // Allow dotDensity "double" fallback behavior for newly added "legacy-double", etc.
+                            // Allow dotDensity "double" fallback behavior for newly added "double-legacy", etc.
                             if (printData[i].options && typeof printData[i].options.dotDensity === 'string') {
-                                printData[i].options.dotDensity = printData[i].options.dotDensity.toLowerCase().replace("legacy-", "");
+                                printData[i].options.dotDensity = printData[i].options.dotDensity.toLowerCase().replace("-legacy", "");
                             }
                         }
                     }

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -285,6 +285,9 @@ public class PrintRaw implements PrintProcessor {
                     case "single": density = 32; break;
                     case "double": density = 33; break;
                     case "triple": density = 39; break;
+                    // negative: legacy mode
+                    case "single-legacy": density = -32; break;
+                    case "double-legacy": density = -33; break;
                 }
             } else {
                 density = 32; //default

--- a/src/qz/printer/action/raw/ImageWrapper.java
+++ b/src/qz/printer/action/raw/ImageWrapper.java
@@ -85,6 +85,8 @@ public class ImageWrapper {
     private boolean igpDots = false; // PGL only, toggle IGP/PGL default resolution of 72dpi
     private int dotDensity = 32;  // Generally 32 = Single (normal) 33 = Double (higher res) for ESC/POS.  Irrelevant for all other languages.
 
+    private boolean legacyMode = false; // Use newlines for ESC/POS spacing; simulates <=2.0.11 behavior
+
     /**
      * Creates a new
      * <code>ImageWrapper</code> from a
@@ -199,7 +201,8 @@ public class ImageWrapper {
     }
 
     public void setDotDensity(int dotDensity) {
-        this.dotDensity = dotDensity;
+        this.legacyMode = dotDensity < 0;
+        this.dotDensity = Math.abs(dotDensity);
     }
 
     public void setLogoId(String logoId) {
@@ -584,9 +587,6 @@ public class ImageWrapper {
      * @param builder the ByteArrayBuilder to use
      */
     private void appendEpsonSlices(ByteArrayBuilder builder) {
-        // Use newlines for spacing; simulate <=2.0.11 behavior
-        // FIXME: Make this configurable
-        boolean legacyMode = true;
         // set line height to the size of each chunk we will be sending
         int segmentHeight = dotDensity > 1 ? 24 : (dotDensity == 1 ? 8 : 16); // height will be handled explicitly below if striping
         // Impact printers (U220, etc) benefit from double-pass striping (odd/even) for higher quality (dotDensity = 1)


### PR DESCRIPTION
Prior to QZ Tray 2.0.12, ESCPOS images were sent using a linespacing/newline technique.  Although newer ESCPOS image methods are much more compatible with a wide range of printers, some customers have requested to maintain the old behavior.

This introduces [`dotDensity: "double-legacy"` and `dotDensity: "single-legacy"`](https://qz.io/docs/raw#escpos), which will restore the old behavior.

https://github.com/tresf/tray/releases/download/v2.2.4/qz-tray-2.2.4-DOTDENSITY-x86_64.exe