### PR TITLE
Move headless flag to static field in App.java

### DIFF
--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -33,7 +33,7 @@ public class App {
     private static final Logger log = LogManager.getLogger(App.class);
     private static Properties trayProperties = null;
 
-    private static PropertyHelper prefs = null;
+    private static PropertyHelper userPrefs = null;
     private static boolean headless = false;
 
     public static void main(String ... args) {
@@ -64,14 +64,18 @@ public class App {
         }
         Installer.getInstance().addUserSettings();
 
-        prefs = new PropertyHelper(FileUtilities.USER_DIR + File.separator + Constants.PREFS_FILE + ".properties");
-        prefs.remove(ArgValue.SECURITY_FILE_STRICT.getMatch()); // per https://github.com/qzind/tray/issues/1337
+        // Init user preferences
+        userPrefs = new PropertyHelper(FileUtilities.USER_DIR + File.separator + Constants.PREFS_FILE + ".properties");
+        userPrefs.remove(ArgValue.SECURITY_FILE_STRICT.getMatch()); // per https://github.com/qzind/tray/issues/1337
+
         // Headless if turned on by user or unsupported by environment
-        headless = parser.isHeadless() || getPref(ArgValue.HEADLESS) || GraphicsEnvironment.isHeadless();
+        headless = parser.isHeadless() ||
+                PrefsSearch.getBoolean(ArgValue.HEADLESS, userPrefs, trayProperties) ||
+                GraphicsEnvironment.isHeadless();
 
         // Load overridable preferences set in qz-tray.properties file
-        NetworkUtilities.setPreferences(certManager.getProperties());
-        SingleInstanceChecker.setPreferences(certManager.getProperties());
+        NetworkUtilities.setPreferences(trayProperties);
+        SingleInstanceChecker.setPreferences(trayProperties);
 
         // Linux needs the cert installed in user-space on every launch for Chrome SSL to work
         if(!SystemUtilities.isWindows() && !SystemUtilities.isMac()) {
@@ -137,15 +141,8 @@ public class App {
         LoggerUtilities.getRootLogger().addAppender(fileAppender);
     }
 
-    /**
-     * Get boolean user pref: Searching "user", "app" and <code>System.getProperty(...)</code>.
-     */
-    public static boolean getPref(ArgValue argValue) {
-        return PrefsSearch.getBoolean(argValue, prefs, App.getTrayProperties());
-    }
-
-    public static PropertyHelper getPrefs() {
-        return prefs;
+    public static PropertyHelper getUserPrefs() {
+        return userPrefs;
     }
 
     public static boolean isHeadless() {

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import qz.build.provision.params.Phase;
 import qz.common.Constants;
+import qz.common.PropertyHelper;
 import qz.installer.Installer;
 import qz.installer.certificate.CertificateManager;
 import qz.installer.certificate.ExpiryTask;
@@ -23,6 +24,7 @@ import qz.ws.PrintSocketServer;
 import qz.ws.SingleInstanceChecker;
 import qz.ws.substitutions.Substitutions;
 
+import java.awt.*;
 import java.io.File;
 import java.security.cert.X509Certificate;
 import java.util.Properties;
@@ -30,6 +32,9 @@ import java.util.Properties;
 public class App {
     private static final Logger log = LogManager.getLogger(App.class);
     private static Properties trayProperties = null;
+
+    private static PropertyHelper prefs = null;
+    private static boolean headless = false;
 
     public static void main(String ... args) {
         ArgParser parser = new ArgParser(args);
@@ -59,6 +64,11 @@ public class App {
         }
         Installer.getInstance().addUserSettings();
 
+        prefs = new PropertyHelper(FileUtilities.USER_DIR + File.separator + Constants.PREFS_FILE + ".properties");
+        prefs.remove(ArgValue.SECURITY_FILE_STRICT.getMatch()); // per https://github.com/qzind/tray/issues/1337
+        // Headless if turned on by user or unsupported by environment
+        headless = parser.isHeadless() || getPref(ArgValue.HEADLESS) || GraphicsEnvironment.isHeadless();
+
         // Load overridable preferences set in qz-tray.properties file
         NetworkUtilities.setPreferences(certManager.getProperties());
         SingleInstanceChecker.setPreferences(certManager.getProperties());
@@ -83,7 +93,7 @@ public class App {
         try {
             log.info("Starting {} {}", Constants.ABOUT_TITLE, Constants.VERSION);
             // Start the WebSocket
-            PrintSocketServer.runServer(certManager, parser.isHeadless());
+            PrintSocketServer.runServer(certManager);
         }
         catch(Exception e) {
             log.error("Could not start tray manager", e);
@@ -126,4 +136,24 @@ public class App {
 
         LoggerUtilities.getRootLogger().addAppender(fileAppender);
     }
+
+    /**
+     * Get boolean user pref: Searching "user", "app" and <code>System.getProperty(...)</code>.
+     */
+    public static boolean getPref(ArgValue argValue) {
+        return PrefsSearch.getBoolean(argValue, prefs, App.getTrayProperties());
+    }
+
+    public static PropertyHelper getPrefs() {
+        return prefs;
+    }
+
+    public static boolean isHeadless() {
+        return headless;
+    }
+
+    public static void setHeadless(boolean headless) {
+        App.headless = headless;
+    }
+
 }

--- a/src/qz/App.java
+++ b/src/qz/App.java
@@ -152,6 +152,13 @@ public class App {
         return headless;
     }
 
+    /**
+     * Sets headless to false as a reactive measure (such as the System Tray failing to attach).
+     * This is marked as @Deprecated because this should be controlled entire in App.java
+     * Furthermore, there are better fallback techniques to handle this behavior (see #1044) for
+     * when the System Tray is unavailable.
+     */
+    @Deprecated
     public static void setHeadless(boolean headless) {
         App.headless = headless;
     }

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -155,7 +155,7 @@ public class TrayManager {
 
         if(isHeadless()) {
             // If isHeadless(), look for a location to forward message dialogs to
-            gatewayDialog.setEndpoint(PrefsSearch.getString(TRAY_DIALOG_ENDPOINT, getPrefs(), App.getTrayProperties()));
+            gatewayDialog.setEndpoint(PrefsSearch.getString(TRAY_DIALOG_ENDPOINT, getUserPrefs(), App.getTrayProperties()));
         } else {
             componentList = new ArrayList<>();
             componentList.add(gatewayDialog.getDialog());
@@ -248,7 +248,7 @@ public class TrayManager {
         JMenuItem sitesItem = new JMenuItem("Site Manager...", iconCache.getIcon(SAVED_ICON));
         sitesItem.setMnemonic(KeyEvent.VK_M);
         sitesItem.addActionListener(savedListener);
-        sitesDialog = new SiteManagerDialog(sitesItem, iconCache, getPrefs());
+        sitesDialog = new SiteManagerDialog(sitesItem, iconCache, getUserPrefs());
         componentList.add(sitesDialog);
 
         JMenuItem diagnosticMenu = new JMenu("Diagnostic");
@@ -301,7 +301,7 @@ public class TrayManager {
         logItem.setMnemonic(KeyEvent.VK_L);
         logItem.addActionListener(logListener);
         diagnosticMenu.add(logItem);
-        logDialog = new LogDialog(logItem, iconCache, getPrefs());
+        logDialog = new LogDialog(logItem, iconCache, getUserPrefs());
         componentList.add(logDialog);
 
         JMenuItem zipLogs = new JMenuItem("Zip logs (to Desktop)");
@@ -375,7 +375,7 @@ public class TrayManager {
     private final ActionListener notificationsListener = new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
-            getPrefs().setProperty(TRAY_NOTIFICATIONS, ((JCheckBoxMenuItem)e.getSource()).getState());
+            getUserPrefs().setProperty(TRAY_NOTIFICATIONS, ((JCheckBoxMenuItem)e.getSource()).getState());
         }
     };
 
@@ -383,7 +383,7 @@ public class TrayManager {
         @Override
         public void actionPerformed(ActionEvent e) {
             JCheckBoxMenuItem j = (JCheckBoxMenuItem)e.getSource();
-            getPrefs().setProperty(TRAY_MONOCLE, j.getState());
+            getUserPrefs().setProperty(TRAY_MONOCLE, j.getState());
             displayWarningMessage(String.format("A restart of %s is required to ensure this feature is %sabled.",
                                                 Constants.ABOUT_TITLE, j.getState()? "en":"dis"));
         }
@@ -473,7 +473,7 @@ public class TrayManager {
     };
 
     public void exit(int returnCode) {
-        getPrefs().save();
+        getUserPrefs().save();
         FileUtilities.cleanup();
         System.exit(returnCode);
     }
@@ -648,6 +648,13 @@ public class TrayManager {
 
     public boolean isMonoclePreferred() {
         return getPref(TRAY_MONOCLE);
+    }
+
+    /**
+     * Get boolean user pref: Searching "user", "app" and <code>System.getProperty(...)</code>.
+     */
+    private static boolean getPref(ArgValue argValue) {
+        return PrefsSearch.getBoolean(argValue, getUserPrefs(), getTrayProperties()) ;
     }
 
     private void performIfIdle(int idleQualifier, ActionListener performer) {

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -105,7 +105,7 @@ public class TrayManager {
         // Set up the shortcut name so that the UI components can use it
         shortcutCreator = ShortcutCreator.getInstance();
 
-        SystemUtilities.setSystemLookAndFeel(isHeadless());
+        SystemUtilities.setSystemLookAndFeel();
         iconCache = new IconCache();
 
         if (SystemUtilities.isSystemTraySupported()) { // UI mode with tray
@@ -178,7 +178,7 @@ public class TrayManager {
                             iconCache.fixTrayIcons(darkTaskbarMode);
                             refreshIcon(null);
                             SwingUtilities.invokeLater(() -> {
-                                SystemUtilities.setSystemLookAndFeel(isHeadless());
+                                SystemUtilities.setSystemLookAndFeel();
                                 for(Component c : componentList) {
                                     SwingUtilities.updateComponentTreeUI(c);
                                     if (c instanceof Themeable) {

--- a/src/qz/common/TrayManager.java
+++ b/src/qz/common/TrayManager.java
@@ -34,7 +34,6 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.TimerTask;
@@ -42,6 +41,8 @@ import java.util.concurrent.TimeUnit;
 
 import static qz.ui.component.IconCache.Icon.*;
 import static qz.utils.ArgValue.*;
+
+import static qz.App.*;
 
 /**
  * Manages the icons and actions associated with the TrayIcon
@@ -51,8 +52,6 @@ import static qz.utils.ArgValue.*;
 public class TrayManager {
 
     private static final Logger log = LogManager.getLogger(TrayManager.class);
-
-    private boolean headless;
 
     // The cached icons
     private final IconCache iconCache;
@@ -77,26 +76,17 @@ public class TrayManager {
     // The shortcut and startup helper
     private final ShortcutCreator shortcutCreator;
 
-    private final PropertyHelper prefs;
-
     // Action to run when reload is triggered
     private Thread reloadThread;
 
     // Actions to run if idle after startup
     private java.util.Timer idleTimer = new java.util.Timer();
 
-    public TrayManager() {
-        this(false);
-    }
-
     /**
      * Create a AutoHideJSystemTray with the specified name/text
      */
-    public TrayManager(boolean isHeadless) {
+    public TrayManager() {
         name = Constants.ABOUT_TITLE + " " + Constants.VERSION;
-
-        prefs = new PropertyHelper(FileUtilities.USER_DIR + File.separator + Constants.PREFS_FILE + ".properties");
-        prefs.remove(SECURITY_FILE_STRICT.getMatch()); // per https://github.com/qzind/tray/issues/1337
 
         // Set strict certificate mode preference
         Certificate.setTrustBuiltIn(!getPref(TRAY_STRICTMODE));
@@ -108,19 +98,17 @@ public class TrayManager {
         FileUtilities.setFileIoEnabled(getPref(SECURITY_FILE_ENABLED));
         FileUtilities.setFileIoStrict(getPref(SECURITY_FILE_STRICT));
 
-        // Headless if turned on by user or unsupported by environment
-        headless = isHeadless || getPref(HEADLESS) || GraphicsEnvironment.isHeadless();
-        if (headless) {
+        if (isHeadless()) {
             log.info("Running in headless mode");
         }
 
         // Set up the shortcut name so that the UI components can use it
         shortcutCreator = ShortcutCreator.getInstance();
 
-        SystemUtilities.setSystemLookAndFeel(headless);
+        SystemUtilities.setSystemLookAndFeel(isHeadless());
         iconCache = new IconCache();
 
-        if (SystemUtilities.isSystemTraySupported(headless)) { // UI mode with tray
+        if (SystemUtilities.isSystemTraySupported()) { // UI mode with tray
             switch(SystemUtilities.getOs()) {
                 case WINDOWS:
                     tray = TrayType.JX.init(iconCache);
@@ -148,9 +136,9 @@ public class TrayManager {
             }
             catch(AWTException awt) {
                 log.error("Could not attach tray, forcing headless mode", awt);
-                headless = true;
+                setHeadless(true);
             }
-        } else if (!headless) { // UI mode without tray
+        } else if (!isHeadless()) { // UI mode without tray
             tray = TrayType.TASKBAR.init(exitListener, iconCache);
             tray.setIcon(DANGER_ICON);
             tray.setToolTip(name);
@@ -158,16 +146,16 @@ public class TrayManager {
         }
 
         // TODO: Remove when fixed upstream.  See issue #393
-        if (SystemUtilities.isUnix() && !isHeadless) {
+        if (SystemUtilities.isUnix() && !isHeadless()) {
             // Update printer list in CUPS immediately (normally 2min)
             System.setProperty("sun.java2d.print.polling", "false");
         }
 
-        gatewayDialog = new GatewayDialog(headless, null,"Action Required", iconCache);
+        gatewayDialog = new GatewayDialog(isHeadless(), null,"Action Required", iconCache);
 
-        if(headless) {
-            // If headless, look for a location to forward message dialogs to
-            gatewayDialog.setEndpoint(PrefsSearch.getString(TRAY_DIALOG_ENDPOINT, prefs, App.getTrayProperties()));
+        if(isHeadless()) {
+            // If isHeadless(), look for a location to forward message dialogs to
+            gatewayDialog.setEndpoint(PrefsSearch.getString(TRAY_DIALOG_ENDPOINT, getPrefs(), App.getTrayProperties()));
         } else {
             componentList = new ArrayList<>();
             componentList.add(gatewayDialog.getDialog());
@@ -190,7 +178,7 @@ public class TrayManager {
                             iconCache.fixTrayIcons(darkTaskbarMode);
                             refreshIcon(null);
                             SwingUtilities.invokeLater(() -> {
-                                SystemUtilities.setSystemLookAndFeel(headless);
+                                SystemUtilities.setSystemLookAndFeel(isHeadless());
                                 for(Component c : componentList) {
                                     SwingUtilities.updateComponentTreeUI(c);
                                     if (c instanceof Themeable) {
@@ -260,7 +248,7 @@ public class TrayManager {
         JMenuItem sitesItem = new JMenuItem("Site Manager...", iconCache.getIcon(SAVED_ICON));
         sitesItem.setMnemonic(KeyEvent.VK_M);
         sitesItem.addActionListener(savedListener);
-        sitesDialog = new SiteManagerDialog(sitesItem, iconCache, prefs);
+        sitesDialog = new SiteManagerDialog(sitesItem, iconCache, getPrefs());
         componentList.add(sitesDialog);
 
         JMenuItem diagnosticMenu = new JMenu("Diagnostic");
@@ -313,7 +301,7 @@ public class TrayManager {
         logItem.setMnemonic(KeyEvent.VK_L);
         logItem.addActionListener(logListener);
         diagnosticMenu.add(logItem);
-        logDialog = new LogDialog(logItem, iconCache, prefs);
+        logDialog = new LogDialog(logItem, iconCache, getPrefs());
         componentList.add(logDialog);
 
         JMenuItem zipLogs = new JMenuItem("Zip logs (to Desktop)");
@@ -387,7 +375,7 @@ public class TrayManager {
     private final ActionListener notificationsListener = new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent e) {
-            prefs.setProperty(TRAY_NOTIFICATIONS, ((JCheckBoxMenuItem)e.getSource()).getState());
+            getPrefs().setProperty(TRAY_NOTIFICATIONS, ((JCheckBoxMenuItem)e.getSource()).getState());
         }
     };
 
@@ -395,7 +383,7 @@ public class TrayManager {
         @Override
         public void actionPerformed(ActionEvent e) {
             JCheckBoxMenuItem j = (JCheckBoxMenuItem)e.getSource();
-            prefs.setProperty(TRAY_MONOCLE, j.getState());
+            getPrefs().setProperty(TRAY_MONOCLE, j.getState());
             displayWarningMessage(String.format("A restart of %s is required to ensure this feature is %sabled.",
                                                 Constants.ABOUT_TITLE, j.getState()? "en":"dis"));
         }
@@ -485,7 +473,7 @@ public class TrayManager {
     };
 
     public void exit(int returnCode) {
-        prefs.save();
+        getPrefs().save();
         FileUtilities.cleanup();
         System.exit(returnCode);
     }
@@ -499,11 +487,11 @@ public class TrayManager {
 
     public boolean showGatewayDialog(final String UID, final Request request, final String prompt, final Point position) {
         // No way to prompt, hope it's whitelisted
-        if (headless && gatewayDialog.getEndpoint() == null) {
+        if (isHeadless() && gatewayDialog.getEndpoint() == null) {
             return request.hasSavedCert();
         }
 
-        GatewayDialog.runSafely(headless, () -> gatewayDialog.prompt(UID, "%s wants to " + prompt, request, position));
+        GatewayDialog.runSafely(isHeadless(), () -> gatewayDialog.prompt(UID, "%s wants to " + prompt, request, position));
 
         GatewayDialog.Response response = gatewayDialog.getResponse();
         switch(response) {
@@ -521,7 +509,7 @@ public class TrayManager {
 
         if(response.alwaysBlockAnonymous(request)) {
             // Treat as "block anonymous requests" to prevent pop-up abuse
-            if(!headless) {
+            if(!isHeadless()) {
                 anonymousItem.setState(false);
                 anonymousItem.doClick();
             } else {
@@ -555,7 +543,7 @@ public class TrayManager {
 
             displayInfoMessage("Server started on port(s) " + PrintSocketServer.getPorts(server));
 
-            if (!headless) {
+            if (!isHeadless()) {
                 aboutDialog.setServer(server);
                 setDefaultIcon();
             }
@@ -633,7 +621,7 @@ public class TrayManager {
      * @param level   The message type: Level.INFO, .WARN, .SEVERE
      */
     private void displayMessage(final String caption, final String text, final TrayIcon.MessageType level) {
-        if (!headless) {
+        if (!isHeadless()) {
             if (tray != null) {
                 SwingUtilities.invokeLater(() -> {
                     boolean showAllNotifications = getPref(TRAY_NOTIFICATIONS);
@@ -660,17 +648,6 @@ public class TrayManager {
 
     public boolean isMonoclePreferred() {
         return getPref(TRAY_MONOCLE);
-    }
-
-    public boolean isHeadless() {
-        return headless;
-    }
-
-    /**
-     * Get boolean user pref: Searching "user", "app" and <code>System.getProperty(...)</code>.
-     */
-    private boolean getPref(ArgValue argValue) {
-        return PrefsSearch.getBoolean(argValue, prefs, App.getTrayProperties());
     }
 
     private void performIfIdle(int idleQualifier, ActionListener performer) {

--- a/src/qz/installer/LinuxInstaller.java
+++ b/src/qz/installer/LinuxInstaller.java
@@ -369,7 +369,7 @@ public class LinuxInstaller extends Installer {
             return true;
         }
         try {
-            SystemUtilities.setSystemLookAndFeel(false);
+            SystemUtilities.setSystemLookAndFeel();
             String message = String.format("A required component, \"%s\", wasn't found. Attempt to fetch it now?", binary);
             return JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(null, message);
         } catch (Throwable ignore) {}

--- a/src/qz/printer/action/html/WebApp.java
+++ b/src/qz/printer/action/html/WebApp.java
@@ -24,6 +24,7 @@ import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import qz.App;
 import qz.common.Constants;
 import qz.utils.SystemUtilities;
 import qz.ws.PrintSocketServer;
@@ -165,7 +166,7 @@ public class WebApp extends Application {
                     // Honor user monocle override
                     useMonocle = PrintSocketServer.getTrayManager().isMonoclePreferred();
                     // Trust TrayManager's headless detection
-                    headless = PrintSocketServer.getTrayManager().isHeadless();
+                    headless = App.isHeadless();
                 } else {
                     // Fallback for JDK11+
                     headless = true;

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -18,6 +18,7 @@ import org.joor.Reflect;
 import org.joor.ReflectException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import qz.App;
 import qz.build.provision.params.Arch;
 import qz.build.provision.params.Os;
 import qz.common.Constants;
@@ -781,8 +782,8 @@ public class SystemUtilities {
     /**
      * Cross-platform SystemTray detector
      */
-    public static boolean isSystemTraySupported(boolean headless) {
-        if(!headless) {
+    public static boolean isSystemTraySupported() {
+        if(!App.isHeadless()) {
             switch(getOs()) {
                 case WINDOWS:
                     if(WindowsUtilities.isHiddenSystemTray()) {

--- a/src/qz/utils/SystemUtilities.java
+++ b/src/qz/utils/SystemUtilities.java
@@ -373,8 +373,8 @@ public class SystemUtilities {
         return false;
     }
 
-    public static boolean setSystemLookAndFeel(boolean headless) {
-        if(headless) {
+    public static boolean setSystemLookAndFeel() {
+        if(App.isHeadless()) {
             return false;
         }
         try {

--- a/src/qz/ws/PrintSocketServer.java
+++ b/src/qz/ws/PrintSocketServer.java
@@ -52,9 +52,9 @@ public class PrintSocketServer {
     private static String wssHost;
     private static List<String> wssAllowedOrigins;
 
-    public static void runServer(CertificateManager certManager, boolean headless) throws InterruptedException, InvocationTargetException {
+    public static void runServer(CertificateManager certManager) throws InterruptedException, InvocationTargetException {
         SwingUtilities.invokeAndWait(() -> {
-            PrintSocketServer.setTrayManager(new TrayManager(headless));
+            PrintSocketServer.setTrayManager(new TrayManager());
         });
 
         wssHost = PrefsSearch.getString(ArgValue.SECURITY_WSS_HOST, certManager.getProperties());


### PR DESCRIPTION
Tracking `headless` mode application wide is historically messy because it's stored as an instance variable inside TrayManager.  Ideally this would live in `App.java` as a static variable so that it can be queried project-wide without passing the variable to unnecessary functions.

This allows functions like `SystemUtilities.setSystemLookAndFeel()` to calculate headless decisions without a bunch of instance variables, as uncovered in #1508.

Also moves prefs field to static field in App.java