### PR TITLE
sample.html: Better handling of hosts/secure/insecure ports

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -1476,19 +1476,10 @@
     }
 
     function startConnection(config) {
-        // Connect to a print-server instance, if specified
-        if ($('#connectionHost').hasClass("dirty")) {
-            var host = $('#connectionHost').val().trim();
-            config ||= {};
-            config.host = host;
-        }
-
-        // Allow secure/insecure port override
-        if ($('#connectionUsingSecure').hasClass("dirty")) {
-            var usingSecure = $("#connectionUsingSecure").prop('checked');
-            config ||= {};
-            config.usingSecure = usingSecure;
-        }
+        // Connect to a print-server instance and/or override secure port handling
+        config ||= {};
+        config.host = includedValue($('#connectionHost'));
+        config.usingSecure = isChecked($('#connectionUsingSecure'));
 
         if (!qz.websocket.isActive()) {
             updateState('Waiting', 'default');


### PR DESCRIPTION
Allows insecure connections to `localhost` by leveraging the `dirty` flag on all of our input controls.

@akberenz since you authored the majority of this code, I'd love a second set of eyes before merging.