### PR TITLE
Use NodeHelper for WebView peer sync

### DIFF
--- a/src/qz/printer/action/html/WebApp.java
+++ b/src/qz/printer/action/html/WebApp.java
@@ -436,22 +436,9 @@ public class WebApp extends Application {
 
     private static void doUpdatePeer() {
         // Call updatePeer; fixes a bug with webView resizing
-        // See: https://github.com/qzind/tray/issues/1449
-        try {
-            SceneHelper.setAllowPGAccess(true);
-            NodeHelper.updatePeer(webView);
-        }
-        catch(SecurityException e) {
-            log.warn("Unable to update peer; Blank pages may occur.", e);
-        }
-        finally {
-            try {
-                SceneHelper.setAllowPGAccess(false);
-            }
-            catch(Throwable t) {
-                log.trace("Unable to restore SceneHelper.allowPGAccess", t);
-            }
-        }
+        SceneHelper.setAllowPGAccess(true);
+        NodeHelper.updatePeer(webView);
+        SceneHelper.setAllowPGAccess(false);
     }
 
     private static double calculateSupportedZoom(double width, double height) {

--- a/src/qz/printer/action/html/WebApp.java
+++ b/src/qz/printer/action/html/WebApp.java
@@ -1,6 +1,8 @@
 package qz.printer.action.html;
 
 import com.github.zafarkhaja.semver.Version;
+import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.SceneHelper;
 import com.sun.javafx.tk.TKPulseListener;
 import com.sun.javafx.tk.Toolkit;
 import javafx.animation.AnimationTimer;
@@ -28,7 +30,6 @@ import qz.ws.PrintSocketServer;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -435,22 +436,21 @@ public class WebApp extends Application {
 
     private static void doUpdatePeer() {
         // Call updatePeer; fixes a bug with webView resizing
-        // Candidate for replacement: NodeHelper.updatePeer()
-        // See: https://github.com/qzind/tray/issues/513
-        String[] methods = {"doUpdatePeer" /*jfx11*/, "impl_updatePeer" /*jfx8*/};
+        // See: https://github.com/qzind/tray/issues/1449
         try {
-            for(Method m : webView.getClass().getDeclaredMethods()) {
-                for(String method : methods) {
-                    if (m.getName().equals(method)) {
-                        m.setAccessible(true);
-                        m.invoke(webView);
-                        return;
-                    }
-                }
-            }
+            SceneHelper.setAllowPGAccess(true);
+            NodeHelper.updatePeer(webView);
         }
-        catch(SecurityException | ReflectiveOperationException e) {
+        catch(SecurityException e) {
             log.warn("Unable to update peer; Blank pages may occur.", e);
+        }
+        finally {
+            try {
+                SceneHelper.setAllowPGAccess(false);
+            }
+            catch(Throwable t) {
+                log.trace("Unable to restore SceneHelper.allowPGAccess", t);
+            }
         }
     }
 


### PR DESCRIPTION
@tresf these are the changes that I did:
- Switched peer update path from reflective private-method invocation to `NodeHelper.updatePeer(webView)`.
- Added explicit PG-access gating via `SceneHelper.setAllowPGAccess(true)` before update and reset in `finally`.
- Removed reflection-specific code and imports.
- Added trace logging for defensive cleanup visibility when PG-access restoration fails.

Please review.

**Edit:**

Closes #1449 