### PR TITLE
Fix Rossetta Prompt Bug on Apple Silicon

### DIFF
--- a/ant/apple/apple-bundle.plist.in
+++ b/ant/apple/apple-bundle.plist.in
@@ -20,5 +20,9 @@
                 <key>CFBundleURLSchemes</key>
                 <array><string>${vendor.name}</string></array>
             </dict>
-        </array>
+        </array>        
+    <key>LSArchitecturePriority</key>
+    <array>
+        <string>${apple.target.arch}</string>
+    </array>
 </dict></plist>

--- a/ant/apple/apple-bundle.plist.in
+++ b/ant/apple/apple-bundle.plist.in
@@ -20,7 +20,7 @@
                 <key>CFBundleURLSchemes</key>
                 <array><string>${vendor.name}</string></array>
             </dict>
-        </array>        
+        </array>
     <key>LSArchitecturePriority</key>
     <array>
         <string>${apple.target.arch}</string>


### PR DESCRIPTION
Closes https://github.com/qzind/tray/issues/1284

This is the better of two fixes for this issue I found. The other is to include a arm64 binary in the Content/MacOS folder, or a symlink thereof. This solution only fixes the issue if this is the first time qz has ran on the system, or you manually edit "QZ Tray.app/Content/info.plist" and change `<key>CFBundleIdentifier</key><string>io.qz.qz-tray</string>` to anything else, for example `<key>CFBundleIdentifier</key><string>io.qz.qz-tray-arm64</string>`.

We need to find a way around this bundleID issue. Something is being cached, and I am unsure of how to clear it.