### PR TITLE
Add qz.io repository dispatch workflows

### DIFF
--- a/.github/workflows/dispatch-demo.yaml
+++ b/.github/workflows/dispatch-demo.yaml
@@ -1,0 +1,29 @@
+name: Dispatch Demo Update Event
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - sample.html
+      - js/*
+      - css/*
+      - fonts/*
+      - assets/*
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.QZIO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.QZIO_APP_PRIVATE_KEY }}
+          repositories: ${{ vars.QZIO_REPO }}
+
+      - name: Create repository dispatch event
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api -X POST '/repos/${{ vars.QZIO_REPO }}/dispatches' \
+          -f 'event_type=tray_demo_updated'

--- a/.github/workflows/dispatch-wiki.yaml
+++ b/.github/workflows/dispatch-wiki.yaml
@@ -1,0 +1,20 @@
+name: Dispatch Wiki Update Event
+on: gollum
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.QZIO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.QZIO_APP_PRIVATE_KEY }}
+          repositories: ${{ vars.QZIO_REPO }}
+
+      - name: Create repository dispatch event
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api -X POST '/repos/${{ vars.QZIO_REPO }}/dispatches' \
+          -f 'event_type=tray_wiki_updated'


### PR DESCRIPTION
As discussed internally, to simplify our website's deployment pipeline, this adds workflows that trigger [`repository_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#repository_dispatch) events of the types `tray_demo_updated` or `tray_wiki_updated` in our website repo when demo code or wiki are updated respectively. The wiki event is still unused.

Even though `repository_dispatch`'s documented use case is to act on events originating outside of GitHub, I think it's the better choice (compared to `workflow_dispatch` or `workflow_call`) because it keeps the workflows in this repo agnostic to implementation details in the website repo. We don't need to make any modifications here if the workflows change, only if we move it to another repo. With the alternatives, we need to know the workflow file and (with `workflow_call`) pass required variables & secrets for deployment. 

Test run at https://github.com/qzind/tray/actions/runs/27085913122/job/79940235842