### PR TITLE
Fix provision step OS detection

### DIFF
--- a/src/qz/build/provision/Step.java
+++ b/src/qz/build/provision/Step.java
@@ -192,7 +192,7 @@ public class Step {
             }
         }
 
-        HashSet<Os> os = new HashSet<>();
+        HashSet<Os> os = null;
         if(jsonStep.has("os")) {
             // Do not tolerate bad os values
             String osString = jsonStep.optString("os");
@@ -202,7 +202,7 @@ public class Step {
             }
         }
 
-        HashSet<Arch> arch = new HashSet<>();
+        HashSet<Arch> arch = null;
         if(jsonStep.has("arch")) {
             // Do not tolerate bad arch values
             String archString = jsonStep.optString("arch");


### PR DESCRIPTION
`Step::validateOs()` will only apply OS detection based on file name if `os` is set to null. This fixes the Step parsing code to actually do so.

This change is untested. I'll let the Java professionals chime in :eyes: 
