### PR TITLE
Server Side Keep-Alive

### DIFF
--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -38,8 +38,7 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 
 @WebSocket
@@ -66,7 +65,11 @@ public class PrintSocketClient {
         trayManager.displayInfoMessage("Client connected");
 
         //new connections are unknown until they send a proper certificate
-        openConnections.put(((InetSocketAddress)session.getRemoteAddress()).getPort(), new SocketConnection(Certificate.UNKNOWN));
+        SocketConnection connection =  new SocketConnection(Certificate.UNKNOWN);
+        openConnections.put(((InetSocketAddress)session.getRemoteAddress()).getPort(), connection);
+
+        //Browsers now slow or interrupt JS timers, leading to the websockets keepalive failing. A server-side keepalive ping will qct as a fallback.
+        connection.startKeepAlive(session, (int)(session.getPolicy().getIdleTimeout().toSeconds() / 2));
     }
 
     @OnWebSocketClose

--- a/src/qz/ws/SocketConnection.java
+++ b/src/qz/ws/SocketConnection.java
@@ -3,6 +3,7 @@ package qz.ws;
 import jssc.SerialPortException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.websocket.api.Session;
 import qz.auth.Certificate;
 import qz.communication.*;
 import qz.printer.status.StatusMonitor;
@@ -11,6 +12,10 @@ import qz.utils.FileWatcher;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 public class SocketConnection {
 
@@ -31,6 +36,9 @@ public class SocketConnection {
 
     // DeviceOptions -> open DeviceIO
     private final HashMap<DeviceOptions,DeviceIO> openDevices = new HashMap<>();
+
+    private static final ScheduledExecutorService keepAliveExecutor = Executors.newScheduledThreadPool(1);
+    private ScheduledFuture<?> keepAlive;
 
 
     public SocketConnection(Certificate cert) {
@@ -95,6 +103,27 @@ public class SocketConnection {
         return openFiles.get(absolute);
     }
 
+    public void startKeepAlive(Session session, int seconds) {
+        if (keepAlive != null && (!keepAlive.isCancelled() || !keepAlive.isDone())) {
+            stopKeepAlive();
+        }
+        //Sane fallback, this should never come up.
+        seconds = Math.max(seconds, 15);
+        keepAlive = keepAliveExecutor.scheduleAtFixedRate(() -> {
+            try {
+                session.getRemote().sendPing(null);
+            }
+            catch(IOException e) {
+                log.warn("Websocket keepalive failed. Stopping", e);
+                this.stopKeepAlive();
+            }
+        }, 0, seconds, TimeUnit.SECONDS);
+    }
+
+    public void stopKeepAlive() {
+        keepAlive.cancel(true);
+    }
+
     public void removeFileListener(Path absolute) {
         openFiles.remove(absolute);
     }
@@ -147,6 +176,7 @@ public class SocketConnection {
             dio.close();
         }
 
+        stopKeepAlive();
         removeAllFileListeners();
         stopDeviceListening();
         StatusMonitor.stopListening(this);


### PR DESCRIPTION
Potential fix for #1275

The server can send pings just like the client to keep a WS alive. No pong logic seems to be required. This ping from the server should be immune to chrome's throttling, and I left the client side ping in to inform the client if the connection fails. The failure should report shortly after waking up the tab, or more likely, right away if the closure of the WS was graceful.

Note: I was never able to reproduce the original issue. I think this fix may also fail on firefox if the tab goes into full suspension due to low system resources, but testing is needed.