### PR TITLE
Allow configurable commands for image printing

### DIFF
--- a/src/qz/printer/PrintOptions.java
+++ b/src/qz/printer/PrintOptions.java
@@ -95,6 +95,11 @@ public class PrintOptions {
             rawOptions.retainTemp = configOpts.optBoolean("retainTemp", false);
         }
 
+        if (!configOpts.isNull("imageEncoding")) {
+            String imageEncoding = configOpts.optString("imageEncoding", String.valueOf(ImageEncoding.ESC_STAR));
+            rawOptions.imageEncoding = ImageEncoding.valueOf(imageEncoding);
+        }
+
 
         //check for pixel options
         if (!configOpts.isNull("units")) {
@@ -423,6 +428,7 @@ public class PrintOptions {
         private int copies = 1;                 //Job copies
         private String jobName = null;          //Job name
         private boolean retainTemp = false;     //Retain any temporary files
+        private ImageEncoding imageEncoding = ImageEncoding.ESC_STAR; //Image encoding
 
 
         public boolean isForceRaw() {
@@ -453,6 +459,10 @@ public class PrintOptions {
 
         public String getJobName(String defaultVal) {
             return jobName == null || jobName.isEmpty()? defaultVal:jobName;
+        }
+
+        public ImageEncoding getImageEncoding() {
+            return imageEncoding;
         }
     }
 
@@ -749,4 +759,10 @@ public class PrintOptions {
         }
     }
 
+    /** Raw image encoding option */
+    public enum ImageEncoding {
+        ESC_STAR,
+        GS_V_0,
+        GS_L
+    }
 }

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -278,7 +278,13 @@ public class PrintRaw implements PrintProcessor {
 
         ImageWrapper iw = new ImageWrapper(img, LanguageType.getType(opt.optString("language")));
         iw.setCharset(Charset.forName(destEncoding));
-        iw.setImageEncoding(PrintOptions.ImageEncoding.valueOf(opt.optString("imageEncoding")));
+
+        // Set image encoding
+        try {
+            iw.setImageEncoding(PrintOptions.ImageEncoding.valueOf(opt.optString("imageEncoding")));
+        } catch (IllegalArgumentException e) {
+            iw.setImageEncoding(PrintOptions.ImageEncoding.ESC_STAR);
+        }
 
         //ESC/POS only
         int density = opt.optInt("dotDensity", -1);

--- a/src/qz/printer/action/PrintRaw.java
+++ b/src/qz/printer/action/PrintRaw.java
@@ -278,6 +278,7 @@ public class PrintRaw implements PrintProcessor {
 
         ImageWrapper iw = new ImageWrapper(img, LanguageType.getType(opt.optString("language")));
         iw.setCharset(Charset.forName(destEncoding));
+        iw.setImageEncoding(PrintOptions.ImageEncoding.valueOf(opt.optString("imageEncoding")));
 
         //ESC/POS only
         int density = opt.optInt("dotDensity", -1);

--- a/src/qz/printer/action/raw/encoder/GsLEncoder.java
+++ b/src/qz/printer/action/raw/encoder/GsLEncoder.java
@@ -1,0 +1,128 @@
+package qz.printer.action.raw.encoder;
+
+import qz.common.ByteArrayBuilder;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+public class GsLEncoder implements ImageEncoder {
+    @Override
+    public byte[] encode(BufferedImage image) {
+        ByteArrayBuilder builder = new ByteArrayBuilder();
+        if (image == null) return builder.getByteArray();
+
+        int width = image.getWidth();
+        int height = image.getHeight();
+        final int sliceHeight = 24;
+
+        for (int y = 0; y < height; y += sliceHeight) {
+            int slicedHeight = Math.min(sliceHeight, height - y);
+
+            // Create a sliced image from the full image
+            BufferedImage slicedImage = image.getSubimage(0, y, width, slicedHeight);
+
+            // Append the store graphic command
+            byte[] storeCommand = generateStoreCommand(slicedImage);
+            builder.append(storeCommand);
+
+            // Append the print graphic command
+            byte[] printCommand = generatePrintCommand();
+            builder.append(printCommand);
+        }
+
+        return builder.getByteArray();
+    }
+
+    /**
+     * Generates the store graphic command (GS ( L with fn = 112) for the given image
+     */
+    private static byte[] generateStoreCommand(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        // Convert image to monochrome
+        BufferedImage monoImage = convertToMonochrome(image);
+
+        // Calculate bytes needed for image data
+        int bytesPerRow = (width + 7) / 8; // Round up to the nearest byte
+        byte[] imageData = new byte[bytesPerRow * height];
+
+        // Convert image to the bit array
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int rgb = monoImage.getRGB(x, y);
+                // If the pixel is black (or dark), set bit to 1
+                boolean isBlack = (rgb & 0xFF) < 128;
+                if (isBlack) {
+                    int byteIndex = y * bytesPerRow + (x / 8);
+                    int bitIndex = 7 - (x % 8);
+                    imageData[byteIndex] |= (byte) (1 << bitIndex);
+                }
+            }
+        }
+
+        // Calculate command parameters
+        int dataLength = imageData.length + 10; // 10 bytes for parameters
+        int pL = dataLength & 0xFF;
+        int pH = (dataLength >> 8) & 0xFF;
+        int m = 48; // Command header
+        int fn = 112; // Function 112: Store the graphics data in the print buffer (raster format)
+        int a = 48; // Normal mode
+        int bx = 1; // Horizontal scale
+        int by = 1; // Vertical scale
+        int c = 49; // Single color
+        int xL = width & 0xFF;
+        int xH = (width >> 8) & 0xFF;
+        int yL = height & 0xFF;
+        int yH = (height >> 8) & 0xFF;
+
+        // Build command
+        ByteArrayOutputStream command = new ByteArrayOutputStream();
+        command.write(0x1D); // GS
+        command.write('(');
+        command.write('L');
+        command.write(pL);
+        command.write(pH);
+        command.write(m);
+        command.write(fn);
+        command.write(a);
+        command.write(bx);
+        command.write(by);
+        command.write(c);
+        command.write(xL);
+        command.write(xH);
+        command.write(yL);
+        command.write(yH);
+        command.write(imageData, 0, imageData.length);
+
+        return command.toByteArray();
+    }
+
+    /**
+     * Generates the print graphic command (GS ( L with fn = 50)
+     */
+    public static byte[] generatePrintCommand() {
+        ByteArrayOutputStream command = new ByteArrayOutputStream();
+        command.write(0x1D); // GS
+        command.write('(');
+        command.write('L');
+        command.write(2); // pL
+        command.write(0); // pH
+        command.write(48); // m
+        command.write(50); // Function 50: Print the graphics data in the print buffer
+
+        return command.toByteArray();
+    }
+
+    /**
+     * Converts a BufferedImage to monochrome (1-bit) format
+     */
+    private static BufferedImage convertToMonochrome(BufferedImage original) {
+        BufferedImage mono = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = mono.createGraphics();
+        g2d.drawImage(original, 0, 0, null);
+        g2d.dispose();
+        return mono;
+    }
+}

--- a/src/qz/printer/action/raw/encoder/GsV0Encoder.java
+++ b/src/qz/printer/action/raw/encoder/GsV0Encoder.java
@@ -1,0 +1,93 @@
+package qz.printer.action.raw.encoder;
+
+import qz.common.ByteArrayBuilder;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+public class GsV0Encoder implements ImageEncoder {
+    @Override
+    public byte[] encode(BufferedImage image) {
+        ByteArrayBuilder builder = new ByteArrayBuilder();
+        if (image == null) return builder.getByteArray();
+
+        int width = image.getWidth();
+        int height = image.getHeight();
+        final int sliceHeight = 24;
+
+        for (int y = 0; y < height; y += sliceHeight) {
+            int slicedHeight = Math.min(sliceHeight, height - y);
+
+            // Create a sliced image from the full image
+            BufferedImage slicedImage = image.getSubimage(0, y, width, slicedHeight);
+
+            // Append the GS v 0 command for the slice
+            byte[] command = generateGsV0Command(slicedImage);
+            builder.append(command);
+        }
+
+        return builder.getByteArray();
+    }
+
+    /**
+     * Generates the GS v 0 command for the given image slice.
+     * Command: GS v 0 m xL xH yL yH d1...dk
+     */
+    private byte[] generateGsV0Command(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        // Convert image to monochrome
+        BufferedImage monoImage = convertToMonochrome(image);
+
+        // Calculate bytes needed for image data
+        int bytesPerRow = (width + 7) / 8; // Round up to the nearest byte
+        byte[] imageData = new byte[bytesPerRow * height];
+
+        // Convert image to the bit array
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int rgb = monoImage.getRGB(x, y);
+                // If the pixel is black (or dark), set bit to 1
+                boolean isBlack = (rgb & 0xFF) < 128;
+                if (isBlack) {
+                    int byteIndex = y * bytesPerRow + (x / 8);
+                    int bitIndex = 7 - (x % 8);
+                    imageData[byteIndex] |= (byte) (1 << bitIndex);
+                }
+            }
+        }
+
+        // Calculate command parameters
+        int xL = bytesPerRow & 0xFF;
+        int xH = (bytesPerRow >> 8) & 0xFF;
+        int yL = height & 0xFF;
+        int yH = (height >> 8) & 0xFF;
+
+        // Build command
+        ByteArrayOutputStream command = new ByteArrayOutputStream();
+        command.write(0x1D); // GS
+        command.write('v');  // 0x76
+        command.write('0');  // 0x30
+        command.write(0);    // m = 0 (normal mode)
+        command.write(xL);
+        command.write(xH);
+        command.write(yL);
+        command.write(yH);
+        command.write(imageData, 0, imageData.length);
+
+        return command.toByteArray();
+    }
+
+    /**
+     * Converts a BufferedImage to monochrome (1-bit) format
+     */
+    private static BufferedImage convertToMonochrome(BufferedImage original) {
+        BufferedImage mono = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = mono.createGraphics();
+        g2d.drawImage(original, 0, 0, null);
+        g2d.dispose();
+        return mono;
+    }
+}

--- a/src/qz/printer/action/raw/encoder/ImageEncoder.java
+++ b/src/qz/printer/action/raw/encoder/ImageEncoder.java
@@ -1,0 +1,7 @@
+package qz.printer.action.raw.encoder;
+
+import java.awt.image.BufferedImage;
+
+public interface ImageEncoder {
+    byte[] encode(BufferedImage image);
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows for configurable image printing commands, specifically for ESC/P printers.

### Summary

Previously, QZ-Tray used command (`ESC *`) for printing images to ESC/P printers. This change introduces support for two additional, widely-used image printing commands: `GS v 0` and `GS ( L`.

The primary goal is to offer better performance for image printing with alternative commands.

### Key Changes

-   **Configurable Image Commands:** A new `imageEncoding` option has been added to the print configuration. This allows users to specify which command set to use for image printing.
    -   `ESC_STAR` (default): The original `ESC *` command.
    -   `GS_V_0`: The `GS v 0` command.
    -   `GS_L`: The `GS ( L` command.
-   **New Encoders:**
    -   `GsV0Encoder.java`: Implements the logic for the `GS v 0` command.
    -   `GsLEncoder.java`: Implements the logic for the `GS ( L` command.

### How to Use

To use one of the new image printing commands, add the `imageEncoding` option to your printing configuration. For example:

```js
{
    type: 'raw',
    format: 'image',
    flavor: 'file',
    data: fileUrl,
    options: { language: 'ESCPOS', imageEncoding: 'GS_L' },
}
```

If the `imageEncoding` option is not specified, the system will default to `ESC_STAR` to maintain backward compatibility with existing setups.
