### PR TITLE
Add flag for fetching QZ Tray product details when getVersion() is called

### DIFF
--- a/js/qz-tray.js
+++ b/js/qz-tray.js
@@ -2899,12 +2899,14 @@ var qz = (function() {
             /**
              * Get version of connected QZ Tray application.
              *
+             * @param {Object} [options] Version options
+             *  @param {boolean} [options.details=false] Returns additional details such as <code>title</code>, <code>vendor</code>, <code>url</code> and <code>email</code>.
              * @returns {Promise<string|Error>} Version number of QZ Tray.
              *
              * @memberof qz.api
              */
-            getVersion: function() {
-                return _qz.websocket.dataPromise('getVersion');
+            getVersion: function(options) {
+                return _qz.websocket.dataPromise('getVersion', options);
             },
 
             /**

--- a/src/qz/common/AboutInfo.java
+++ b/src/qz/common/AboutInfo.java
@@ -56,14 +56,15 @@ public class AboutInfo {
         return about;
     }
 
-    private static JSONObject product() throws JSONException {
+    public static JSONObject product() throws JSONException {
         JSONObject product = new JSONObject();
 
         product
                 .put("title", Constants.ABOUT_TITLE)
                 .put("version", Constants.VERSION)
                 .put("vendor", Constants.ABOUT_COMPANY)
-                .put("url", Constants.ABOUT_URL);
+                .put("url", Constants.ABOUT_URL)
+                .put("email", Constants.ABOUT_EMAIL);
 
         return product;
     }

--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.websocket.server.JettyServerUpgradeResponse;
 import org.usb4java.LoaderException;
 import qz.auth.Certificate;
 import qz.auth.Request;
+import qz.common.AboutInfo;
 import qz.common.Constants;
 import qz.common.TrayManager;
 import qz.communication.*;
@@ -661,7 +662,11 @@ public class PrintSocketClient {
                 sendResult(session, UID, SystemUtilities.getHostName());
                 break;
             case GET_VERSION:
-                sendResult(session, UID, Constants.VERSION);
+                if(!params.has("details") || !params.optBoolean("details", false)) {
+                    sendResult(session, UID, Constants.VERSION);
+                } else {
+                    sendResult(session, UID, AboutInfo.product());
+                }
                 break;
             case WEBSOCKET_STOP:
                 log.info("Another instance of {} is asking this to close", Constants.ABOUT_TITLE);


### PR DESCRIPTION
Closes #1497 

Usage:

```js
qz.api.getVersion({ details: true })
   .then(details => console.log(details));
```

Output:
```js
{
   title: 'QZ Tray',
   version: '2.3.0-SNAPSHOT',
   vendor: 'QZ Industries, LLC',
   url: 'https://qz.io',
   email: 'support@qz.io'
}
```
