### PR TITLE
File Drag fix

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -3403,6 +3403,8 @@
             // Event from button
             evt.preventDefault();
 
+            $("#qz-page").removeClass("drag-target");
+
             var item = evt.dataTransfer.items[0];
             if(item.kind === "file") {
                 file = item.getAsFile();
@@ -3484,7 +3486,6 @@
                 }
             }).catch(displayError); 
         }
-        $("#qz-page").removeClass("drag-target"); 
     }
 
     function drag(evt, entering) {


### PR DESCRIPTION
If there was an error, we were hitting 
```js
displayError("Please drag a valid file");
return;
```
Before calling 
```js
$("#qz-page").removeClass("drag-target");
```
I simply moved the call to the start of the function.
fixes #1347 