### PR TITLE
Harden serial port close lifecycle around pending reads

### DIFF
--- a/src/qz/communication/JsscSerialPortAdapter.java
+++ b/src/qz/communication/JsscSerialPortAdapter.java
@@ -1,0 +1,54 @@
+package qz.communication;
+
+import jssc.SerialPort;
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import jssc.SerialPortTimeoutException;
+
+class JsscSerialPortAdapter implements SerialPortAdapter {
+    private final SerialPort port;
+
+    JsscSerialPortAdapter(String portName) {
+        port = new SerialPort(portName);
+    }
+
+    @Override
+    public boolean openPort() throws SerialPortException {
+        return port.openPort();
+    }
+
+    @Override
+    public boolean closePort() throws SerialPortException {
+        return port.closePort();
+    }
+
+    @Override
+    public boolean isOpened() {
+        return port.isOpened();
+    }
+
+    @Override
+    public void addEventListener(SerialPortEventListener listener) throws SerialPortException {
+        port.addEventListener(listener);
+    }
+
+    @Override
+    public void setParams(int baudRate, int dataBits, int stopBits, int parity) throws SerialPortException {
+        port.setParams(baudRate, dataBits, stopBits, parity);
+    }
+
+    @Override
+    public void setFlowControlMode(int mask) throws SerialPortException {
+        port.setFlowControlMode(mask);
+    }
+
+    @Override
+    public void writeBytes(byte[] data) throws SerialPortException {
+        port.writeBytes(data);
+    }
+
+    @Override
+    public byte[] readBytes(int byteCount, int timeout) throws SerialPortException, SerialPortTimeoutException {
+        return port.readBytes(byteCount, timeout);
+    }
+}

--- a/src/qz/communication/SerialIO.java
+++ b/src/qz/communication/SerialIO.java
@@ -23,6 +23,13 @@ public class SerialIO implements DeviceListener {
 
     private static final Logger log = LogManager.getLogger(SerialIO.class);
 
+    private enum PortState {
+        CLOSED,
+        OPENING,
+        OPEN,
+        CLOSING
+    }
+
     // Timeout to wait before giving up on reading the specified amount of bytes
     private static final int TIMEOUT = 1200;
 
@@ -30,6 +37,7 @@ public class SerialIO implements DeviceListener {
     private SerialPortAdapter port;
     private SerialOptions serialOpts;
     private final SerialPortAdapterFactory portFactory;
+    private volatile PortState state = PortState.CLOSED;
 
     private ByteArrayBuilder data = new ByteArrayBuilder();
 
@@ -58,39 +66,72 @@ public class SerialIO implements DeviceListener {
      * @return Boolean indicating success.
      * @throws SerialPortException If the port fails to open.
      */
-    public boolean open(SerialOptions opts) throws SerialPortException {
-        if (isOpen()) {
-            log.warn("Serial port [{}] is already open", portName);
+    public synchronized boolean open(SerialOptions opts) throws SerialPortException {
+        if (state != PortState.CLOSED) {
+            log.warn("Serial port [{}] is not closed, current state is [{}]", portName, state);
             return false;
         }
 
-        port = portFactory.create(portName);
-        port.openPort();
+        state = PortState.OPENING;
 
-        serialOpts = new SerialOptions();
-        setOptions(opts);
+        try {
+            port = portFactory.create(portName);
+            port.openPort();
 
-        return port.isOpened();
+            serialOpts = new SerialOptions();
+            setOptions(opts, port);
+
+            if (port.isOpened()) {
+                state = PortState.OPEN;
+                return true;
+            }
+
+            state = PortState.CLOSED;
+            port = null;
+            return false;
+        }
+        catch(SerialPortException e) {
+            state = PortState.CLOSED;
+            port = null;
+            throw e;
+        }
     }
 
     public void applyPortListener(SerialPortEventListener listener) throws SerialPortException {
-        port.addEventListener(listener);
+        SerialPortAdapter activePort = port;
+        if (state != PortState.OPEN || activePort == null) {
+            throw new SerialPortException(portName, "addEventListener", "Port is not open");
+        }
+
+        activePort.addEventListener(listener);
     }
 
     /**
      * @return Boolean indicating if port is currently open.
      */
     public boolean isOpen() {
-        return port != null && port.isOpened();
+        SerialPortAdapter activePort = port;
+        return state == PortState.OPEN && activePort != null && activePort.isOpened();
     }
 
     public String processSerialEvent(SerialPortEvent event) {
+        SerialPortAdapter activePort = port;
+        if (state != PortState.OPEN || activePort == null) {
+            log.trace("Ignoring serial event for [{}] while state is [{}]", portName, state);
+            return null;
+        }
+
         SerialOptions.ResponseFormat format = serialOpts.getResponseFormat();
 
         try {
             // Receive data
             if (event.isRXCHAR()) {
-                data.append(port.readBytes(event.getEventValue(), TIMEOUT));
+                data.append(activePort.readBytes(event.getEventValue(), TIMEOUT));
+
+                if (state != PortState.OPEN) {
+                    log.trace("Ignoring serial response for [{}] while state is [{}]", portName, state);
+                    return null;
+                }
 
                 String response = null;
                 if (format.isBoundNewline()) {
@@ -237,14 +278,14 @@ public class SerialIO implements DeviceListener {
      *
      * @throws SerialPortException If the properties fail to set
      */
-    private void setOptions(SerialOptions opts) throws SerialPortException {
+    private void setOptions(SerialOptions opts, SerialPortAdapter activePort) throws SerialPortException {
         if (opts == null) { return; }
 
         SerialOptions.PortSettings ps = opts.getPortSettings();
         if (ps != null && !ps.equals(serialOpts.getPortSettings())) {
             log.debug("Applying new port settings");
-            port.setParams(ps.getBaudRate(), ps.getDataBits(), ps.getStopBits(), ps.getParity());
-            port.setFlowControlMode(ps.getFlowControl());
+            activePort.setParams(ps.getBaudRate(), ps.getDataBits(), ps.getStopBits(), ps.getParity());
+            activePort.setFlowControlMode(ps.getFlowControl());
             serialOpts.setPortSettings(ps);
         }
 
@@ -258,13 +299,22 @@ public class SerialIO implements DeviceListener {
     /**
      * Applies the port parameters and writes the buffered data to the serial port.
      */
-    public void sendData(JSONObject params, SerialOptions opts) throws JSONException, IOException, SerialPortException {
+    public synchronized void sendData(JSONObject params, SerialOptions opts) throws JSONException, IOException, SerialPortException {
+        SerialPortAdapter activePort = port;
+        if (state != PortState.OPEN || activePort == null) {
+            throw new SerialPortException(portName, "writeBytes", "Port is not open");
+        }
+
         if (opts != null) {
-            setOptions(opts);
+            setOptions(opts, activePort);
+        }
+
+        if (state != PortState.OPEN) {
+            throw new SerialPortException(portName, "writeBytes", "Port is closing");
         }
 
         log.debug("Sending data over [{}]", portName);
-        port.writeBytes(DeviceUtilities.getDataBytes(params, serialOpts.getPortSettings().getEncoding()));
+        activePort.writeBytes(DeviceUtilities.getDataBytes(params, serialOpts.getPortSettings().getEncoding()));
     }
 
     /**
@@ -273,13 +323,27 @@ public class SerialIO implements DeviceListener {
      * @throws SerialPortException If the port fails to close.
      */
     @Override
-    public void close() {
-        if (!isOpen()) {
+    public synchronized void close() {
+        if (state == PortState.CLOSED) {
             log.warn("Serial port [{}] is not open.", portName);
+            return;
+        }
+
+        if (state == PortState.CLOSING) {
+            log.debug("Serial port [{}] is already closing.", portName);
+            return;
+        }
+
+        state = PortState.CLOSING;
+        SerialPortAdapter activePort = port;
+        if (activePort == null) {
+            log.warn("Serial port [{}] has no active port to close.", portName);
+            state = PortState.CLOSED;
+            return;
         }
 
         try {
-            boolean closed = port.closePort();
+            boolean closed = activePort.closePort();
             if (closed) {
                 log.info("Serial port [{}] closed successfully.", portName);
             } else {
@@ -287,11 +351,11 @@ public class SerialIO implements DeviceListener {
                 throw new SerialPortException(portName, "closePort", "Port not closed");
             }
         } catch(SerialPortException e) {
-            log.warn("Serial port [{}] was not closed properly.", portName);
+            log.warn("Serial port [{}] was not closed properly.", portName, e);
+        } finally {
+            port = null;
+            state = PortState.CLOSED;
         }
-
-        port = null;
-        portName = null;
     }
 
     private Integer min(Integer a, Integer b) {

--- a/src/qz/communication/SerialIO.java
+++ b/src/qz/communication/SerialIO.java
@@ -1,6 +1,9 @@
 package qz.communication;
 
-import jssc.*;
+import jssc.SerialPortEvent;
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import jssc.SerialPortTimeoutException;
 import org.apache.commons.codec.binary.StringUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -24,8 +27,9 @@ public class SerialIO implements DeviceListener {
     private static final int TIMEOUT = 1200;
 
     private String portName;
-    private SerialPort port;
+    private SerialPortAdapter port;
     private SerialOptions serialOpts;
+    private final SerialPortAdapterFactory portFactory;
 
     private ByteArrayBuilder data = new ByteArrayBuilder();
 
@@ -38,8 +42,13 @@ public class SerialIO implements DeviceListener {
      * @param portName Port name to open, such as "COM1" or "/dev/tty0/"
      */
     public SerialIO(String portName, SocketConnection websocket) {
+        this(portName, websocket, JsscSerialPortAdapter::new);
+    }
+
+    SerialIO(String portName, SocketConnection websocket, SerialPortAdapterFactory portFactory) {
         this.portName = portName;
         this.websocket = websocket;
+        this.portFactory = portFactory;
     }
 
     /**
@@ -55,7 +64,7 @@ public class SerialIO implements DeviceListener {
             return false;
         }
 
-        port = new SerialPort(portName);
+        port = portFactory.create(portName);
         port.openPort();
 
         serialOpts = new SerialOptions();

--- a/src/qz/communication/SerialPortAdapter.java
+++ b/src/qz/communication/SerialPortAdapter.java
@@ -1,0 +1,23 @@
+package qz.communication;
+
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import jssc.SerialPortTimeoutException;
+
+interface SerialPortAdapter {
+    boolean openPort() throws SerialPortException;
+
+    boolean closePort() throws SerialPortException;
+
+    boolean isOpened();
+
+    void addEventListener(SerialPortEventListener listener) throws SerialPortException;
+
+    void setParams(int baudRate, int dataBits, int stopBits, int parity) throws SerialPortException;
+
+    void setFlowControlMode(int mask) throws SerialPortException;
+
+    void writeBytes(byte[] data) throws SerialPortException;
+
+    byte[] readBytes(int byteCount, int timeout) throws SerialPortException, SerialPortTimeoutException;
+}

--- a/src/qz/communication/SerialPortAdapterFactory.java
+++ b/src/qz/communication/SerialPortAdapterFactory.java
@@ -1,0 +1,5 @@
+package qz.communication;
+
+interface SerialPortAdapterFactory {
+    SerialPortAdapter create(String portName);
+}

--- a/test/qz/communication/SerialIOTests.java
+++ b/test/qz/communication/SerialIOTests.java
@@ -1,0 +1,293 @@
+package qz.communication;
+
+import jssc.SerialPortEvent;
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import jssc.SerialPortTimeoutException;
+import org.codehaus.jettison.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SerialIOTests {
+    private static final String PORT_NAME = "TEST_PORT";
+    private static final int EXPECTED_READ_TIMEOUT = 1200;
+
+    private static SerialIO openedSerialWith(FakeSerialPortAdapter fake) throws SerialPortException {
+        SerialIO serial = serialWith(fake);
+        Assert.assertTrue(serial.open(new SerialOptions()));
+        return serial;
+    }
+
+    private static SerialIO serialWith(FakeSerialPortAdapter fake) {
+        return new SerialIO(PORT_NAME, null, portName -> fake);
+    }
+
+    private static SerialIO serialWith(FakeSerialPortAdapter first, FakeSerialPortAdapter second) {
+        AtomicInteger creates = new AtomicInteger();
+        // SerialIO creates the native adapter during open
+        // so return one fake per open
+        return new SerialIO(PORT_NAME, null, portName -> creates.getAndIncrement() == 0 ? first : second);
+    }
+
+    private static SerialPortEvent rxEvent(int value) {
+        return new SerialPortEvent(PORT_NAME, SerialPortEvent.RXCHAR, value);
+    }
+
+    private static void expectSerialPortException(SerialAction action) throws Exception {
+        try {
+            action.run();
+            Assert.fail("Expected SerialPortException");
+        } catch (SerialPortException expected) {
+        }
+    }
+
+    @Test
+    public void closeShouldIgnoreAlreadyClosedSerial() {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        SerialIO serial = serialWith(fake);
+
+        serial.close();
+
+        Assert.assertEquals(fake.closeCalls, 0);
+        Assert.assertFalse(serial.isOpen());
+    }
+
+    @Test
+    public void closeShouldOnlyCloseNativePortOnce() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        SerialIO serial = openedSerialWith(fake);
+
+        serial.close();
+        serial.close();
+
+        Assert.assertEquals(fake.closeCalls, 1);
+        Assert.assertFalse(serial.isOpen());
+    }
+
+    @Test
+    public void sendDataAfterCloseShouldNotWriteToNativePort() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        SerialIO serial = openedSerialWith(fake);
+
+        serial.close();
+
+        expectSerialPortException(() -> serial.sendData(new JSONObject().put("data", "hello"), null));
+        Assert.assertEquals(fake.writeCalls, 0);
+    }
+
+    @Test
+    public void processSerialEventAfterCloseShouldNotReadNativePort() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        SerialIO serial = openedSerialWith(fake);
+
+        serial.close();
+        String output = serial.processSerialEvent(rxEvent(5));
+
+        Assert.assertNull(output);
+        Assert.assertEquals(fake.readCalls, 0);
+    }
+
+    @Test
+    public void processSerialEventShouldUseConfiguredReadTimeout() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        fake.timeoutOnRead = true;
+        SerialIO serial = openedSerialWith(fake);
+
+        String output = serial.processSerialEvent(rxEvent(5));
+
+        Assert.assertNull(output);
+        Assert.assertEquals(fake.readCalls, 1);
+        Assert.assertEquals(fake.lastReadTimeout, EXPECTED_READ_TIMEOUT);
+        Assert.assertTrue(serial.isOpen());
+    }
+
+    @Test
+    public void closePortFalseShouldCloseQzStatePredictably() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        fake.closeResult = false;
+        SerialIO serial = openedSerialWith(fake);
+
+        serial.close();
+
+        Assert.assertEquals(fake.closeCalls, 1);
+        Assert.assertFalse(serial.isOpen());
+        expectSerialPortException(() -> serial.sendData(new JSONObject().put("data", "hello"), null));
+        Assert.assertEquals(fake.writeCalls, 0);
+    }
+
+    @Test
+    public void closePortExceptionShouldCloseQzStatePredictably() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        fake.throwOnClose = true;
+        SerialIO serial = openedSerialWith(fake);
+
+        serial.close();
+
+        Assert.assertEquals(fake.closeCalls, 1);
+        Assert.assertFalse(serial.isOpen());
+        expectSerialPortException(() -> serial.sendData(new JSONObject().put("data", "hello"), null));
+        Assert.assertEquals(fake.writeCalls, 0);
+    }
+
+    @Test
+    public void pendingReadResultShouldBeIgnoredAfterCloseRequest() throws Exception {
+        FakeSerialPortAdapter fake = new FakeSerialPortAdapter();
+        fake.readBytes = "late data".getBytes(StandardCharsets.UTF_8);
+        fake.blockRead = true;
+        SerialIO serial = openedSerialWith(fake);
+
+        final String[] output = new String[1];
+        Thread reader = new Thread(() -> output[0] = serial.processSerialEvent(rxEvent(fake.readBytes.length)));
+        reader.start();
+
+        // Hold readBytes open so close can
+        // move QZ state to CLOSED first
+        Assert.assertTrue(fake.readStarted.await(2, TimeUnit.SECONDS), "Timed out waiting for fake read");
+        serial.close();
+        fake.releaseRead.countDown();
+        reader.join(2000);
+
+        Assert.assertFalse(reader.isAlive(), "Reader thread did not finish");
+        Assert.assertNull(output[0]);
+        Assert.assertEquals(fake.readCalls, 1);
+        Assert.assertFalse(serial.isOpen());
+    }
+
+    @Test
+    public void reopenAfterSuccessfulCloseShouldUseNewNativePort() throws Exception {
+        FakeSerialPortAdapter first = new FakeSerialPortAdapter();
+        FakeSerialPortAdapter second = new FakeSerialPortAdapter();
+        SerialIO serial = serialWith(first, second);
+
+        Assert.assertTrue(serial.open(new SerialOptions()));
+        serial.close();
+        Assert.assertFalse(serial.isOpen());
+
+        Assert.assertTrue(serial.open(new SerialOptions()));
+        Assert.assertTrue(serial.isOpen());
+        Assert.assertEquals(first.closeCalls, 1);
+        Assert.assertEquals(second.openCalls, 1);
+    }
+
+    @Test
+    public void failedCloseShouldAllowClearReopenAttempt() throws Exception {
+        FakeSerialPortAdapter first = new FakeSerialPortAdapter();
+        FakeSerialPortAdapter second = new FakeSerialPortAdapter();
+        first.closeResult = false;
+        SerialIO serial = serialWith(first, second);
+
+        Assert.assertTrue(serial.open(new SerialOptions()));
+        serial.close();
+        Assert.assertFalse(serial.isOpen());
+
+        // QZ releases its stale adapter so a later
+        // open gets a clean native attempt
+        Assert.assertTrue(serial.open(new SerialOptions()));
+        Assert.assertTrue(serial.isOpen());
+        Assert.assertEquals(first.closeCalls, 1);
+        Assert.assertEquals(second.openCalls, 1);
+    }
+
+    // Lets expectSerialPortException accept
+    // lambdas with checked exceptions
+    private interface SerialAction {
+        void run() throws Exception;
+    }
+
+    // Small fake instead of a mock
+    // this avoids adding a test dependency for one narrow seam
+    // Model only the JSSC behavior SerialIO owns
+    // and that keeps the testing hardware-free
+    private static class FakeSerialPortAdapter implements SerialPortAdapter {
+        boolean opened;
+        boolean closeResult = true;
+        boolean throwOnClose;
+        boolean throwOnRead;
+        boolean timeoutOnRead;
+        boolean blockRead;
+        byte[] readBytes = new byte[0];
+        byte[] writtenBytes;
+        int openCalls;
+        int closeCalls;
+        int readCalls;
+        int writeCalls;
+        int lastReadTimeout;
+        SerialPortEventListener listener;
+        CountDownLatch readStarted = new CountDownLatch(1);
+        CountDownLatch releaseRead = new CountDownLatch(1);
+
+        @Override
+        public boolean openPort() {
+            openCalls++;
+            opened = true;
+            return true;
+        }
+
+        @Override
+        public boolean closePort() throws SerialPortException {
+            closeCalls++;
+            if (throwOnClose) {
+                throw new SerialPortException(PORT_NAME, "closePort", "test close failure");
+            }
+            opened = false;
+            return closeResult;
+        }
+
+        @Override
+        public boolean isOpened() {
+            return opened;
+        }
+
+        @Override
+        public void addEventListener(SerialPortEventListener listener) {
+            // Listener registration only proves
+            // SerialIO reached an open state
+            this.listener = listener;
+        }
+
+        @Override
+        public void setParams(int baudRate, int dataBits, int stopBits, int parity) {
+            // Option application is not under test here
+            // allow setup to continue
+        }
+
+        @Override
+        public void setFlowControlMode(int mask) {
+            // Flow control is outside the
+            // lifecycle behavior these tests exercise
+        }
+
+        @Override
+        public void writeBytes(byte[] data) {
+            writeCalls++;
+            writtenBytes = Arrays.copyOf(data, data.length);
+        }
+
+        @Override
+        public byte[] readBytes(int byteCount, int timeout) throws SerialPortException, SerialPortTimeoutException {
+            readCalls++;
+            lastReadTimeout = timeout;
+            if (blockRead) {
+                readStarted.countDown();
+                try {
+                    releaseRead.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (throwOnRead) {
+                throw new SerialPortException(PORT_NAME, "readBytes", "test read failure");
+            }
+            if (timeoutOnRead) {
+                throw new SerialPortTimeoutException(PORT_NAME, "readBytes", timeout);
+            }
+            return readBytes;
+        }
+    }
+}

--- a/test/qz/communication/SerialIOTests.java
+++ b/test/qz/communication/SerialIOTests.java
@@ -9,7 +9,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -208,17 +207,14 @@ public class SerialIOTests {
         boolean opened;
         boolean closeResult = true;
         boolean throwOnClose;
-        boolean throwOnRead;
         boolean timeoutOnRead;
         boolean blockRead;
         byte[] readBytes = new byte[0];
-        byte[] writtenBytes;
         int openCalls;
         int closeCalls;
         int readCalls;
         int writeCalls;
         int lastReadTimeout;
-        SerialPortEventListener listener;
         CountDownLatch readStarted = new CountDownLatch(1);
         CountDownLatch releaseRead = new CountDownLatch(1);
 
@@ -246,9 +242,8 @@ public class SerialIOTests {
 
         @Override
         public void addEventListener(SerialPortEventListener listener) {
-            // Listener registration only proves
-            // SerialIO reached an open state
-            this.listener = listener;
+            // Listener behavior is not part of this lifecycle test
+            // accepting registration keeps open setup realistic
         }
 
         @Override
@@ -266,7 +261,6 @@ public class SerialIOTests {
         @Override
         public void writeBytes(byte[] data) {
             writeCalls++;
-            writtenBytes = Arrays.copyOf(data, data.length);
         }
 
         @Override
@@ -280,9 +274,6 @@ public class SerialIOTests {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
-            }
-            if (throwOnRead) {
-                throw new SerialPortException(PORT_NAME, "readBytes", "test read failure");
             }
             if (timeoutOnRead) {
                 throw new SerialPortTimeoutException(PORT_NAME, "readBytes", timeout);


### PR DESCRIPTION
@tresf, this PR proposes to introduce these fixes:

- a narrow serial port adapter seam so `SerialIO` lifecycle behavior can be tested without physical hardware
- a QZ-owned serial lifecycle state around open, close, read, and write paths
- preventing reads/writes after close has been requested and makes close idempotent
- focused SerialIO tests for close failures, pending reads, timeout use, and reopen behavior

You should however note that I do not have access to the faulty USB-serial adapter described in #1431

So this PR validates the lifecycle behavior with simulated JSSC failures. Thus physical hardware validation is still needed from someone with the affected hardware

In other matters `serial.closePort` still follows the existing close/remove/success websocket convention

Thus native close failures are logged, but not returned as websocket errors because that would change API behavior

So, should failed JSSC close be surfaced to the browser?