### PR TITLE
Remove WMIC dependency from Windows installers

### DIFF
--- a/ant/apple/installer.xml
+++ b/ant/apple/installer.xml
@@ -258,6 +258,7 @@
             <arg value="--entitlement"/>
             <arg value="${build.dir}/apple-entitlements.plist"/>
             <arg value="${bundle.dir}/Contents/PlugIns/Java.runtime/Contents/Home/bin/java"/>
+            <arg value="${bundle.dir}/Contents/PlugIns/Java.runtime/Contents/Home/bin/jcmd"/>
             <arg value="${bundle.dir}/Contents/PlugIns/Java.runtime"/>
         </exec>
         <exec executable="codesign" failonerror="true">

--- a/src/qz/build/JLink.java
+++ b/src/qz/build/JLink.java
@@ -236,6 +236,8 @@ public class JLink {
                 // Java accessibility bridge dependency, see https://github.com/qzind/tray/issues/1234
                 depList.add("jdk.accessibility");
             default:
+                // Adds "bin/jcmd"
+                depList.add("jdk.jcmd");
                 // "jar:" URLs create transient zipfs dependency, see https://stackoverflow.com/a/57846672/3196753
                 depList.add("jdk.zipfs");
                 // fix for https://github.com/qzind/tray/issues/894 solution from https://github.com/adoptium/adoptium-support/issues/397

--- a/src/qz/build/JLink.java
+++ b/src/qz/build/JLink.java
@@ -294,6 +294,7 @@ public class JLink {
                 case WINDOWS:
                     keepFiles.add("java.exe");
                     keepFiles.add("javaw.exe");
+                    keepFiles.add("jcmd.exe");
                     if(depList.contains("jdk.accessibility")) {
                         // Java accessibility bridge switching tool
                         keepFiles.add("jabswitch.exe");
@@ -303,6 +304,7 @@ public class JLink {
                     break;
                 default:
                     keepFiles.add("java");
+                    keepFiles.add("jcmd");
                     keepExt = null;
             }
 

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -46,7 +46,7 @@ public class TaskKiller {
         // Use jcmd to get all java processes
         HashSet<Integer> pids = findPidsJcmd();
         if(!SystemUtilities.isWindows()) {
-            // Fallback to pgrep (See liberica/QZ-23)
+            // Fallback to pgrep, needed for macOS (See JDK-8319589, JDK-8197387)
             pids.addAll(findPidsPgrep());
         }
 

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import qz.common.Constants;
-import qz.installer.certificate.firefox.locator.AppLocator;
 import qz.utils.ShellUtilities;
 import qz.utils.SystemUtilities;
 import qz.ws.PrintSocketServer;
@@ -22,7 +21,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 
 import static qz.common.Constants.PROPS_FILE;
 
@@ -44,17 +43,16 @@ public class TaskKiller {
             ShellUtilities.execute("/bin/launchctl", "unload", MacInstaller.LAUNCH_AGENT_PATH);
         }
 
-        // Get the matching PIDs
-        ArrayList<Integer> pids;
-        try {
-            pids = findTrayPids();
-        } catch(IOException e) {
-            log.error("Failed to retrieve PIDs for {}", Constants.ABOUT_TITLE, e);
-            return false;
+        // Use jcmd to get all java processes
+        HashSet<Integer> pids = findPidsJcmd();
+        if(!SystemUtilities.isWindows()) {
+            // Fallback to pgrep (See liberica/QZ-23)
+            pids.addAll(findPidsPgrep());
         }
 
         // Kill each PID
         String[] killPid = new String[KILL_PID_CMD.length + 1];
+        System.arraycopy(KILL_PID_CMD, 0, killPid, 0, KILL_PID_CMD.length);
         for (Integer pid : pids) {
             killPid[killPid.length - 1] = pid.toString();
             log.debug("Found {} running as PID {}, calling '{}'", Constants.ABOUT_TITLE, pid, Arrays.toString(killPid));
@@ -71,48 +69,73 @@ public class TaskKiller {
         } else if (SystemUtilities.isMac()) {
             jcmd = SystemUtilities.getJarParentPath().resolve("../PlugIns/Java.runtime/Contents/Home/bin/jcmd");
         } else {
-            jcmd = SystemUtilities.getJarParentPath().resolve("../PlugIns/Java.runtime/Contents/Home/bin/jcmd");
+            jcmd = SystemUtilities.getJarParentPath().resolve("/runtime/bin/jcmd");
         }
         if(!jcmd.toFile().exists()) {
-            throw new IOException("Could not find jcmd, we can't stop running instances");
+            throw new IOException("Could not find jcmd, we can't use it for detecting running instances");
         }
         return jcmd;
+    }
+
+    private static HashSet<Integer> findPidsPgrep() {
+        HashSet<Integer> foundPids = new HashSet<>();
+
+        for(String jarName : JAR_NAMES) {
+            String[] pids = ShellUtilities.executeRaw("pgrep", "-f", jarName).split("\\s*\\r?\\n");
+            for(String pid : pids) {
+                if (StringUtils.isNumeric(pid)) {
+                    foundPids.add(Integer.parseInt(pid));
+                }
+            }
+        }
+
+        // Careful not to kill ourselves ;)
+        foundPids.remove(SystemUtilities.getProcessId());
+
+        return foundPids;
     }
 
 
     /**
      * Uses jcmd to fetch all PIDs that match this product
      */
-    private static ArrayList<Integer> findTrayPids() throws IOException {
-        ArrayList<Integer> foundProcs = new ArrayList<>();
+    private static HashSet<Integer> findPidsJcmd() {
+        HashSet<Integer> foundPids = new HashSet<>();
 
-        String[] stdout = ShellUtilities.executeRaw(getJcmdPath().toString(), "-l").split("\\r?\\n");
-        if(stdout == null || stdout.length == 0) {
-            throw new IOException("Error calling '" + getJcmdPath() + "' -l");
+        String[] stdout = {};
+        try {
+            stdout = ShellUtilities.executeRaw(getJcmdPath().toString(), "-l").split("\\r?\\n");
+            if(stdout == null || stdout.length == 0) {
+               log.error("Error calling '{}' {}", getJcmdPath(), "-l");
+            }
+        } catch(Exception e) {
+            log.error(e);
+            return foundPids;
         }
+
         for(String line : stdout) {
             // e.g. "35446 C:\Program Files\QZ Tray\qz-tray.jar"
             String[] parts = line.split(" ", 1);
-            if (parts.length >= 2) {
+            if (parts.length >= 2 && StringUtils.isNumeric(parts[0])) {
                 Integer proc = Integer.parseInt(parts[0]);
                 String command = parts[1];
                 // Handle running from IDE such as IntelliJ
                 if(command.contains(PrintSocketServer.class.getCanonicalName())) {
-                    foundProcs.add(proc);
+                    foundPids.add(proc);
                     continue;
                 }
                 // Handle "qz-tray.jar"
                 for(String jarName : JAR_NAMES) {
                     if(command.contains(jarName));
-                    foundProcs.add(proc);
+                    foundPids.add(proc);
                     break; // continue parent loop
                 }
             }
         }
 
         // Careful not to kill ourselves ;)
-        foundProcs.remove(SystemUtilities.getProcessId());
+        foundPids.remove(SystemUtilities.getProcessId());
 
-        return foundProcs;
+        return foundPids;
     }
 }

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -71,7 +71,7 @@ public class TaskKiller {
             jcmd = SystemUtilities.getJarParentPath().resolve("runtime/bin/jcmd");
         }
         if(!jcmd.toFile().exists()) {
-            log.error("Could not find find {}", jcmd);
+            log.error("Could not find {}", jcmd);
             throw new IOException("Could not find jcmd, we can't use it for detecting running instances");
         }
         return jcmd;

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -65,13 +65,14 @@ public class TaskKiller {
     private static Path getJcmdPath() throws IOException {
         Path jcmd;
         if(SystemUtilities.isWindows()) {
-            jcmd = SystemUtilities.getJarParentPath().resolve("/runtime/bin/jcmd.exe");
+            jcmd = SystemUtilities.getJarParentPath().resolve("runtime/bin/jcmd.exe");
         } else if (SystemUtilities.isMac()) {
             jcmd = SystemUtilities.getJarParentPath().resolve("../PlugIns/Java.runtime/Contents/Home/bin/jcmd");
         } else {
-            jcmd = SystemUtilities.getJarParentPath().resolve("/runtime/bin/jcmd");
+            jcmd = SystemUtilities.getJarParentPath().resolve("runtime/bin/jcmd");
         }
         if(!jcmd.toFile().exists()) {
+            log.error("Could not find find {}", jcmd);
             throw new IOException("Could not find jcmd, we can't use it for detecting running instances");
         }
         return jcmd;

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -15,10 +15,8 @@ import org.apache.logging.log4j.Logger;
 import qz.installer.certificate.firefox.locator.AppLocator;
 import qz.utils.ShellUtilities;
 import qz.utils.SystemUtilities;
-import qz.utils.WindowsUtilities;
 import qz.ws.PrintSocketServer;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +35,13 @@ public class TaskKiller {
      * Kills all QZ Tray processes, being careful not to kill itself
      */
     public static boolean killAll() {
+        // TODO:
+        // 1. Calculate the path to jcmd
+        // 2. List all Java processes using jcmd -l
+        // 3. Filter Java processes matching "qz-tray.jar"
+        // 4. Filter Java processes matching "PrintSocketClient" (IntelliJ)
+        // 5. Kill all matching processes
+
         boolean success = true;
 
         ArrayList<String> javaProcs;
@@ -85,13 +90,6 @@ public class TaskKiller {
                     killCmd[killCmd.length - 1] = parts[0].trim();
                     success = success && ShellUtilities.execute(killCmd);
                 }
-            }
-        }
-
-        if(WindowsUtilities.isWindowsXP()) {
-            File f = new File("TempWmicBatchFile.bat");
-            if(f.exists()) {
-                f.deleteOnExit();
             }
         }
 

--- a/src/qz/installer/TaskKiller.java
+++ b/src/qz/installer/TaskKiller.java
@@ -57,6 +57,7 @@ public class TaskKiller {
         String[] killPid = new String[KILL_PID_CMD.length + 1];
         for (Integer pid : pids) {
             killPid[killPid.length - 1] = pid.toString();
+            log.debug("Found {} running as PID {}, calling '{}'", Constants.ABOUT_TITLE, pid, Arrays.toString(killPid));
             success = success && ShellUtilities.execute(killPid);
         }
 

--- a/src/qz/installer/certificate/firefox/locator/AppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/AppLocator.java
@@ -18,6 +18,7 @@ public abstract class AppLocator {
     public abstract ArrayList<AppInfo> locate(AppAlias appAlias);
     public abstract ArrayList<Path> getPidPaths(ArrayList<String> pids);
 
+    @SuppressWarnings("unused")
     public ArrayList<String> getPids(String ... processNames) {
         return getPids(new ArrayList<>(Arrays.asList(processNames)));
     }

--- a/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
+++ b/src/qz/installer/certificate/firefox/locator/WindowsAppLocator.java
@@ -10,31 +10,28 @@
 
 package qz.installer.certificate.firefox.locator;
 
-import org.apache.commons.lang3.StringUtils;
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Psapi;
+import com.sun.jna.platform.win32.Tlhelp32;
+import com.sun.jna.platform.win32.WinNT;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import qz.installer.certificate.firefox.locator.AppAlias.Alias;
-import qz.utils.ShellUtilities;
-import qz.utils.SystemUtilities;
 import qz.utils.WindowsUtilities;
 
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Locale;
 
 import static com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE;
 
 public class WindowsAppLocator extends AppLocator{
     protected static final Logger log = LogManager.getLogger(MacAppLocator.class);
-
-    private static final String[] WIN32_PID_QUERY = {"wmic.exe", "process", "where", null, "get", "processid"};
-    private static final int WIN32_PID_QUERY_INPUT_INDEX = 3;
-
-    private static final String[] WIN32_PATH_QUERY = {"wmic.exe", "process", "where", null, "get", "ExecutablePath"};
-    private static final int WIN32_PATH_QUERY_INPUT_INDEX = 3;
 
     private static String REG_TEMPLATE = "Software\\%s%s\\%s%s";
 
@@ -61,48 +58,57 @@ public class WindowsAppLocator extends AppLocator{
 
     @Override
     public ArrayList<String> getPids(ArrayList<String> processNames) {
-        ArrayList<String> pidList = new ArrayList<>();
+        ArrayList<String> javaPids = new ArrayList<>();
+        Tlhelp32.PROCESSENTRY32 pe32 = new Tlhelp32.PROCESSENTRY32();
+        pe32.dwSize = new WinNT.DWORD(pe32.size());
 
-        if (processNames.isEmpty()) return pidList;
-
-        WIN32_PID_QUERY[WIN32_PID_QUERY_INPUT_INDEX] = "(Name='" + String.join("' OR Name='", processNames) + "')";
-        String[] response = ShellUtilities.executeRaw(WIN32_PID_QUERY).split("[\\r\\n]+");
-
-        // Add all found pids
-        for(String line : response) {
-            String pid = line.trim();
-            if(StringUtils.isNumeric(pid.trim())) {
-                pidList.add(pid);
-            }
+        // Fetch a snapshot of all processes
+        WinNT.HANDLE hSnapshot = Kernel32.INSTANCE.CreateToolhelp32Snapshot(Tlhelp32.TH32CS_SNAPPROCESS, new WinNT.DWORD(0));
+        if (hSnapshot.equals(WinNT.INVALID_HANDLE_VALUE)) {
+            log.warn("Process snapshot has invalid handle");
+            return javaPids;
         }
 
-        if(WindowsUtilities.isWindowsXP()) {
-            // Cleanup XP crumbs per https://stackoverflow.com/q/12391655/3196753
-            File f = new File("TempWmicBatchFile.bat");
-            if(f.exists()) {
-                f.deleteOnExit();
-            }
+        if (Kernel32.INSTANCE.Process32First(hSnapshot, pe32)) {
+            do {
+                String processName = Native.toString(pe32.szExeFile);
+                if(processNames.contains(processName.toLowerCase(Locale.ENGLISH))) {
+                    javaPids.add(pe32.th32ProcessID.toString());
+                }
+            } while (Kernel32.INSTANCE.Process32Next(hSnapshot, pe32));
         }
 
-        return pidList;
+        Kernel32.INSTANCE.CloseHandle(hSnapshot);
+        return javaPids;
     }
+
 
     @Override
     public ArrayList<Path> getPidPaths(ArrayList<String> pids) {
-        ArrayList<Path> pathList = new ArrayList<>();
+        ArrayList<Path> paths = new ArrayList<>();
 
         for(String pid : pids) {
-            WIN32_PATH_QUERY[WIN32_PATH_QUERY_INPUT_INDEX] = "ProcessId=" + pid;
-            String[] response = ShellUtilities.executeRaw(WIN32_PATH_QUERY).split("\\s*\\r?\\n");
-            if (response.length > 1) {
-                try {
-                    pathList.add(Paths.get(response[1]).toRealPath());
-                } catch(IOException e) {
-                    log.warn("Could not locate process " + pid);
-                }
+            WinNT.HANDLE hProcess = Kernel32.INSTANCE.OpenProcess(WinNT.PROCESS_QUERY_INFORMATION | WinNT.PROCESS_VM_READ, false, Integer.parseInt(pid));
+            if (hProcess == null) {
+                log.warn("Handle for PID {} is missing, skipping.", pid);
+                continue;
             }
+
+            int bufferSize = WinNT.MAX_PATH;
+            Pointer buffer = new Memory(bufferSize * Native.WCHAR_SIZE);
+
+            if (Psapi.INSTANCE.GetModuleFileNameEx(hProcess, null, buffer, bufferSize) == 0) {
+                log.warn("Full path to PID {} is empty, skipping.", pid);
+                Kernel32.INSTANCE.CloseHandle(hProcess);
+                continue;
+            }
+
+            Kernel32.INSTANCE.CloseHandle(hProcess);
+            paths.add(Paths.get(Native.WCHAR_SIZE == 1 ?
+                                        buffer.getString(0) :
+                                        buffer.getWideString(0)));
         }
-        return pathList;
+        return paths;
     }
 
     /**

--- a/src/qz/utils/ShellUtilities.java
+++ b/src/qz/utils/ShellUtilities.java
@@ -182,10 +182,6 @@ public class ShellUtilities {
         InputStreamReader in = null;
         try {
             Process p = Runtime.getRuntime().exec(commandArray, envp);
-            if(SystemUtilities.isWindows() && commandArray.length > 0 && commandArray[0].startsWith("wmic")) {
-                // Fix deadlock on old Windows versions https://stackoverflow.com/a/13367685/3196753
-                p.getOutputStream().close();
-            }
             in = new InputStreamReader(p.getInputStream(), Charsets.UTF_8);
             StringBuilder out = new StringBuilder();
             int c;


### PR DESCRIPTION
WMIC has been removed from newer Windows 11 versions and must be removed from the source code.

TODO:
* [x] Switch Firefox `AppLocator` to use JNA
* [x] Switch `TaskKiller` to use `jcmd` (this will impact all platforms)

> [!NOTE]
> Due to some upstream bugs  [`JDK-8197387`](https://bugs.openjdk.org/browse/JDK-8197387), [`JDK-8319589`](https://bugs.openjdk.org/browse/JDK-8319589), `jcmd` cannot completely replace `pgrep` at this time.  Bug filed downstream with Liberica `QZ-23`)


Closes #1334