### PR TITLE
Guard setSecurityAlgorithm from pending connections

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -964,11 +964,14 @@ var qz = (function() {
             algorithm: function(quiet) {
                 //if not connected yet we will assume compatibility exists for the time being
                 if (_qz.tools.isActive()) {
-                    if (_qz.tools.isVersion(2, 0)) {
-                        if (!quiet) {
-                            _qz.log.warn("Connected to an older version of QZ, alternate signature algorithms are not supported");
+                    //guard race condition for pending connections
+                    if( _qz.websocket.connection && _qz.websocket.connection.semver) {
+                        if (_qz.tools.isVersion(2, 0)) {
+                            if (!quiet) {
+                                _qz.log.warn("Connected to an older version of QZ, alternate signature algorithms are not supported");
+                            }
+                            return false;
                         }
-                        return false;
                     }
                 }
 

--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -963,15 +963,13 @@ var qz = (function() {
             /** Check if QZ version supports chosen algorithm */
             algorithm: function(quiet) {
                 //if not connected yet we will assume compatibility exists for the time being
-                if (_qz.tools.isActive()) {
-                    //guard race condition for pending connections
-                    if( _qz.websocket.connection && _qz.websocket.connection.semver) {
-                        if (_qz.tools.isVersion(2, 0)) {
-                            if (!quiet) {
-                                _qz.log.warn("Connected to an older version of QZ, alternate signature algorithms are not supported");
-                            }
-                            return false;
+                //check semver to guard race condition for pending connections
+                if (_qz.tools.isActive() && _qz.websocket.connection.semver) {
+                    if (_qz.tools.isVersion(2, 0)) {
+                        if (!quiet) {
+                            _qz.log.warn("Connected to an older version of QZ, alternate signature algorithms are not supported");
                         }
+                        return false;
                     }
                 }
 


### PR DESCRIPTION
If qz.setSignatureAlgorithm is called mid-connection, it can cause an unhandled exception.

Closes #1301 