### PR TITLE
Add support for PDFBOX 3.0

### DIFF
--- a/ant/dependencies.properties
+++ b/ant/dependencies.properties
@@ -66,7 +66,7 @@ mslinks.rev=1.2
 
 pdfbox.org=org.apache.pdfbox
 pdfbox.name=pdfbox
-pdfbox.rev=2.0.38-SNAPSHOT
+pdfbox.rev=3.0.9-SNAPSHOT
 
 purejavahidapi.org=nyholku
 purejavahidapi.name=purejavahidapi

--- a/src/qz/printer/action/PrintPDF.java
+++ b/src/qz/printer/action/PrintPDF.java
@@ -3,7 +3,9 @@ package qz.printer.action;
 import com.github.zafarkhaja.semver.Version;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.io.IOUtils;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.multipdf.Splitter;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -159,14 +161,11 @@ public class PrintPDF extends PrintPixel implements PrintProcessor {
     }
 
     public static PDDocument loadPdf(String data, PrintingUtilities.Flavor flavor) throws IOException {
-        switch(flavor) {
-            case PLAIN:
-                // There's really no such thing as a 'PLAIN' PDF, assume it's a URL
-            case FILE:
-                return refreshAcroForm(PDDocument.load(ConnectionUtilities.getInputStream(data, true)));
-            default:
-                return refreshAcroForm(PDDocument.load(new ByteArrayInputStream(flavor.read(data))));
-        }
+        return switch(flavor) {
+            // There's really no such thing as a 'PLAIN' PDF, assume it's a URL
+            case PLAIN, FILE -> refreshAcroForm(Loader.loadPDF(new RandomAccessReadBuffer(ConnectionUtilities.getInputStream(data, true))));
+            default -> refreshAcroForm(Loader.loadPDF(new RandomAccessReadBuffer(new ByteArrayInputStream(flavor.read(data)))));
+        };
     }
 
     /**

--- a/src/qz/printer/action/pdf/ParamPdfRenderer.java
+++ b/src/qz/printer/action/pdf/ParamPdfRenderer.java
@@ -39,8 +39,8 @@ public class ParamPdfRenderer extends PDFRenderer {
             super(parameters);
 
             // Note:  These must match PdfFontPageDrawer's ignoreTransparency condition
-            addOperator(new OpaqueDrawObject());
-            addOperator(new OpaqueGraphicStateParameters());
+            addOperator(new OpaqueDrawObject(this));
+            addOperator(new OpaqueGraphicStateParameters(this));
         }
     }
 }

--- a/src/qz/printer/rendering/OpaqueDrawObject.java
+++ b/src/qz/printer/rendering/OpaqueDrawObject.java
@@ -1,5 +1,6 @@
 package qz.printer.rendering;
 
+import org.apache.pdfbox.contentstream.PDFGraphicsStreamEngine;
 import org.apache.pdfbox.contentstream.operator.MissingOperandException;
 import org.apache.pdfbox.contentstream.operator.Operator;
 import org.apache.pdfbox.contentstream.operator.graphics.GraphicsOperatorProcessor;
@@ -16,7 +17,9 @@ import java.util.List;
 // override draw object to remove any calls to show transparency
 public class OpaqueDrawObject extends GraphicsOperatorProcessor {
 
-    public OpaqueDrawObject() { }
+    public OpaqueDrawObject(PDFGraphicsStreamEngine context) {
+        super(context);
+    }
 
     public void process(Operator operator, List<COSBase> operands) throws IOException {
         if (operands.isEmpty()) {
@@ -25,7 +28,8 @@ public class OpaqueDrawObject extends GraphicsOperatorProcessor {
             COSBase base0 = operands.get(0);
             if (base0 instanceof COSName) {
                 COSName objectName = (COSName)base0;
-                PDXObject xobject = context.getResources().getXObject(objectName);
+                PDFGraphicsStreamEngine context = getGraphicsContext();
+                PDXObject xobject = getGraphicsContext().getResources().getXObject(objectName);
 
                 if (xobject == null) {
                     throw new MissingResourceException("Missing XObject: " + objectName.getName());

--- a/src/qz/printer/rendering/OpaqueDrawObject.java
+++ b/src/qz/printer/rendering/OpaqueDrawObject.java
@@ -29,7 +29,7 @@ public class OpaqueDrawObject extends GraphicsOperatorProcessor {
             if (base0 instanceof COSName) {
                 COSName objectName = (COSName)base0;
                 PDFGraphicsStreamEngine context = getGraphicsContext();
-                PDXObject xobject = getGraphicsContext().getResources().getXObject(objectName);
+                PDXObject xobject = context.getResources().getXObject(objectName);
 
                 if (xobject == null) {
                     throw new MissingResourceException("Missing XObject: " + objectName.getName());

--- a/src/qz/printer/rendering/OpaqueGraphicStateParameters.java
+++ b/src/qz/printer/rendering/OpaqueGraphicStateParameters.java
@@ -39,6 +39,10 @@ public class OpaqueGraphicStateParameters extends OperatorProcessor
 {
     private static final Log LOG = LogFactory.getLog(OpaqueGraphicStateParameters.class);
 
+    public OpaqueGraphicStateParameters(PDFStreamEngine context) {
+        super(context);
+    }
+
     @Override
     public void process(Operator operator, List<COSBase> arguments) throws IOException
     {

--- a/src/qz/printer/rendering/PdfFontPageDrawer.java
+++ b/src/qz/printer/rendering/PdfFontPageDrawer.java
@@ -33,8 +33,8 @@ public class PdfFontPageDrawer extends PageDrawer {
 
         if (ignoresTransparency) {
             // Note:  These must match ParamPdfRenderer's OpaquePageDrawer
-            addOperator(new OpaqueDrawObject());
-            addOperator(new OpaqueGraphicStateParameters());
+            addOperator(new OpaqueDrawObject(this));
+            addOperator(new OpaqueGraphicStateParameters(this));
         }
     }
 


### PR DESCRIPTION
Switches the PDFBOX library from 2.x to 3.x

TODO:
* [x] Regression testing
* [x] Update workarounds for PDFBOX 3.x 

@akberenz can you help me with the workaround?  `getContext()` is null and it's expected to be passed in now. 

https://github.com/qzind/tray/blob/b8cab39987bb49daff0e6ce706f149d8b883f013/src/qz/printer/action/pdf/ParamPdfRenderer.java#L41-L44