### PR TITLE
Add support for private-network-access headers

### DIFF
--- a/src/qz/utils/ArgValue.java
+++ b/src/qz/utils/ArgValue.java
@@ -89,6 +89,8 @@ public enum ArgValue {
                            "security.wss.httpsonly"),
     SECURITY_WSS_HOST(PREFERENCES, "Influences which physical adapter to bind to by setting the host parameter for http/websocket listening", null, "0.0.0.0",
                            "security.wss.host"),
+    SECURITY_WSS_ALLOWORIGIN(PREFERENCES, "Override 'Access-Control-Allow-Origin: *' HTTP response header for fine-grained control of incoming HTTP connections", null, "*",
+                             "security.wss.alloworigin"),
     WEBSOCKET_SECURE_PORTS(PREFERENCES, "Comma separated list of secure websocket (wss://) ports to use", null, StringUtils.join(Constants.DEFAULT_WSS_PORTS, ","),
                            "websocket.secure.ports"),
     WEBSOCKET_INSECURE_PORTS(PREFERENCES, "Comma separated list of insecure websocket (ws://) ports to use", null, StringUtils.join(Constants.DEFAULT_WS_PORTS, ","),

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -25,6 +25,7 @@ import qz.printer.status.StatusMonitor;
 import qz.utils.*;
 import qz.ws.substitutions.Substitutions;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.usb.util.UsbUtil;
 import java.awt.*;
 import java.io.EOFException;
@@ -848,7 +849,11 @@ public class PrintSocketClient {
         if(!allowOrigin.equals("*")) {
             String origin = req.getHeader("Origin");
             if(!allowOrigin.equals(origin)) {
-                log.error("Connection-supplied origin value '{}' does not match {}: '{}'; WebSocket connection will fail", origin, ArgValue.SECURITY_WSS_ALLOWORIGIN.getMatch(), allowOrigin);
+                String message = String.format("Connection-supplied origin value '%s' does not match %s: '%s'; WebSocket connection will fail", origin, ArgValue.SECURITY_WSS_ALLOWORIGIN.getMatch(), allowOrigin);
+                log.error(message);
+                try {
+                    resp.sendError(HttpServletResponse.SC_FORBIDDEN, message);
+                } catch(IOException ignore) {}
                 return null;
             }
         }

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -12,6 +12,8 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.*;
 import org.eclipse.jetty.websocket.api.exceptions.CloseException;
 import org.eclipse.jetty.websocket.api.exceptions.WebSocketException;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeRequest;
+import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
 import org.usb4java.LoaderException;
 import qz.auth.Certificate;
 import qz.auth.RequestState;
@@ -837,4 +839,19 @@ public class PrintSocketClient {
         }
     }
 
+    /**
+     * Simulate preflight headers origin filter
+     *
+     * TODO: Revisit when specification is updated to include WebSockets https://wicg.github.io/private-network-access/#integration-websockets
+     */
+    public static PrintSocketClient originFilterUpgrade(JettyServerUpgradeRequest req, JettyServerUpgradeResponse resp, Server server, String allowOrigin) {
+        if(!allowOrigin.equals("*")) {
+            String origin = req.getHeader("Origin");
+            if(!allowOrigin.equals(origin)) {
+                log.error("Connection-supplied origin value '{}' does not match {}: '{}'; WebSocket connection will fail", origin, ArgValue.SECURITY_WSS_ALLOWORIGIN.getMatch(), allowOrigin);
+                return null;
+            }
+        }
+        return new PrintSocketClient(server);
+    }
 }

--- a/src/qz/ws/PrintSocketServer.java
+++ b/src/qz/ws/PrintSocketServer.java
@@ -100,6 +100,7 @@ public class PrintSocketServer {
                             request.getHeader("Access-Control-Request-Private-Network").equals("true")) {
                         response.setHeader("Access-Control-Allow-Private-Network", "true");
                     }
+                    filterChain.doFilter(request, response);
                 }), "/*", null);
 
                 // Handle WebSocket connections


### PR DESCRIPTION
* Adds preflight headers for:
   * `Access-Control-Allow-Origin`
   * `Access-Control-Request-Private-Network`
   * `Access-Control-Allow-Private-Network`
* Adds new `SECURITY_WSS_ALLOWORIGIN` (`security.wss.alloworigin`) option to influence origin value (e.g. `*`, `https://demo.qz.io`)
* Simulates `Access-Control-Allow-Origin` for WebSockets using manual `Origin` verification

Closes #1236