### PR TITLE
Better Gtk detection (#1502)

### DIFF
--- a/ant/linux/linux.properties
+++ b/ant/linux/linux.properties
@@ -1,3 +1,2 @@
 # Linux launcher options
-# 1. Expose UNIXToolkit.getGtkVersion
-linux.launch.opts=--add-opens java.desktop/sun.awt=ALL-UNNAMED
+linux.launch.opts=

--- a/src/qz/utils/GtkUtilities.java
+++ b/src/qz/utils/GtkUtilities.java
@@ -1,124 +1,18 @@
 package qz.utils;
 
-import com.sun.jna.Library;
-import com.sun.jna.Native;
-import com.sun.jna.Pointer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.lang.reflect.Method;
+import qz.utils.gtk.Gtk;
 
 public class GtkUtilities {
-    private static final Logger log = LogManager.getLogger(GtkUtilities.class);
+    static final Gtk GTK_INSTANCE = Gtk.getInstance();
 
-    /**
-     * Initializes Gtk2/3 and returns the desktop scaling factor, usually 1.0 or 2.0
-     */
+    public static boolean isGtkAvailable() {
+        return switch(SystemUtilities.getOs()) {
+            case MAC, WINDOWS -> false;
+            default -> GTK_INSTANCE != null;
+        };
+    }
+
     public static double getScaleFactor() {
-        try {
-            GTK gtkHandle = getGtkInstance();
-            if (gtkHandle != null && gtkHandle.gtk_init_check(0, null)) {
-                log.debug("Initialized Gtk");
-
-                if (gtkHandle instanceof GTK2) {
-                    return getGtk2ScaleFactor((GTK2)gtkHandle);
-                } else {
-                    return getGtk3ScaleFactor((GTK3)gtkHandle);
-                }
-            } else {
-                log.warn("An error occurred initializing the Gtk library");
-            }
-        } catch(Throwable t) {
-            log.warn("An error occurred initializing the Gtk library", t);
-        }
-        return 1;
-    }
-
-    private static GTK getGtkInstance() {
-        log.debug("Finding preferred Gtk version...");
-        switch(getGtkMajorVersion()) {
-            case 2:
-                return GTK2.INSTANCE;
-            case 3:
-                return GTK3.INSTANCE;
-            default:
-                log.warn("Not a compatible Gtk version");
-        }
-        return null;
-    }
-
-    /**
-     * Get the major version of Gtk (e.g. 2, 3)
-     * UNIXToolkit is unavailable on Windows or Mac; reflection is required.
-     * @return Major version if found, zero if not.
-     */
-    private static int getGtkMajorVersion() {
-        try {
-            Class toolkitClass = Class.forName("sun.awt.UNIXToolkit");
-            Method versionMethod = toolkitClass.getDeclaredMethod("getGtkVersion");
-            Enum versionInfo = (Enum)versionMethod.invoke(toolkitClass);
-            Method numberMethod = versionInfo.getClass().getDeclaredMethod("getNumber");
-            int version = ((Integer)numberMethod.invoke(versionInfo)).intValue();
-            log.debug("Found Gtk{}", version);
-            return version;
-        } catch(Throwable t) {
-            log.warn("Could not obtain GtkVersion information from UNIXToolkit: {}", t.getMessage());
-        }
-        return 0;
-    }
-
-    private static double getGtk2ScaleFactor(GTK2 gtk2) {
-        Pointer display = gtk2.gdk_display_get_default();
-        log.debug("Gtk 2.10+ detected, calling \"gdk_screen_get_resolution\"");
-        Pointer screen = gtk2.gdk_display_get_default_screen(display);
-        return gtk2.gdk_screen_get_resolution(screen) / 96.0d;
-    }
-
-    private static double getGtk3ScaleFactor(GTK3 gtk3) {
-        Pointer display = gtk3.gdk_display_get_default();
-        int gtkMinorVersion = gtk3.gtk_get_minor_version();
-        if (gtkMinorVersion < 10) {
-            log.warn("Gtk 3.10+ is required to detect scaling factor, skipping.");
-        } else if (gtkMinorVersion >= 22) {
-            log.debug("Gtk 3.22+ detected, calling \"gdk_monitor_get_scale_factor\"");
-            Pointer monitor = gtk3.gdk_display_get_primary_monitor(display);
-            return gtk3.gdk_monitor_get_scale_factor(monitor);
-        } else if (gtkMinorVersion >= 10) {
-            log.debug("Gtk 3.10+ detected, calling \"gdk_screen_get_monitor_scale_factor\"");
-            Pointer screen = gtk3.gdk_display_get_default_screen(display);
-            return gtk3.gdk_screen_get_monitor_scale_factor(screen, 0);
-        }
-        return 1;
-    }
-
-    /**
-     * Gtk2/Gtk3 wrapper
-     */
-    private interface GTK extends Library {
-        // Gtk2.0+
-        boolean gtk_init_check(int argc, String[] argv);
-        Pointer gdk_display_get_default();
-        Pointer gdk_display_get_default_screen (Pointer display);
-    }
-
-    private interface GTK3 extends GTK {
-        GTK3 INSTANCE = Native.load("gtk-3", GTK3.class);
-
-        // Gtk 3.0+
-        int gtk_get_minor_version ();
-
-        // Gtk 3.10-3.21
-        int gdk_screen_get_monitor_scale_factor (Pointer screen, int monitor_num);
-
-        // Gtk 3.22+
-        Pointer gdk_display_get_primary_monitor (Pointer display);
-        int gdk_monitor_get_scale_factor (Pointer monitor);
-    }
-
-    private interface GTK2 extends GTK {
-        GTK2 INSTANCE = Native.load("gtk-x11-2.0", GTK2.class);
-
-        // Gtk 2.1-3.0
-        double gdk_screen_get_resolution(Pointer screen);
+        return GTK_INSTANCE != null? GTK_INSTANCE.getScaleFactor():1.0;
     }
 }

--- a/src/qz/utils/UnixUtilities.java
+++ b/src/qz/utils/UnixUtilities.java
@@ -9,14 +9,12 @@
  */
 package qz.utils;
 
-import com.github.zafarkhaja.semver.Version;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.platform.unix.LibC;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import qz.common.Constants;
 
 import java.awt.*;
 import java.io.BufferedReader;
@@ -245,9 +243,6 @@ public class UnixUtilities {
     }
 
     public static double getScaleFactor() {
-        if (Constants.JAVA_VERSION.lessThan(Version.valueOf("11.0.0"))) {
-            return Toolkit.getDefaultToolkit().getScreenResolution() / 96.0;
-        }
         return GtkUtilities.getScaleFactor();
     }
 

--- a/src/qz/utils/gtk/Gtk.java
+++ b/src/qz/utils/gtk/Gtk.java
@@ -1,0 +1,67 @@
+package qz.utils.gtk;
+
+import com.github.zafarkhaja.semver.Version;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * GTK2/GTK3/GTK4 wrapper
+ */
+public interface Gtk extends Library {
+    Logger log = LogManager.getLogger(Gtk.class);
+
+    // Gtk2.0+
+    boolean gtk_init_check(int argc, String[] argv);
+    Pointer gdk_display_get_default();
+    Pointer gdk_display_get_default_screen(Pointer display);
+
+    static Gtk getInstance() {
+        return getInstance(true);
+    }
+
+    static Gtk getInstance(boolean init) {
+        log.debug("Finding available GTK version...");
+        for(GtkType type : GtkType.values()) {
+            try {
+                Gtk found = Native.load(type.lib, type.type);
+                if(found != null) {
+                    log.debug("Found GTK {} as '{}'", found.getVersion(), type.lib);
+                    if(init) {
+                        if (found.gtk_init_check(0, null)) {
+                            log.debug("Initialized GTK {}", found.getVersion());
+                            return found;
+                        } else {
+                            log.warn("Unable to initialize GTK {} as '{}'", found.getVersion(), type.lib);
+                        }
+                    } else {
+                        log.warn("Skipping initialization of GTK {} as '{}'.  This should only occur in unit tests.", found.getVersion(), type.lib);
+                        return found;
+                    }
+                }
+            }
+            catch(Throwable t) {
+                log.debug("Could not load GTK as '{}'", type.lib);
+            }
+        }
+        log.warn("Could not find a compatible GTK version");
+        return null;
+    }
+
+    Version getVersion();
+    double getScaleFactor();
+
+    default Pointer getScreen() {
+        Pointer display = gdk_display_get_default();
+        if (display != null) {
+            Pointer screen = gdk_display_get_default_screen(display);
+            if (screen != null) {
+                return screen;
+            }
+        }
+        log.warn("Unable to obtain default screen");
+        return null;
+    }
+}

--- a/src/qz/utils/gtk/Gtk2.java
+++ b/src/qz/utils/gtk/Gtk2.java
@@ -1,0 +1,37 @@
+package qz.utils.gtk;
+
+import com.github.zafarkhaja.semver.Version;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+import com.sun.jna.Pointer;
+
+interface Gtk2 extends Gtk {
+    // Gtk 2.1-3.0
+    double gdk_screen_get_resolution(Pointer screen);
+
+    default Version getVersion() {
+        NativeLibrary lib = Native.getNativeLibrary(this);
+        try {
+            return Version.of(
+                    lib.getGlobalVariableAddress("gtk_major_version").getInt(0),
+                    lib.getGlobalVariableAddress("gtk_minor_version").getInt(0),
+                    lib.getGlobalVariableAddress("gtk_micro_version").getInt(0));
+        } catch(Throwable t) {
+            log.debug("Failed to read GTK2 version info", t);
+            return Version.of(0);
+        }
+    }
+
+    @Override
+    default double getScaleFactor() {
+        Pointer screen = getScreen();
+        if(screen != null) {
+            double dpi = gdk_screen_get_resolution(screen);
+            if(dpi > 0) {
+                return dpi / 96.0d;
+            }
+        }
+        log.warn("Unable to detect GTK2 scale factor");
+        return 1.0;
+    }
+}

--- a/src/qz/utils/gtk/Gtk3.java
+++ b/src/qz/utils/gtk/Gtk3.java
@@ -1,0 +1,69 @@
+package qz.utils.gtk;
+
+import com.github.zafarkhaja.semver.Version;
+import com.sun.jna.Pointer;
+
+interface Gtk3 extends Gtk {
+    // Gtk 3.0+
+    int gtk_get_major_version();
+    int gtk_get_minor_version();
+    int gtk_get_micro_version();
+
+    // Gtk 3.10-3.21
+    int gdk_screen_get_monitor_scale_factor (Pointer screen, int monitor_num);
+
+    // Gtk 3.22+
+    Pointer gdk_display_get_primary_monitor(Pointer display);
+    Pointer gdk_display_get_monitor(Pointer display, int monitor_num);
+    int gdk_monitor_get_scale_factor(Pointer monitor);
+
+    default Pointer getMonitor() {
+        Pointer display = gdk_display_get_default();
+        if (display != null) {
+            Pointer monitor = gdk_display_get_primary_monitor(display);
+            if (monitor == null) {
+                log.debug("Primary monitor is null, falling back to monitor index 0");
+                monitor = gdk_display_get_monitor(display, 0);
+            }
+            if (monitor != null) {
+                return monitor;
+            }
+        }
+        log.warn("Unable to obtain primary monitor");
+        return null;
+    }
+
+    @Override
+    default Version getVersion() {
+        return Version.of(gtk_get_major_version(), gtk_get_minor_version(), gtk_get_micro_version());
+    }
+
+    @Override
+    default double getScaleFactor() {
+        Version version = getVersion();
+        if (version.isHigherThanOrEquivalentTo(Version.of(3, 10, 0))) {
+            if(version.isHigherThanOrEquivalentTo(Version.of(3, 22, 0))) {
+                // use 3.22+ api
+                Pointer monitor = getMonitor();
+                if (monitor != null) {
+                    int factor = gdk_monitor_get_scale_factor(monitor);
+                    if (factor > 0) {
+                        return factor;
+                    }
+                }
+            }
+            // 3.10+ fallback
+            Pointer screen = getScreen();
+            if (screen != null) {
+                int factor = gdk_screen_get_monitor_scale_factor(screen, 0);
+                if(factor > 0) {
+                    return factor;
+                }
+            }
+        } else {
+            log.warn("GTK 3.10+ is required to detect scaling factor, skipping.");
+        }
+        log.warn("Unable to detect GTK scale factor");
+        return 1.0;
+    }
+}

--- a/src/qz/utils/gtk/Gtk4.java
+++ b/src/qz/utils/gtk/Gtk4.java
@@ -1,0 +1,21 @@
+package qz.utils.gtk;
+
+import com.sun.jna.Pointer;
+
+public interface Gtk4 extends Gtk3 {
+    Pointer gdk_display_get_monitors(Pointer display);
+
+    Pointer g_list_model_get_item(Pointer listModel, int position);
+
+    @Override
+    default Pointer getMonitor() {
+        Pointer display = gdk_display_get_default();
+        if (display != null) {
+            Pointer monitors = gdk_display_get_monitors(display);
+            if (monitors != null) {
+                return g_list_model_get_item(monitors, 0);
+            }
+        }
+        return null;
+    }
+}

--- a/src/qz/utils/gtk/GtkType.java
+++ b/src/qz/utils/gtk/GtkType.java
@@ -1,7 +1,7 @@
 package qz.utils.gtk;
 
 enum GtkType {
-    GTK4("gtk-4", Gtk4.class),
+    // GTK4("gtk-4", Gtk4.class),
     GTK3("gtk-3", Gtk3.class),
     GTK2("gtk-x11-2.0", Gtk2.class);
 

--- a/src/qz/utils/gtk/GtkType.java
+++ b/src/qz/utils/gtk/GtkType.java
@@ -1,0 +1,15 @@
+package qz.utils.gtk;
+
+enum GtkType {
+    GTK4("gtk-4", Gtk4.class),
+    GTK3("gtk-3", Gtk3.class),
+    GTK2("gtk-x11-2.0", Gtk2.class);
+
+    final String lib;
+    final Class<? extends Gtk> type;
+
+    GtkType(String lib, Class<? extends Gtk> type) {
+        this.lib = lib;
+        this.type = type;
+    }
+}

--- a/test/qz/utils/gtk/GtkTests.java
+++ b/test/qz/utils/gtk/GtkTests.java
@@ -1,0 +1,49 @@
+package qz.utils.gtk;
+
+import com.github.zafarkhaja.semver.Version;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import qz.utils.SystemUtilities;
+
+import java.awt.*;
+
+public class GtkTests {
+    private static final Logger log = LogManager.getLogger(GtkTests.class);
+
+    static final boolean INIT_GTK = !GraphicsEnvironment.isHeadless();
+    static final Gtk GTK_INSTANCE = Gtk.getInstance(INIT_GTK);
+
+    @BeforeClass
+    public void filterOs() {
+        switch(SystemUtilities.getOs()) {
+            case WINDOWS:
+            case MAC:
+                throw new SkipException("GTK is not needed on macOS or Windows");
+        }
+    }
+
+    @Test
+    public void testGtkAvailability() {
+        Assert.assertNotNull(GTK_INSTANCE);
+    }
+
+    @Test
+    public void testGtkVersion() {
+        Assert.assertNotNull(GTK_INSTANCE);
+        Assert.assertNotEquals(GTK_INSTANCE.getVersion(), Version.of(0));
+    }
+
+    @Test
+    public void testGtkGetScaleFactor() {
+        if(!INIT_GTK) {
+            throw new SkipException("Skipping calculation of scale factor, GTK has not been initialized.");
+        }
+        Assert.assertNotNull(GTK_INSTANCE);
+        log.debug("GTK {} scale factor: {}", GTK_INSTANCE.getVersion(), GTK_INSTANCE.getScaleFactor());
+        Assert.assertNotEquals(GTK_INSTANCE.getScaleFactor(), 0);
+    }
+}


### PR DESCRIPTION
Improve Gtk detection via JNA

Reopened because after #1502 was merged, GTK4 seems to deadlock the Java process and this needs to be corrected before merged into master.

@IdelsTak thoughts welcome.