### PR TITLE
Add shared serial port access between tabs

### DIFF
--- a/src/qz/communication/SerialPortMonitor.java
+++ b/src/qz/communication/SerialPortMonitor.java
@@ -1,0 +1,168 @@
+package qz.communication;
+
+import jssc.SerialPortException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.eclipse.jetty.websocket.api.Session;
+import qz.ws.SocketConnection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SerialPortMonitor {
+    private static final Logger log = LogManager.getLogger(SerialPortMonitor.class);
+
+    private static final HashMap<String, SharedSerialPort> openPorts = new HashMap<>();
+    private static final HashMap<SocketConnection, SerialSession> serialSessions = new HashMap<>();
+    private static final HashMap<String, List<SocketConnection>> portListeners = new HashMap<>();
+
+    public synchronized static boolean startListening(SocketConnection connection, Session session,
+                                                       String portName, SerialOptions opts) throws SerialPortException {
+        if (isListening(connection, portName)) {
+            log.warn("Connection already listening to port [{}]", portName);
+            return true;
+        }
+
+        SerialSession serialSession = serialSessions.computeIfAbsent(connection, c -> new SerialSession(session));
+
+        SharedSerialPort sharedPort = openPorts.get(portName);
+        if (sharedPort == null) {
+            sharedPort = new SharedSerialPort(portName);
+            final String pn = portName;
+            sharedPort.setOnCloseCallback(() -> {
+                synchronized (SerialPortMonitor.class) {
+                    openPorts.remove(pn);
+                    portListeners.remove(pn);
+                    log.info("Shared port [{}] removed from monitor", pn);
+                }
+            });
+
+            if (!sharedPort.open(opts)) {
+                log.error("Failed to open serial port [{}]", portName);
+                return false;
+            }
+
+            openPorts.put(portName, sharedPort);
+            log.info("Opened new shared port [{}]", portName);
+        } else {
+            if (opts != null && opts.isPortSettingsExplicitlySet()) {
+                SerialOptions.PortSettings existingSettings = sharedPort.getPortSettings();
+                SerialOptions.PortSettings requestedSettings = opts.getPortSettings();
+
+                if (requestedSettings != null && existingSettings != null && !requestedSettings.equals(existingSettings)) {
+                    throw new SerialPortException(portName, "openPort",
+                        "Port is already open with different settings. Remove explicit settings to join the shared port.");
+                }
+            }
+
+            if (opts != null && opts.isEncodingExplicitlySet()) {
+                SerialOptions.PortSettings existingSettings = sharedPort.getPortSettings();
+                SerialOptions.PortSettings requestedSettings = opts.getPortSettings();
+
+                if (requestedSettings != null && existingSettings != null &&
+                    !requestedSettings.getEncoding().equals(existingSettings.getEncoding())) {
+                    throw new SerialPortException(portName, "openPort",
+                        "Port is already open with different encoding. Remove encoding option to join the shared port.");
+                }
+            }
+
+            if (opts != null && opts.isRxExplicitlySet()) {
+                SerialOptions.ResponseFormat existingFormat = sharedPort.getResponseFormat();
+                SerialOptions.ResponseFormat requestedFormat = opts.getResponseFormat();
+
+                if (requestedFormat != null && existingFormat != null && !requestedFormat.equals(existingFormat)) {
+                    throw new SerialPortException(portName, "openPort",
+                        "Port is already open with different rx settings. Remove rx options to join the shared port.");
+                }
+            }
+        }
+
+        sharedPort.addListener(connection, serialSession);
+        portListeners.computeIfAbsent(portName, k -> new ArrayList<>()).add(connection);
+
+        log.info("Connection now listening to port [{}], total listeners: {}", portName, sharedPort.getListenerCount());
+        return true;
+    }
+
+    public synchronized static void stopListening(SocketConnection connection, String portName) {
+        SharedSerialPort sharedPort = openPorts.get(portName);
+        if (sharedPort == null) {
+            return;
+        }
+
+        boolean portClosed = sharedPort.removeListener(connection);
+
+        List<SocketConnection> listeners = portListeners.get(portName);
+        if (listeners != null) {
+            listeners.remove(connection);
+            if (listeners.isEmpty()) {
+                portListeners.remove(portName);
+            }
+        }
+
+        if (portClosed) {
+            log.info("Port [{}] closed (last listener removed)", portName);
+        }
+    }
+
+    public synchronized static void stopListening(SocketConnection connection) {
+        List<String> portsToRemove = new ArrayList<>();
+        for (Map.Entry<String, List<SocketConnection>> entry : portListeners.entrySet()) {
+            if (entry.getValue().contains(connection)) {
+                portsToRemove.add(entry.getKey());
+            }
+        }
+
+        for (String portName : portsToRemove) {
+            stopListening(connection, portName);
+        }
+
+        serialSessions.remove(connection);
+    }
+
+    public synchronized static boolean isListening(SocketConnection connection, String portName) {
+        List<SocketConnection> listeners = portListeners.get(portName);
+        return listeners != null && listeners.contains(connection);
+    }
+
+    public synchronized static void sendData(SocketConnection connection, String portName,
+                                              JSONObject params, SerialOptions opts)
+            throws JSONException, IOException, SerialPortException {
+
+        if (!isListening(connection, portName)) {
+            throw new SerialPortException(portName, "sendData", "Connection is not listening to this port");
+        }
+
+        SharedSerialPort sharedPort = openPorts.get(portName);
+        if (sharedPort == null || !sharedPort.isOpen()) {
+            throw new SerialPortException(portName, "sendData", "Port is not open");
+        }
+
+        sharedPort.sendData(params, opts);
+    }
+
+    public synchronized static int getListenerCount(String portName) {
+        SharedSerialPort sharedPort = openPorts.get(portName);
+        return sharedPort != null ? sharedPort.getListenerCount() : 0;
+    }
+
+    public synchronized static boolean isPortOpen(String portName) {
+        SharedSerialPort sharedPort = openPorts.get(portName);
+        return sharedPort != null && sharedPort.isOpen();
+    }
+
+    public synchronized static List<String> getPortsForConnection(SocketConnection connection) {
+        List<String> ports = new ArrayList<>();
+        for (Map.Entry<String, List<SocketConnection>> entry : portListeners.entrySet()) {
+            if (entry.getValue().contains(connection)) {
+                ports.add(entry.getKey());
+            }
+        }
+        return ports;
+    }
+}

--- a/src/qz/communication/SerialSession.java
+++ b/src/qz/communication/SerialSession.java
@@ -1,0 +1,28 @@
+package qz.communication;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.websocket.api.Session;
+import qz.ws.PrintSocketClient;
+import qz.ws.StreamEvent;
+
+public class SerialSession {
+    private static final Logger log = LogManager.getLogger(SerialSession.class);
+
+    private final Session session;
+
+    public SerialSession(Session session) {
+        this.session = session;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public void sendSerialEvent(String portName, String output, Runnable closeHandler) {
+        StreamEvent event = new StreamEvent(StreamEvent.Stream.SERIAL, StreamEvent.Type.RECEIVE)
+                .withData("portName", portName)
+                .withData("output", output);
+        PrintSocketClient.sendStream(session, event, closeHandler);
+    }
+}

--- a/src/qz/communication/SharedSerialPort.java
+++ b/src/qz/communication/SharedSerialPort.java
@@ -1,0 +1,334 @@
+package qz.communication;
+
+import jssc.SerialPort;
+import jssc.SerialPortEvent;
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import qz.common.ByteArrayBuilder;
+import qz.utils.ByteUtilities;
+import qz.utils.DeviceUtilities;
+import qz.ws.SocketConnection;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SharedSerialPort implements SerialPortEventListener {
+    private static final Logger log = LogManager.getLogger(SharedSerialPort.class);
+
+    private static final int READ_TIMEOUT = 1200;
+
+    private final String portName;
+    private SerialPort port;
+    private SerialOptions serialOpts;
+    private final ByteArrayBuilder data = new ByteArrayBuilder();
+
+    private final Map<SocketConnection, SerialSession> listeners = new HashMap<>();
+    private Runnable onCloseCallback;
+
+    public SharedSerialPort(String portName) {
+        this.portName = portName;
+    }
+
+    public void setOnCloseCallback(Runnable callback) {
+        this.onCloseCallback = callback;
+    }
+
+    public synchronized boolean open(SerialOptions opts) throws SerialPortException {
+        if (isOpen()) {
+            log.warn("Serial port [{}] is already open", portName);
+            return true;
+        }
+
+        port = new SerialPort(portName);
+        port.openPort();
+
+        serialOpts = new SerialOptions();
+        applyOptions(opts);
+        port.addEventListener(this);
+
+        log.info("Shared serial port [{}] opened", portName);
+        return port.isOpened();
+    }
+
+    public synchronized boolean isOpen() {
+        return port != null && port.isOpened();
+    }
+
+    public synchronized SerialOptions.PortSettings getPortSettings() {
+        return serialOpts != null ? serialOpts.getPortSettings() : null;
+    }
+
+    public synchronized SerialOptions.ResponseFormat getResponseFormat() {
+        return serialOpts != null ? serialOpts.getResponseFormat() : null;
+    }
+
+    public synchronized void addListener(SocketConnection connection, SerialSession session) {
+        if (listeners.containsKey(connection)) {
+            log.warn("Connection already listening to port [{}]", portName);
+            return;
+        }
+
+        listeners.put(connection, session);
+        log.info("Added listener to shared port [{}], now {} listeners", portName, listeners.size());
+    }
+
+    public synchronized boolean removeListener(SocketConnection connection) {
+        if (listeners.remove(connection) != null) {
+            log.info("Removed listener from shared port [{}], now {} listeners", portName, listeners.size());
+        }
+
+        if (listeners.isEmpty()) {
+            close();
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized int getListenerCount() {
+        return listeners.size();
+    }
+
+    public synchronized boolean hasListener(SocketConnection connection) {
+        return listeners.containsKey(connection);
+    }
+
+    public synchronized void sendData(JSONObject params, SerialOptions opts) throws JSONException, IOException, SerialPortException {
+        if (!isOpen()) {
+            throw new SerialPortException(portName, "sendData", "Port is not open");
+        }
+
+        Charset encoding = serialOpts.getPortSettings().getEncoding();
+        if (opts != null && opts.getPortSettings() != null) {
+            SerialOptions.PortSettings requested = opts.getPortSettings();
+            SerialOptions.PortSettings current = serialOpts.getPortSettings();
+            if (requested.getBaudRate() != current.getBaudRate() ||
+                requested.getDataBits() != current.getDataBits() ||
+                requested.getStopBits() != current.getStopBits() ||
+                requested.getParity() != current.getParity() ||
+                requested.getFlowControl() != current.getFlowControl()) {
+                log.warn("sendData options for port [{}] contain port settings that are ignored on shared ports", portName);
+            }
+            encoding = requested.getEncoding();
+        }
+
+        if (opts != null && opts.getResponseFormat() != null) {
+            log.warn("sendData options for port [{}] contain rx settings that are ignored on shared ports", portName);
+        }
+
+        log.debug("Sending data over shared port [{}]", portName);
+        port.writeBytes(DeviceUtilities.getDataBytes(params, encoding));
+    }
+
+    @Override
+    public void serialEvent(SerialPortEvent event) {
+        String output = processSerialEvent(event);
+        if (output != null) {
+            log.debug("Received serial output on [{}]: {}", portName, output);
+            dispatchToListeners(output);
+        }
+    }
+
+    private void dispatchToListeners(String output) {
+        List<Map.Entry<SocketConnection, SerialSession>> listenersCopy;
+        synchronized (this) {
+            listenersCopy = new ArrayList<>(listeners.entrySet());
+        }
+
+        for (Map.Entry<SocketConnection, SerialSession> entry : listenersCopy) {
+            SocketConnection connection = entry.getKey();
+            SerialSession session = entry.getValue();
+            session.sendSerialEvent(portName, output, () -> {
+                log.warn("Failed to send to listener on port [{}], removing", portName);
+                SerialPortMonitor.stopListening(connection, portName);
+            });
+        }
+    }
+
+    private String processSerialEvent(SerialPortEvent event) {
+        SerialOptions.ResponseFormat format = serialOpts.getResponseFormat();
+
+        try {
+            if (event.isRXCHAR()) {
+                data.append(port.readBytes(event.getEventValue(), READ_TIMEOUT));
+
+                String response = null;
+                if (format.isBoundNewline()) {
+                    response = processNewlineDelimited(format);
+                } else if (format.getBoundStart() != null && format.getBoundStart().length > 0) {
+                    response = processFormatted(format);
+                } else if (format.getFixedWidth() > 0) {
+                    response = processFixedWidth(format);
+                } else {
+                    log.trace("Reading raw response");
+                    response = new String(data.getByteArray(), format.getEncoding());
+                    data.clear();
+                }
+
+                return response;
+            }
+        } catch (SerialPortException e) {
+            log.error("Exception occurred while reading data from port.", e);
+        } catch (Exception e) {
+            log.error("Error processing serial event.", e);
+        }
+
+        return null;
+    }
+
+    private String processNewlineDelimited(SerialOptions.ResponseFormat format) {
+        Integer endIdx = ByteUtilities.firstMatchingIndex(data.getByteArray(), new byte[] {'\r', '\n'});
+        int delimSize = 2;
+
+        if (endIdx == null) {
+            Integer crIdx = ByteUtilities.firstMatchingIndex(data.getByteArray(), new byte[] {'\r'});
+            Integer nlIdx = ByteUtilities.firstMatchingIndex(data.getByteArray(), new byte[] {'\n'});
+            endIdx = minNullable(crIdx, nlIdx);
+            delimSize = 1;
+        }
+
+        if (endIdx != null) {
+            log.trace("Reading newline-delimited response");
+            byte[] output = new byte[endIdx];
+            System.arraycopy(data.getByteArray(), 0, output, 0, endIdx);
+            String buffer = new String(output, format.getEncoding());
+
+            if (!buffer.isEmpty()) {
+                data.clearRange(0, endIdx + delimSize);
+                return buffer;
+            }
+            data.clearRange(0, endIdx + delimSize);
+        }
+        return null;
+    }
+
+    private String processFormatted(SerialOptions.ResponseFormat format) {
+        Integer startIdx = ByteUtilities.firstMatchingIndex(data.getByteArray(), format.getBoundStart());
+
+        if (startIdx != null) {
+            int startOffset = startIdx + format.getBoundStart().length;
+            int copyLength = 0;
+            int endIdx = 0;
+
+            if (format.getBoundEnd() != null && format.getBoundEnd().length > 0) {
+                Integer boundEnd = ByteUtilities.firstMatchingIndex(data.getByteArray(), format.getBoundEnd(), startIdx);
+                if (boundEnd != null) {
+                    log.trace("Reading bounded response");
+                    copyLength = boundEnd - startOffset;
+                    endIdx = boundEnd + 1;
+                    if (format.isIncludeStart()) {
+                        copyLength += format.getBoundEnd().length;
+                    }
+                }
+            } else if (format.getFixedWidth() > 0) {
+                log.trace("Reading fixed length prefixed response");
+                copyLength = format.getFixedWidth();
+                endIdx = startOffset + format.getFixedWidth();
+            } else if (format.getLength() != null) {
+                SerialOptions.ByteParam lengthParam = format.getLength();
+                if (data.getLength() > startOffset + lengthParam.getIndex() + lengthParam.getLength()) {
+                    log.trace("Reading dynamic formatted response");
+                    int expectedLength = ByteUtilities.parseBytes(data.getByteArray(),
+                            startOffset + lengthParam.getIndex(), lengthParam.getLength(), lengthParam.getEndian());
+                    startOffset += lengthParam.getIndex() + lengthParam.getLength();
+                    copyLength = expectedLength;
+                    endIdx = startOffset + copyLength;
+
+                    if (format.getCrc() != null) {
+                        SerialOptions.ByteParam crcParam = format.getCrc();
+                        int expand = crcParam.getIndex() + crcParam.getLength();
+                        copyLength += expand;
+                        endIdx += expand;
+                    }
+                }
+            } else {
+                log.warn("Reading header formatted raw response, are you missing an rx option?");
+                copyLength = data.getLength() - startOffset;
+                endIdx = data.getLength();
+            }
+
+            if (copyLength > 0 && data.getLength() >= endIdx) {
+                log.debug("Response format readable, starting copy");
+
+                if (format.isIncludeStart()) {
+                    copyLength += (startOffset - startIdx);
+                    startOffset = startIdx;
+                }
+
+                byte[] responseData = new byte[copyLength];
+                System.arraycopy(data.getByteArray(), startOffset, responseData, 0, copyLength);
+
+                String response = new String(responseData, format.getEncoding());
+                data.clearRange(startIdx, endIdx);
+                return response;
+            }
+        }
+        return null;
+    }
+
+    private String processFixedWidth(SerialOptions.ResponseFormat format) {
+        if (data.getLength() >= format.getFixedWidth()) {
+            log.trace("Reading fixed length response");
+            byte[] output = new byte[format.getFixedWidth()];
+            System.arraycopy(data.getByteArray(), 0, output, 0, format.getFixedWidth());
+
+            String response = new String(output, format.getEncoding());
+            data.clearRange(0, format.getFixedWidth());
+            return response;
+        }
+        return null;
+    }
+
+    private void applyOptions(SerialOptions opts) throws SerialPortException {
+        if (opts == null) return;
+
+        SerialOptions.PortSettings ps = opts.getPortSettings();
+        if (ps != null && !ps.equals(serialOpts.getPortSettings())) {
+            log.debug("Applying port settings");
+            port.setParams(ps.getBaudRate(), ps.getDataBits(), ps.getStopBits(), ps.getParity());
+            port.setFlowControlMode(ps.getFlowControl());
+            serialOpts.setPortSettings(ps);
+        }
+
+        SerialOptions.ResponseFormat rf = opts.getResponseFormat();
+        if (rf != null) {
+            log.debug("Applying response formatting");
+            serialOpts.setResponseFormat(rf);
+        }
+    }
+
+    public synchronized void close() {
+        if (port == null) {
+            return;
+        }
+
+        log.info("Closing shared serial port [{}]", portName);
+
+        try {
+            if (port.isOpened()) {
+                port.closePort();
+            }
+        } catch (SerialPortException e) {
+            log.warn("Error closing serial port [{}]: {}", portName, e.getMessage());
+        }
+
+        port = null;
+
+        if (onCloseCallback != null) {
+            onCloseCallback.run();
+        }
+    }
+
+    private Integer minNullable(Integer a, Integer b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        return Math.min(a, b);
+    }
+}

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -344,23 +344,22 @@ public class PrintSocketClient {
                     opts = new SerialOptions(params.optJSONObject("options"), false);
                 }
 
-                SerialIO serial = connection.getSerialPort(params.optString("port"));
-                if (serial != null) {
-                    serial.sendData(params, opts);
+                String portName = params.optString("port");
+                if (SerialPortMonitor.isListening(connection, portName)) {
+                    SerialPortMonitor.sendData(connection, portName, params, opts);
                     sendResult(session, UID, null);
                 } else {
-                    sendError(session, UID, String.format("Serial port [%s] must be opened first.", params.optString("port")));
+                    sendError(session, UID, String.format("Serial port [%s] must be opened first.", portName));
                 }
                 break;
             }
             case SERIAL_CLOSE_PORT: {
-                SerialIO serial = connection.getSerialPort(params.optString("port"));
-                if (serial != null) {
-                    serial.close();
-                    connection.removeSerialPort(params.optString("port"));
+                String portName = params.optString("port");
+                if (SerialPortMonitor.isListening(connection, portName)) {
+                    SerialPortMonitor.stopListening(connection, portName);
                     sendResult(session, UID, null);
                 } else {
-                    sendError(session, UID, String.format("Serial port [%s] is not open.", params.optString("port")));
+                    sendError(session, UID, String.format("Serial port [%s] is not open.", portName));
                 }
                 break;
             }

--- a/src/qz/ws/SocketConnection.java
+++ b/src/qz/ws/SocketConnection.java
@@ -134,6 +134,8 @@ public class SocketConnection {
     public synchronized void disconnect() throws SerialPortException, DeviceException, IOException {
         log.info("Closing all communication channels for {}", certificate.getCommonName());
 
+        SerialPortMonitor.stopListening(this);
+
         for(SerialIO sio : openSerialPorts.values()) {
             sio.close();
         }


### PR DESCRIPTION
## Summary

Enables multiple browser tabs to share access to the same serial port. Previously, only the first tab could open a serial port; subsequent tabs received "port busy" errors.

Fixes #1366

## Changes

- **New `SerialPortMonitor`** - Central coordinator following the existing `StatusMonitor` pattern with reference counting
- **New `SharedSerialPort`** - Wraps JSSC SerialPort with multi-listener dispatch, broadcasts received data to all connected tabs
- **New `SerialSession`** - WebSocket session wrapper for sending serial events
- **Modified `SerialOptions`** - Added explicit settings tracking and equals() methods for conflict detection
- **Modified `SerialUtilities`** - Routes through SerialPortMonitor instead of direct SerialIO creation
- **Modified `SocketConnection`** - Added cleanup on disconnect

## Behavior

- **Bidirectional**: All tabs can send and receive data
- **First opener wins**: First tab's port settings (baud rate, parity, etc.) become canonical
- **Joining tabs**: Can join without specifying settings, or must specify matching settings
- **Reference counting**: Physical port closes only when last listener disconnects
- **Conflict handling**: Rejects with clear error if explicit settings differ from the open port

## Testing

We have a dev testing utility using socat to create virtual serial port pairs for automated testing without physical hardware. It's not included in this PR since socat isn't universally available, but we can add it if helpful for CI or review.