### PR TITLE
Add ability to set custom title of JS lib (i.e. "QZ Tray" --> "My Printing App")

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -2821,7 +2821,7 @@ var qz = (function() {
              *
              * @memberof qz.api
              */
-            setPromiseType : function(promiser) {
+            setPromiseType: function(promiser) {
                 _qz.tools.promise = promiser;
             },
 


### PR DESCRIPTION
```js
qz.api.getTitle(); // returns "QZ Tray"

// Change all internal JS references of "QZ Tray" to "My Printing App"
qz.api.setTitle("My Printing App");

qz.api.getTitle(); // returns "My Printing App"
```
```diff
- Error: Unable to establish connection with QZ Tray
                                             ^^^^^^^

+ Error: Unable to establish connection with My Printing App
                                             ^^^^^^^^^^^^^^^

- Established connection with QZ Tray on 8181
                              ^^^^^^^

+ Established connection with My Printing App on 8181
                              ^^^^^^^^^^^^^^^
```